### PR TITLE
Add quartet GQA verify kernel behind opt-in flag

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,19 @@
+## 2026-04-16 — Iteration 1
+
+- Attempted: fixed the three quartet-GQA P0 regressions in [dflash_mlx/kernels.py](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/dflash_mlx/kernels.py:575), re-enabled the runtime hook path behind an instance flag in [dflash_mlx/runtime.py](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/dflash_mlx/runtime.py:591), and added an isolated microbench in [benchmark/quartet_gqa_microbench.py](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/benchmark/quartet_gqa_microbench.py:1).
+- Observed: `python3 -m benchmark.quartet_gqa_validate` now passes on `N={256,1024,4096,8192}` with `allclose=True`, `fallback_m1=True`, and `fallback_fp16=True`.
+- Observed: isolated microbench (`python3 -m benchmark.quartet_gqa_microbench`) reports stock/quartet ratios of `1.1865` at `N=1024`, `1.1422` at `N=2048`, `1.4286` at `N=4096`, and `1.3263` at `N=8192`.
+- Changed: restored the shared batched reduce kernel to `BN=32`, switched quartet pass-1 back to bf16 IO with fp32 stats, fixed the quartet grid to MLX's total-thread convention, and added silent fallback from quartet to batched 2-pass in the FA hook when `_dflash_quartet_enabled` is true.
+- Next blocking issue: run the hook-level and end-to-end numerical checks on real Qwen3.5-9B FA verify with `_dflash_quartet_enabled=True` before considering a merge.
+
+## 2026-04-16 — Iteration 2
+
+- Attempted: added [benchmark/quartet_gqa_hook_check.py](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/benchmark/quartet_gqa_hook_check.py:1), [benchmark/quartet_gqa_e2e_check.py](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/benchmark/quartet_gqa_e2e_check.py:1), a runtime helper [configure_quartet_gqa()](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/dflash_mlx/runtime.py:677), and an opt-in benchmark flag in [benchmark/benchmark.py](/Users/bastienbouge/Documents/dev/dflash-mlx-quartet-gqa/benchmark/benchmark.py:629).
+- Observed: `python3 -m benchmark.quartet_gqa_hook_check` passed on all 8 FA layers of Qwen3.5-9B (`[3, 7, 11, 15, 19, 23, 27, 31]`) with `max_abs_diff=0.0` and `allclose=True` for each layer at `ctx_len=4096`, `verify_len=16`.
+- Observed: `python3 -m benchmark.quartet_gqa_e2e_check` passed on 3 long prompts (`code`, `math`, `narrative`) with `token_match=True` in all cases. Acceptance matched exactly off/on: `0.93359375`, `0.9296875`, `0.92578125`.
+- Observed: V3 single-run benchmark comparison against current `main`, using exact prompt lengths `1024/2048/4096`, repeated README math prompt, `max_new_tokens=256`, `block_tokens=16`, `--no-eos` semantics:
+- Observed: `ctx=1024` main `baseline_tps=30.8161`, `dflash_tps=29.1141`, `acceptance=0.01171875`; quartet `baseline_tps=30.8574`, `dflash_tps=160.9654`, `acceptance=0.921875`.
+- Observed: `ctx=2048` main `baseline_tps=30.9132`, `dflash_tps=28.1646`, `acceptance=0.0`; quartet `baseline_tps=28.9968`, `dflash_tps=117.0376`, `acceptance=0.92578125`.
+- Observed: `ctx=4096` main `baseline_tps=30.4248`, `dflash_tps=23.3831`, `acceptance=0.0078125`; quartet `baseline_tps=26.2662`, `dflash_tps=103.4183`, `acceptance=0.9296875`.
+- Changed: benchmark control path can now enable quartet with `--quartet-gqa` while keeping the runtime default OFF.
+- Next blocking issue: none for numerical/perf validation on this branch; the remaining merge step is packaging the branch state into a PR while keeping quartet disabled by default.

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -20,10 +20,10 @@ from mlx_lm import stream_generate as mlx_stream_generate
 from mlx_lm.utils import load as load_pristine_target
 
 from dflash_mlx.runtime import (
-    generate_dflash_once,
     load_draft_bundle,
     load_target_bundle,
     resolve_model_ref,
+    stream_dflash_generate,
 )
 
 DEFAULT_SCHEDULES: tuple[int, ...] = (8, 16, 32)
@@ -226,6 +226,9 @@ def _ttft_ms_from_baseline(result: dict[str, Any]) -> float:
 
 
 def _ttft_ms_from_dflash(result: dict[str, Any]) -> float:
+    ttft_us = result.get("ttft_us")
+    if ttft_us is not None:
+        return float(ttft_us) / 1_000.0
     phase_timings = dict(result.get("phase_timings_us", {}))
     return float(phase_timings.get("prefill", 0.0)) / 1_000.0
 
@@ -327,6 +330,61 @@ def _generate_stock_baseline_once(
     }
 
 
+def _generate_dflash_stream_once(
+    *,
+    target_model: Any,
+    tokenizer: Any,
+    draft_model: Any,
+    prompt: str,
+    max_new_tokens: int,
+    use_chat_template: bool,
+    block_tokens: int | None,
+    verify_chunk_tokens: int | None,
+    stop_token_ids: list[int] | None,
+    suppress_token_ids: list[int] | None,
+) -> dict[str, Any]:
+    if hasattr(mx, "reset_peak_memory"):
+        try:
+            mx.reset_peak_memory()
+        except Exception:
+            pass
+
+    start_ns = time.perf_counter_ns()
+    first_token_us: float | None = None
+    summary: dict[str, Any] | None = None
+    stream = stream_dflash_generate(
+        target_model=target_model,
+        tokenizer=tokenizer,
+        draft_model=draft_model,
+        prompt=prompt,
+        max_new_tokens=max_new_tokens,
+        use_chat_template=use_chat_template,
+        block_tokens=block_tokens,
+        verify_chunk_tokens=verify_chunk_tokens,
+        stop_token_ids=stop_token_ids,
+        suppress_token_ids=suppress_token_ids,
+    )
+    try:
+        for event in stream:
+            event_type = event.get("event")
+            if event_type == "token" and first_token_us is None:
+                first_token_us = (time.perf_counter_ns() - start_ns) / 1_000.0
+            elif event_type == "summary":
+                summary = dict(event)
+    finally:
+        stream.close()
+
+    if summary is None:
+        raise RuntimeError("DFlash stream did not yield a summary event")
+
+    summary["ttft_us"] = (
+        first_token_us
+        if first_token_us is not None
+        else float(dict(summary.get("phase_timings_us", {})).get("prefill", 0.0))
+    )
+    return summary
+
+
 def _release_loaded_models() -> None:
     gc.collect()
     if hasattr(mx, "clear_cache"):
@@ -385,7 +443,7 @@ def _run_once_sequential(
     dflash_stop_token_ids = [] if no_eos else dflash_eos_token_ids
     dflash_suppress_token_ids = dflash_eos_token_ids if no_eos else None
     try:
-        dflash = generate_dflash_once(
+        dflash = _generate_dflash_stream_once(
             target_model=target_model,
             tokenizer=tokenizer,
             draft_model=draft_model,

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -20,6 +20,7 @@ from mlx_lm import stream_generate as mlx_stream_generate
 from mlx_lm.utils import load as load_pristine_target
 
 from dflash_mlx.runtime import (
+    configure_quartet_gqa,
     load_draft_bundle,
     load_target_bundle,
     resolve_model_ref,
@@ -412,6 +413,7 @@ def _run_once_sequential(
     quantize_draft: bool,
     no_eos: bool,
     split_sdpa: bool,
+    quartet_gqa: bool,
 ) -> dict[str, Any]:
     pristine_target_model, pristine_tokenizer, pristine_meta = _load_pristine_target_bundle(
         target_model_ref
@@ -434,6 +436,7 @@ def _run_once_sequential(
         lazy=True,
         split_full_attention_sdpa=split_sdpa,
     )
+    configure_quartet_gqa(target_model, enabled=quartet_gqa)
     draft_model, draft_meta = load_draft_bundle(
         draft_model_ref,
         lazy=True,
@@ -496,6 +499,7 @@ def benchmark_once(
     quantize_draft: bool = False,
     no_eos: bool = False,
     split_sdpa: bool = True,
+    quartet_gqa: bool = False,
     cooldown: int = 10,
 ) -> dict[str, Any]:
     thermal_pressure = _get_thermal_pressure()
@@ -511,6 +515,7 @@ def benchmark_once(
         quantize_draft=quantize_draft,
         no_eos=no_eos,
         split_sdpa=split_sdpa,
+        quartet_gqa=quartet_gqa,
     )
     target_meta = result.pop("target_meta")
     draft_meta = result.pop("draft_meta")
@@ -541,6 +546,7 @@ def benchmark_matrix(
     quantize_draft: bool = False,
     no_eos: bool = False,
     split_sdpa: bool = True,
+    quartet_gqa: bool = False,
     cooldown: int = 10,
 ) -> dict[str, Any]:
     target_meta: dict[str, Any] | None = None
@@ -565,6 +571,7 @@ def benchmark_matrix(
             quantize_draft=quantize_draft,
             no_eos=no_eos,
             split_sdpa=split_sdpa,
+            quartet_gqa=quartet_gqa,
         )
         if target_meta is None:
             target_meta = run.pop("target_meta")
@@ -625,6 +632,12 @@ def main() -> None:
         default=True,
         help="Enable split_full_attention_sdpa when loading the target model (default: enabled).",
     )
+    parser.add_argument(
+        "--quartet-gqa",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable quartet-GQA SDPA on applicable full-attention verify layers (default: disabled).",
+    )
     args = parser.parse_args()
     repeat = args.repeat if args.repeat is not None else (DEFAULT_REPEAT if args.matrix else 1)
     if repeat < 1:
@@ -639,6 +652,7 @@ def main() -> None:
         "quantize_draft": args.quantize_draft,
         "no_eos": args.no_eos,
         "split_sdpa": args.split_sdpa,
+        "quartet_gqa": args.quartet_gqa,
         "cooldown": args.cooldown,
     }
     if args.matrix or repeat > 1:

--- a/benchmark/quartet_gqa_e2e_check.py
+++ b/benchmark/quartet_gqa_e2e_check.py
@@ -1,0 +1,145 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+import argparse
+
+from dflash_mlx.generate import get_stop_token_ids
+from dflash_mlx.runtime import configure_quartet_gqa, generate_dflash_once, load_draft_bundle, load_target_bundle
+
+MATH_PROMPT = (
+    "The function $f$ satisfies the functional equation "
+    "\\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. "
+    "If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. "
+    "Enter all such integers, separated by commas. Please reason step by step, "
+    "and put your final answer within \\boxed{}."
+)
+
+CODE_PROMPT = (
+    "Write a Python implementation of Kahn's algorithm for topological sorting, "
+    "include cycle detection, explain the invariants, and discuss the time and "
+    "space complexity in detail."
+)
+
+NARRATIVE_PROMPT = (
+    "Write the opening scene of a literary science-fiction novella about a cartographer "
+    "mapping the weather inside a rotating habitat. Keep the prose precise, vivid, "
+    "and grounded in concrete sensory detail."
+)
+
+
+def _build_long_token_stream(tokenizer, *, seed_text: str, total_tokens: int) -> list[int]:
+    chunk = list(tokenizer.encode(seed_text + "\n\n"))
+    if not chunk:
+        raise ValueError("Tokenizer produced no tokens for e2e-check seed prompt")
+    tokens: list[int] = []
+    while len(tokens) < total_tokens:
+        tokens.extend(chunk)
+    return tokens[:total_tokens]
+
+
+def _run_once(
+    *,
+    target_model,
+    tokenizer,
+    draft_model,
+    prompt_label: str,
+    prompt_tokens: list[int],
+    max_new_tokens: int,
+    block_tokens: int,
+    quartet_enabled: bool,
+) -> dict:
+    configure_quartet_gqa(target_model, enabled=quartet_enabled)
+    eos_token_ids = get_stop_token_ids(tokenizer)
+    return generate_dflash_once(
+        target_model=target_model,
+        tokenizer=tokenizer,
+        draft_model=draft_model,
+        prompt=prompt_label,
+        prompt_tokens_override=prompt_tokens,
+        max_new_tokens=max_new_tokens,
+        use_chat_template=False,
+        block_tokens=block_tokens,
+        verify_chunk_tokens=None,
+        stop_token_ids=[],
+        suppress_token_ids=eos_token_ids,
+        quantize_kv_cache=False,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="End-to-end quartet-GQA token-match check on 3 long prompts.")
+    parser.add_argument("--model", default="Qwen/Qwen3.5-9B")
+    parser.add_argument("--draft", default="z-lab/Qwen3.5-9B-DFlash")
+    parser.add_argument("--context-tokens", type=int, default=4096)
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    parser.add_argument("--block-tokens", type=int, default=16)
+    args = parser.parse_args()
+
+    target_model, tokenizer, _ = load_target_bundle(
+        args.model,
+        lazy=True,
+        split_full_attention_sdpa=True,
+    )
+    draft_model, _ = load_draft_bundle(args.draft, lazy=True)
+
+    prompts = {
+        "code": _build_long_token_stream(
+            tokenizer,
+            seed_text=CODE_PROMPT,
+            total_tokens=int(args.context_tokens),
+        ),
+        "math": _build_long_token_stream(
+            tokenizer,
+            seed_text=MATH_PROMPT,
+            total_tokens=int(args.context_tokens),
+        ),
+        "narrative": _build_long_token_stream(
+            tokenizer,
+            seed_text=NARRATIVE_PROMPT,
+            total_tokens=int(args.context_tokens),
+        ),
+    }
+
+    failures: list[dict[str, object]] = []
+    for prompt_name, prompt_tokens in prompts.items():
+        ref = _run_once(
+            target_model=target_model,
+            tokenizer=tokenizer,
+            draft_model=draft_model,
+            prompt_label=prompt_name,
+            prompt_tokens=prompt_tokens,
+            max_new_tokens=int(args.max_new_tokens),
+            block_tokens=int(args.block_tokens),
+            quartet_enabled=False,
+        )
+        test = _run_once(
+            target_model=target_model,
+            tokenizer=tokenizer,
+            draft_model=draft_model,
+            prompt_label=prompt_name,
+            prompt_tokens=prompt_tokens,
+            max_new_tokens=int(args.max_new_tokens),
+            block_tokens=int(args.block_tokens),
+            quartet_enabled=True,
+        )
+        token_match = ref["generated_token_ids"] == test["generated_token_ids"]
+        result = {
+            "prompt": prompt_name,
+            "token_match": token_match,
+            "acceptance_ref": float(ref.get("acceptance_ratio", 0.0)),
+            "acceptance_test": float(test.get("acceptance_ratio", 0.0)),
+            "elapsed_us_ref": float(ref.get("elapsed_us", 0.0)),
+            "elapsed_us_test": float(test.get("elapsed_us", 0.0)),
+        }
+        print(result)
+        if not token_match:
+            failures.append(result)
+
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/quartet_gqa_hook_check.py
+++ b/benchmark/quartet_gqa_hook_check.py
@@ -1,0 +1,162 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+import argparse
+
+import mlx.core as mx
+
+from dflash_mlx.runtime import (
+    _target_text_model,
+    _verify_target_block,
+    configure_quartet_gqa,
+    load_draft_bundle,
+    load_target_bundle,
+    make_target_cache,
+)
+
+README_MATH_PROMPT = (
+    "The function $f$ satisfies the functional equation "
+    "\\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. "
+    "If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. "
+    "Enter all such integers, separated by commas. Please reason step by step, "
+    "and put your final answer within \\boxed{}."
+)
+
+
+def _build_long_token_stream(tokenizer, *, seed_text: str, total_tokens: int) -> list[int]:
+    chunk = list(tokenizer.encode(seed_text + "\n\n"))
+    if not chunk:
+        raise ValueError("Tokenizer produced no tokens for hook-check seed prompt")
+    tokens: list[int] = []
+    while len(tokens) < total_tokens:
+        tokens.extend(chunk)
+    return tokens[:total_tokens]
+
+
+def _prefill_cache(
+    *,
+    target_model,
+    prefix_tokens: list[int],
+    cache: list[object],
+    chunk_size: int,
+) -> None:
+    prefix = mx.array(prefix_tokens, dtype=mx.uint32)[None]
+    for start in range(0, int(prefix.shape[1]), chunk_size):
+        chunk = prefix[:, start : start + chunk_size]
+        logits = target_model(chunk, cache=cache)
+        mx.eval(logits)
+
+
+def _set_only_quartet_layer(target_model, enabled_layer: int | None) -> list[int]:
+    fa_layers = configure_quartet_gqa(target_model, enabled=False)
+    if enabled_layer is None:
+        return fa_layers
+    inner = _target_text_model(target_model)
+    inner.layers[enabled_layer].self_attn._dflash_quartet_enabled = True
+    return fa_layers
+
+
+def _run_verify_logits(
+    *,
+    target_model,
+    prefix_tokens: list[int],
+    verify_tokens: list[int],
+    capture_layer_ids: set[int],
+    enabled_layer: int | None,
+    prefill_chunk_size: int,
+) -> mx.array:
+    _set_only_quartet_layer(target_model, enabled_layer)
+    cache = make_target_cache(
+        target_model,
+        enable_speculative_linear_cache=True,
+        quantize_kv_cache=False,
+    )
+    _prefill_cache(
+        target_model=target_model,
+        prefix_tokens=prefix_tokens,
+        cache=cache,
+        chunk_size=prefill_chunk_size,
+    )
+    verify_ids = mx.array(verify_tokens, dtype=mx.uint32)[None]
+    logits, captured = _verify_target_block(
+        target_model=target_model,
+        verify_ids=verify_ids,
+        target_cache=cache,
+        verify_chunk_tokens=None,
+        capture_layer_ids=capture_layer_ids,
+    )
+    if isinstance(captured, dict):
+        mx.eval(logits, *captured.values())
+    else:
+        mx.eval(logits, *captured)
+    return logits
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Layer-by-layer quartet-GQA hook numerical check.")
+    parser.add_argument("--model", default="Qwen/Qwen3.5-9B")
+    parser.add_argument("--draft", default="z-lab/Qwen3.5-9B-DFlash")
+    parser.add_argument("--context-tokens", type=int, default=4096)
+    parser.add_argument("--verify-tokens", type=int, default=16)
+    parser.add_argument("--prefill-chunk-size", type=int, default=2048)
+    parser.add_argument("--atol", type=float, default=1e-3)
+    parser.add_argument("--rtol", type=float, default=1e-3)
+    args = parser.parse_args()
+
+    target_model, tokenizer, _ = load_target_bundle(
+        args.model,
+        lazy=True,
+        split_full_attention_sdpa=True,
+    )
+    draft_model, _ = load_draft_bundle(args.draft, lazy=True)
+
+    total = int(args.context_tokens) + int(args.verify_tokens)
+    token_stream = _build_long_token_stream(
+        tokenizer,
+        seed_text=README_MATH_PROMPT,
+        total_tokens=total,
+    )
+    prefix_tokens = token_stream[: int(args.context_tokens)]
+    verify_tokens = token_stream[int(args.context_tokens) : total]
+    capture_layer_ids = {int(layer_id) + 1 for layer_id in draft_model.target_layer_ids}
+
+    fa_layers = _set_only_quartet_layer(target_model, enabled_layer=None)
+    ref_logits = _run_verify_logits(
+        target_model=target_model,
+        prefix_tokens=prefix_tokens,
+        verify_tokens=verify_tokens,
+        capture_layer_ids=capture_layer_ids,
+        enabled_layer=None,
+        prefill_chunk_size=int(args.prefill_chunk_size),
+    )
+
+    failures: list[dict[str, float | int | bool]] = []
+    for layer_index in fa_layers:
+        test_logits = _run_verify_logits(
+            target_model=target_model,
+            prefix_tokens=prefix_tokens,
+            verify_tokens=verify_tokens,
+            capture_layer_ids=capture_layer_ids,
+            enabled_layer=layer_index,
+            prefill_chunk_size=int(args.prefill_chunk_size),
+        )
+        diff = mx.abs(ref_logits.astype(mx.float32) - test_logits.astype(mx.float32))
+        max_abs_diff = float(mx.max(diff).item())
+        allclose = bool(mx.allclose(ref_logits, test_logits, atol=args.atol, rtol=args.rtol).item())
+        result = {
+            "layer_index": layer_index,
+            "max_abs_diff": max_abs_diff,
+            "allclose": allclose,
+        }
+        print(result)
+        if not allclose:
+            failures.append(result)
+
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/quartet_gqa_microbench.py
+++ b/benchmark/quartet_gqa_microbench.py
@@ -1,0 +1,136 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import mlx.core as mx
+from mlx_lm.models.base import scaled_dot_product_attention
+
+from dflash_mlx.kernels import quartet_gqa_sdpa_exact
+
+
+def _dense_prefix_causal_mask(
+    *,
+    batch: int,
+    heads: int,
+    q_len: int,
+    kv_len: int,
+    dtype: mx.Dtype,
+) -> mx.array:
+    floor = float(mx.finfo(dtype).min)
+    base = [[[[
+        0.0 if k <= (kv_len - q_len + q) else floor
+        for k in range(kv_len)
+    ] for q in range(q_len)] for _ in range(heads)] for _ in range(batch)]
+    return mx.array(base, dtype=dtype)
+
+
+def _time_callable(fn, *, warmup: int, measure: int) -> float:
+    for _ in range(warmup):
+        out = fn()
+        mx.eval(out)
+
+    elapsed_us = 0.0
+    for _ in range(measure):
+        start = time.perf_counter_ns()
+        out = fn()
+        mx.eval(out)
+        elapsed_us += (time.perf_counter_ns() - start) / 1000.0
+    return elapsed_us / measure
+
+
+def _bench_case(
+    *,
+    kv_len: int,
+    warmup: int,
+    measure: int,
+    quartet_explicit_mask: bool,
+) -> dict[str, float | int]:
+    batch = 1
+    hq = 32
+    hk = 8
+    q_len = 16
+    dim = 128
+    dtype = mx.bfloat16
+    scale = dim**-0.5
+
+    queries = mx.random.normal((batch, hq, q_len, dim), dtype=mx.float32).astype(dtype)
+    keys = mx.random.normal((batch, hk, kv_len, dim), dtype=mx.float32).astype(dtype)
+    values = mx.random.normal((batch, hk, kv_len, dim), dtype=mx.float32).astype(dtype)
+    causal_mask = _dense_prefix_causal_mask(
+        batch=batch,
+        heads=hq,
+        q_len=q_len,
+        kv_len=kv_len,
+        dtype=dtype,
+    )
+
+    mx.eval(queries, keys, values, causal_mask)
+
+    def stock_call():
+        return scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=None,
+            scale=scale,
+            mask=causal_mask,
+        )
+
+    quartet_mask = causal_mask if quartet_explicit_mask else None
+
+    def quartet_call():
+        out = quartet_gqa_sdpa_exact(
+            queries=queries,
+            keys=keys,
+            values=values,
+            scale=scale,
+            mask=quartet_mask,
+        )
+        if out is None:
+            raise RuntimeError(f"quartet_gqa_sdpa_exact returned None for kv_len={kv_len}")
+        return out
+
+    stock_us = _time_callable(stock_call, warmup=warmup, measure=measure)
+    quartet_us = _time_callable(quartet_call, warmup=warmup, measure=measure)
+    return {
+        "kv_len": kv_len,
+        "stock_us": stock_us,
+        "quartet_us": quartet_us,
+        "ratio_stock_over_quartet": stock_us / quartet_us if quartet_us else float("inf"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Microbench stock SDPA vs quartet-GQA SDPA.")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--measure", type=int, default=50)
+    parser.add_argument(
+        "--quartet-explicit-mask",
+        action="store_true",
+        help="Pass the dense additive mask to quartet too. Default mimics runtime with implicit prefix-causal masking.",
+    )
+    args = parser.parse_args()
+
+    for kv_len in (1024, 2048, 4096, 8192):
+        result = _bench_case(
+            kv_len=kv_len,
+            warmup=args.warmup,
+            measure=args.measure,
+            quartet_explicit_mask=args.quartet_explicit_mask,
+        )
+        print(
+            {
+                "kv_len": result["kv_len"],
+                "stock_us": round(float(result["stock_us"]), 2),
+                "quartet_us": round(float(result["quartet_us"]), 2),
+                "ratio_stock_over_quartet": round(float(result["ratio_stock_over_quartet"]), 4),
+            }
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/quartet_gqa_validate.py
+++ b/benchmark/quartet_gqa_validate.py
@@ -1,0 +1,144 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import mlx.core as mx
+from mlx_lm.models.base import scaled_dot_product_attention
+
+from dflash_mlx.kernels import quartet_gqa_sdpa_exact
+
+
+def _dense_prefix_causal_mask(
+    *,
+    batch: int,
+    heads: int,
+    q_len: int,
+    kv_len: int,
+    dtype: mx.Dtype,
+    pad_multiple: int = 0,
+) -> mx.array:
+    floor = float(mx.finfo(dtype).min)
+    base = [[[[
+        0.0 if k <= (kv_len - q_len + q) else floor
+        for k in range(kv_len)
+    ] for q in range(q_len)] for _ in range(heads)] for _ in range(batch)]
+
+    if pad_multiple > 0:
+        pad_start = max(0, kv_len - pad_multiple)
+        for b in range(batch):
+            for h in range(heads):
+                for q in range(q_len):
+                    for k in range(pad_start, kv_len):
+                        base[b][h][q][k] = floor
+
+    return mx.array(base, dtype=dtype)
+
+
+def _validate_case(
+    *,
+    kv_len: int,
+    with_mask: bool,
+    rtol: float,
+    atol: float,
+) -> dict[str, float | int | bool]:
+    batch = 1
+    hq = 32
+    hk = 8
+    q_len = 16
+    dim = 128
+    dtype = mx.bfloat16
+    scale = dim**-0.5
+
+    queries = mx.random.normal((batch, hq, q_len, dim), dtype=mx.float32).astype(dtype)
+    keys = mx.random.normal((batch, hk, kv_len, dim), dtype=mx.float32).astype(dtype)
+    values = mx.random.normal((batch, hk, kv_len, dim), dtype=mx.float32).astype(dtype)
+
+    causal_mask = _dense_prefix_causal_mask(
+        batch=batch,
+        heads=hq,
+        q_len=q_len,
+        kv_len=kv_len,
+        dtype=dtype,
+        pad_multiple=64 if with_mask and kv_len >= 256 else 0,
+    )
+    custom_mask = causal_mask if with_mask else None
+
+    ref = scaled_dot_product_attention(
+        queries,
+        keys,
+        values,
+        cache=None,
+        scale=scale,
+        mask=causal_mask,
+    )
+    out = quartet_gqa_sdpa_exact(
+        queries=queries,
+        keys=keys,
+        values=values,
+        scale=scale,
+        mask=custom_mask,
+    )
+    if out is None:
+        raise RuntimeError(f"quartet_gqa_sdpa_exact returned None for N={kv_len} mask={with_mask}")
+
+    mx.eval(ref, out)
+    diff = mx.abs(ref.astype(mx.float32) - out.astype(mx.float32))
+    denom = mx.maximum(mx.abs(ref.astype(mx.float32)), mx.array(1e-6, dtype=mx.float32))
+    rel = diff / denom
+    max_abs_diff = float(mx.max(diff).item())
+    max_rel_diff = float(mx.max(rel).item())
+    allclose = bool(mx.allclose(ref, out, rtol=rtol, atol=atol).item())
+    return {
+        "kv_len": kv_len,
+        "with_mask": with_mask,
+        "max_abs_diff": max_abs_diff,
+        "max_rel_diff": max_rel_diff,
+        "allclose": allclose,
+    }
+
+
+def _validate_fallback() -> dict[str, bool]:
+    queries = mx.zeros((1, 32, 1, 128), dtype=mx.bfloat16)
+    keys = mx.zeros((1, 8, 32, 128), dtype=mx.bfloat16)
+    values = mx.zeros((1, 8, 32, 128), dtype=mx.bfloat16)
+    wrong_m = quartet_gqa_sdpa_exact(queries, keys, values, scale=128**-0.5)
+    wrong_dtype = quartet_gqa_sdpa_exact(
+        queries.astype(mx.float16),
+        keys.astype(mx.float16),
+        values.astype(mx.float16),
+        scale=128**-0.5,
+    )
+    return {
+        "fallback_m1": wrong_m is None,
+        "fallback_fp16": wrong_dtype is None,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate quartet-GQA SDPA numerics.")
+    parser.add_argument("--rtol", type=float, default=5e-3)
+    parser.add_argument("--atol", type=float, default=5e-3)
+    args = parser.parse_args()
+
+    results = []
+    for kv_len in (256, 1024, 4096, 8192):
+        results.append(_validate_case(kv_len=kv_len, with_mask=False, rtol=args.rtol, atol=args.atol))
+        results.append(_validate_case(kv_len=kv_len, with_mask=True, rtol=args.rtol, atol=args.atol))
+
+    fallback = _validate_fallback()
+
+    failed = [entry for entry in results if not entry["allclose"]]
+    for entry in results:
+        print(entry)
+    print(fallback)
+
+    if failed or not all(fallback.values()):
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/results/qwen3-5-27b-4bit-1024.json
+++ b/benchmark/results/qwen3-5-27b-4bit-1024.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-27B-DFlash",
     "max_new_tokens": 1024,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 1227.4889580003219,
-        "generation_tps": 33.55212570419146,
-        "peak_memory_gb": 15.334403507
+        "ttft_ms": 1218.338541992125,
+        "generation_tps": 33.99348117733003,
+        "peak_memory_gb": 15.3344065
       },
       "dflash": {
-        "ttft_ms": 374.810291,
-        "generation_tps": 68.4101221181033,
+        "ttft_ms": 375.744792,
+        "generation_tps": 68.2632121658571,
         "tokens_per_cycle": 9.481481481481481,
         "cycles": 108,
         "acceptance_ratio": 0.89453125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 7.45,
-        "peak_memory_gb": 19.119086774
+        "peak_memory_gb": 19.116264032
       },
-      "speedup": 2.038920655019996
+      "speedup": 2.0081265525515306
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 453.17537499977334,
-        "generation_tps": 32.86708444364418,
-        "peak_memory_gb": 15.334419319
+        "ttft_ms": 436.89825000183185,
+        "generation_tps": 33.96548482327647,
+        "peak_memory_gb": 15.334422334
       },
       "dflash": {
-        "ttft_ms": 412.71141600000004,
-        "generation_tps": 63.905354500457435,
+        "ttft_ms": 355.611334,
+        "generation_tps": 69.19011835170355,
         "tokens_per_cycle": 9.481481481481481,
         "cycles": 108,
         "acceptance_ratio": 0.89453125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 7.45,
-        "peak_memory_gb": 19.11909831
+        "peak_memory_gb": 19.116289592
       },
-      "speedup": 1.9443572675280425
+      "speedup": 2.0370714185798318
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 431.86612499994226,
-        "generation_tps": 33.2401371460435,
-        "peak_memory_gb": 15.334418998
+        "ttft_ms": 437.2577909962274,
+        "generation_tps": 33.990932475418894,
+        "peak_memory_gb": 15.334422423
       },
       "dflash": {
-        "ttft_ms": 379.324625,
-        "generation_tps": 65.79517033411425,
+        "ttft_ms": 362.5255,
+        "generation_tps": 69.39381734017034,
         "tokens_per_cycle": 9.481481481481481,
         "cycles": 108,
         "acceptance_ratio": 0.89453125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 7.45,
-        "peak_memory_gb": 19.11909685
+        "peak_memory_gb": 19.116263568
       },
-      "speedup": 1.9793892559780155
+      "speedup": 2.0415390895896612
     }
   ],
   "summary": {
-    "baseline_tps_median": 33.2401371460435,
-    "dflash_tps_median": 65.79517033411425,
-    "dflash_tps_min": 63.905354500457435,
-    "dflash_tps_max": 68.4101221181033,
-    "speedup_median": 1.9793892559780155,
+    "baseline_tps_median": 33.990932475418894,
+    "dflash_tps_median": 69.19011835170355,
+    "dflash_tps_min": 68.2632121658571,
+    "dflash_tps_max": 69.39381734017034,
+    "speedup_median": 2.0370714185798318,
     "acceptance_ratio_median": 0.89453125
   }
 }

--- a/benchmark/results/qwen3-5-27b-4bit-16384.json
+++ b/benchmark/results/qwen3-5-27b-4bit-16384.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "mlx-community/Qwen3.5-27B-4bit",
+    "draft_model": "z-lab/Qwen3.5-27B-DFlash",
+    "max_new_tokens": 16384,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1012.5618340098299,
+        "generation_tps": 33.87018160466159,
+        "peak_memory_gb": 15.37425974
+      },
+      "dflash": {
+        "ttft_ms": 393.789625,
+        "generation_tps": 39.48739272018214,
+        "tokens_per_cycle": 6.931088900578643,
+        "cycles": 1901,
+        "acceptance_ratio": 0.855722525804493,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 6.5,
+        "peak_memory_gb": 20.134012872
+      },
+      "speedup": 1.165845320260918
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1018.3995829866035,
+        "generation_tps": 33.88269243474909,
+        "peak_memory_gb": 15.374270561
+      },
+      "dflash": {
+        "ttft_ms": 379.49058299999996,
+        "generation_tps": 39.12137818518539,
+        "tokens_per_cycle": 6.931088900578643,
+        "cycles": 1901,
+        "acceptance_ratio": 0.855722525804493,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 6.5,
+        "peak_memory_gb": 20.134040108
+      },
+      "speedup": 1.154612439980232
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1033.693500008667,
+        "generation_tps": 33.87026269605207,
+        "peak_memory_gb": 15.374269124
+      },
+      "dflash": {
+        "ttft_ms": 374.508625,
+        "generation_tps": 39.32967850325602,
+        "tokens_per_cycle": 6.931088900578643,
+        "cycles": 1901,
+        "acceptance_ratio": 0.855722525804493,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 6.5,
+        "peak_memory_gb": 20.13401696
+      },
+      "speedup": 1.1611861075952121
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 33.87026269605207,
+    "dflash_tps_median": 39.32967850325602,
+    "dflash_tps_min": 39.12137818518539,
+    "dflash_tps_max": 39.48739272018214,
+    "speedup_median": 1.1611861075952121,
+    "acceptance_ratio_median": 0.855722525804493
+  }
+}

--- a/benchmark/results/qwen3-5-27b-4bit-2048.json
+++ b/benchmark/results/qwen3-5-27b-4bit-2048.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-27B-DFlash",
     "max_new_tokens": 2048,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 448.8239580005029,
-        "generation_tps": 33.61316643157089,
-        "peak_memory_gb": 15.412956116
+        "ttft_ms": 465.88595800858457,
+        "generation_tps": 33.87985609359392,
+        "peak_memory_gb": 15.374273444
       },
       "dflash": {
-        "ttft_ms": 371.75579200000004,
-        "generation_tps": 63.84495933370266,
+        "ttft_ms": 397.588125,
+        "generation_tps": 63.818459002083465,
         "tokens_per_cycle": 9.183856502242152,
         "cycles": 223,
         "acceptance_ratio": 0.89111328125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 5.4,
-        "peak_memory_gb": 19.20985679
+        "peak_memory_gb": 19.207021888
       },
-      "speedup": 1.899403302681321
+      "speedup": 1.8836697188377491
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 431.0550410009455,
-        "generation_tps": 32.345749230496644,
-        "peak_memory_gb": 15.412956462
+        "ttft_ms": 438.6428750003688,
+        "generation_tps": 33.86744323675437,
+        "peak_memory_gb": 15.374270902
       },
       "dflash": {
-        "ttft_ms": 376.315333,
-        "generation_tps": 62.778297464780195,
+        "ttft_ms": 377.43904200000003,
+        "generation_tps": 63.95869268007311,
         "tokens_per_cycle": 9.183856502242152,
         "cycles": 223,
         "acceptance_ratio": 0.89111328125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 5.4,
-        "peak_memory_gb": 19.209888106
+        "peak_memory_gb": 19.207059672
       },
-      "speedup": 1.940851547986118
+      "speedup": 1.8885007714625017
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 443.4094169992022,
-        "generation_tps": 30.66589879952857,
-        "peak_memory_gb": 15.412960037
+        "ttft_ms": 438.4502920001978,
+        "generation_tps": 33.88062413915513,
+        "peak_memory_gb": 15.374274846
       },
       "dflash": {
-        "ttft_ms": 361.655083,
-        "generation_tps": 55.102009298221006,
+        "ttft_ms": 381.490375,
+        "generation_tps": 64.03532173338535,
         "tokens_per_cycle": 9.183856502242152,
         "cycles": 223,
         "acceptance_ratio": 0.89111328125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 5.4,
-        "peak_memory_gb": 19.209857186
+        "peak_memory_gb": 19.20704888
       },
-      "speedup": 1.7968496426091414
+      "speedup": 1.8900278067599428
     }
   ],
   "summary": {
-    "baseline_tps_median": 32.345749230496644,
-    "dflash_tps_median": 62.778297464780195,
-    "dflash_tps_min": 55.102009298221006,
-    "dflash_tps_max": 63.84495933370266,
-    "speedup_median": 1.899403302681321,
+    "baseline_tps_median": 33.87985609359392,
+    "dflash_tps_median": 63.95869268007311,
+    "dflash_tps_min": 63.818459002083465,
+    "dflash_tps_max": 64.03532173338535,
+    "speedup_median": 1.8885007714625017,
     "acceptance_ratio_median": 0.89111328125
   }
 }

--- a/benchmark/results/qwen3-5-27b-4bit-32768.json
+++ b/benchmark/results/qwen3-5-27b-4bit-32768.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "mlx-community/Qwen3.5-27B-4bit",
+    "draft_model": "z-lab/Qwen3.5-27B-DFlash",
+    "max_new_tokens": 32768,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1058.8048750068992,
+        "generation_tps": 33.86654590575888,
+        "peak_memory_gb": 15.374265446
+      },
+      "dflash": {
+        "ttft_ms": 396.15479200000004,
+        "generation_tps": 39.34984646247292,
+        "tokens_per_cycle": 6.931088900578643,
+        "cycles": 1901,
+        "acceptance_ratio": 0.855722525804493,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 6.5,
+        "peak_memory_gb": 20.134004728
+      },
+      "speedup": 1.1619090583365816
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1023.3399580029072,
+        "generation_tps": 33.84623258621966,
+        "peak_memory_gb": 15.374274245
+      },
+      "dflash": {
+        "ttft_ms": 377.589417,
+        "generation_tps": 39.09422798983776,
+        "tokens_per_cycle": 6.931088900578643,
+        "cycles": 1901,
+        "acceptance_ratio": 0.855722525804493,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 6.5,
+        "peak_memory_gb": 20.1340333
+      },
+      "speedup": 1.1550540489329026
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1025.88770899456,
+        "generation_tps": 33.80368703596127,
+        "peak_memory_gb": 15.374274502
+      },
+      "dflash": {
+        "ttft_ms": 375.311625,
+        "generation_tps": 39.386875736174844,
+        "tokens_per_cycle": 6.931088900578643,
+        "cycles": 1901,
+        "acceptance_ratio": 0.855722525804493,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 6.5,
+        "peak_memory_gb": 20.134016784
+      },
+      "speedup": 1.1651650807876084
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 33.84623258621966,
+    "dflash_tps_median": 39.34984646247292,
+    "dflash_tps_min": 39.09422798983776,
+    "dflash_tps_max": 39.386875736174844,
+    "speedup_median": 1.1619090583365816,
+    "acceptance_ratio_median": 0.855722525804493
+  }
+}

--- a/benchmark/results/qwen3-5-27b-4bit-4096.json
+++ b/benchmark/results/qwen3-5-27b-4bit-4096.json
@@ -14,77 +14,37 @@
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
-    "repeat": 3,
-    "git_hash": "da458e2"
+    "repeat": 1,
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 447.6496250008495,
-        "generation_tps": 32.31754331219741,
-        "peak_memory_gb": 15.571684056
+        "ttft_ms": 1161.4825830038171,
+        "generation_tps": 32.6807154774636,
+        "peak_memory_gb": 15.374258462
       },
       "dflash": {
-        "ttft_ms": 361.967167,
-        "generation_tps": 53.617985084286914,
+        "ttft_ms": 431.071,
+        "generation_tps": 53.256181877912574,
         "tokens_per_cycle": 8.325203252032521,
         "cycles": 492,
         "acceptance_ratio": 0.8798828125,
         "acceptance_first_20_avg": 6.6,
         "acceptance_last_20_avg": 10.15,
-        "peak_memory_gb": 19.40699201
+        "peak_memory_gb": 19.404144844
       },
-      "speedup": 1.6590984211368014
-    },
-    {
-      "run": 2,
-      "thermal_pressure": "unknown",
-      "baseline": {
-        "ttft_ms": 774.2356250000739,
-        "generation_tps": 29.284688776098967,
-        "peak_memory_gb": 15.571680397
-      },
-      "dflash": {
-        "ttft_ms": 366.566125,
-        "generation_tps": 47.590828141320806,
-        "tokens_per_cycle": 8.325203252032521,
-        "cycles": 492,
-        "acceptance_ratio": 0.8798828125,
-        "acceptance_first_20_avg": 6.6,
-        "acceptance_last_20_avg": 10.15,
-        "peak_memory_gb": 19.407023794
-      },
-      "speedup": 1.6251095753547022
-    },
-    {
-      "run": 3,
-      "thermal_pressure": "unknown",
-      "baseline": {
-        "ttft_ms": 794.8466670004564,
-        "generation_tps": 29.384055250396887,
-        "peak_memory_gb": 15.571684103
-      },
-      "dflash": {
-        "ttft_ms": 365.131875,
-        "generation_tps": 48.8945147138223,
-        "tokens_per_cycle": 8.325203252032521,
-        "cycles": 492,
-        "acceptance_ratio": 0.8798828125,
-        "acceptance_first_20_avg": 6.6,
-        "acceptance_last_20_avg": 10.15,
-        "peak_memory_gb": 19.40698115
-      },
-      "speedup": 1.6639811726858869
+      "speedup": 1.62959045112209
     }
   ],
   "summary": {
-    "baseline_tps_median": 29.384055250396887,
-    "dflash_tps_median": 48.8945147138223,
-    "dflash_tps_min": 47.590828141320806,
-    "dflash_tps_max": 53.617985084286914,
-    "speedup_median": 1.6590984211368014,
+    "baseline_tps_median": 32.6807154774636,
+    "dflash_tps_median": 53.256181877912574,
+    "dflash_tps_min": 53.256181877912574,
+    "dflash_tps_max": 53.256181877912574,
+    "speedup_median": 1.62959045112209,
     "acceptance_ratio_median": 0.8798828125
   }
 }

--- a/benchmark/results/qwen3-5-27b-4bit-8192.json
+++ b/benchmark/results/qwen3-5-27b-4bit-8192.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "mlx-community/Qwen3.5-27B-4bit",
+    "draft_model": "z-lab/Qwen3.5-27B-DFlash",
+    "max_new_tokens": 8192,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 941.2457090074895,
+        "generation_tps": 33.886204135343625,
+        "peak_memory_gb": 15.374263124
+      },
+      "dflash": {
+        "ttft_ms": 386.52925,
+        "generation_tps": 45.60524934011774,
+        "tokens_per_cycle": 7.129677980852915,
+        "cycles": 1149,
+        "acceptance_ratio": 0.8597412109375,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 8.05,
+        "peak_memory_gb": 19.696594956
+      },
+      "speedup": 1.3458352891332268
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 993.3022920013173,
+        "generation_tps": 33.87716213868322,
+        "peak_memory_gb": 15.374271013
+      },
+      "dflash": {
+        "ttft_ms": 374.230125,
+        "generation_tps": 45.173626403903626,
+        "tokens_per_cycle": 7.129677980852915,
+        "cycles": 1149,
+        "acceptance_ratio": 0.8597412109375,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 8.05,
+        "peak_memory_gb": 19.69661494
+      },
+      "speedup": 1.3334536765203644
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1001.4187499909895,
+        "generation_tps": 33.862083145372246,
+        "peak_memory_gb": 15.374273621
+      },
+      "dflash": {
+        "ttft_ms": 377.670208,
+        "generation_tps": 45.29177072933977,
+        "tokens_per_cycle": 7.129677980852915,
+        "cycles": 1149,
+        "acceptance_ratio": 0.8597412109375,
+        "acceptance_first_20_avg": 6.6,
+        "acceptance_last_20_avg": 8.05,
+        "peak_memory_gb": 19.69659236
+      },
+      "speedup": 1.3375364573673476
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 33.87716213868322,
+    "dflash_tps_median": 45.29177072933977,
+    "dflash_tps_min": 45.173626403903626,
+    "dflash_tps_max": 45.60524934011774,
+    "speedup_median": 1.3375364573673476,
+    "acceptance_ratio_median": 0.8597412109375
+  }
+}

--- a/benchmark/results/qwen3-5-35b-a3b-4bit-1024.json
+++ b/benchmark/results/qwen3-5-35b-a3b-4bit-1024.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-35B-A3B-DFlash",
     "max_new_tokens": 1024,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 1516.507125001226,
-        "generation_tps": 138.9988454255071,
-        "peak_memory_gb": 19.57421719
+        "ttft_ms": 1515.9357499942416,
+        "generation_tps": 147.07368430393,
+        "peak_memory_gb": 19.574705422
       },
       "dflash": {
-        "ttft_ms": 456.284125,
-        "generation_tps": 230.1902340965039,
+        "ttft_ms": 467.10333299999996,
+        "generation_tps": 257.4676730359577,
         "tokens_per_cycle": 9.309090909090909,
         "cycles": 110,
         "acceptance_ratio": 0.892578125,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 9.85,
-        "peak_memory_gb": 20.717418465
+        "peak_memory_gb": 20.711656643
       },
-      "speedup": 1.6560586053203477
+      "speedup": 1.750603272465092
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 484.2092090002552,
-        "generation_tps": 139.9655411043486,
-        "peak_memory_gb": 19.574882812
+        "ttft_ms": 511.1406670039287,
+        "generation_tps": 146.86566318622596,
+        "peak_memory_gb": 19.57485166
       },
       "dflash": {
-        "ttft_ms": 444.66108399999996,
-        "generation_tps": 242.9177890318574,
+        "ttft_ms": 457.545458,
+        "generation_tps": 262.3523679238872,
         "tokens_per_cycle": 9.309090909090909,
         "cycles": 110,
         "acceptance_ratio": 0.892578125,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 9.85,
-        "peak_memory_gb": 20.717421961
+        "peak_memory_gb": 20.711643299
       },
-      "speedup": 1.735554245103477
+      "speedup": 1.786342445417101
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 496.7304580004565,
-        "generation_tps": 144.3663821267179,
-        "peak_memory_gb": 19.574877148
+        "ttft_ms": 504.99745800334495,
+        "generation_tps": 146.89889212841769,
+        "peak_memory_gb": 19.57485829
       },
       "dflash": {
-        "ttft_ms": 445.80654200000004,
-        "generation_tps": 258.38876648600035,
+        "ttft_ms": 455.351542,
+        "generation_tps": 262.0053956076027,
         "tokens_per_cycle": 9.309090909090909,
         "cycles": 110,
         "acceptance_ratio": 0.892578125,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 9.85,
-        "peak_memory_gb": 20.717465217
+        "peak_memory_gb": 20.711690019
       },
-      "speedup": 1.789812577412926
+      "speedup": 1.7835763892525474
     }
   ],
   "summary": {
-    "baseline_tps_median": 139.9655411043486,
-    "dflash_tps_median": 242.9177890318574,
-    "dflash_tps_min": 230.1902340965039,
-    "dflash_tps_max": 258.38876648600035,
-    "speedup_median": 1.735554245103477,
+    "baseline_tps_median": 146.89889212841769,
+    "dflash_tps_median": 262.0053956076027,
+    "dflash_tps_min": 257.4676730359577,
+    "dflash_tps_max": 262.3523679238872,
+    "speedup_median": 1.7835763892525474,
     "acceptance_ratio_median": 0.892578125
   }
 }

--- a/benchmark/results/qwen3-5-35b-a3b-4bit-16384.json
+++ b/benchmark/results/qwen3-5-35b-a3b-4bit-16384.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+    "draft_model": "z-lab/Qwen3.5-35B-A3B-DFlash",
+    "max_new_tokens": 16384,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1414.4339589984156,
+        "generation_tps": 124.31869098774459,
+        "peak_memory_gb": 19.913394334
+      },
+      "dflash": {
+        "ttft_ms": 1064.7030419999999,
+        "generation_tps": 130.7130611729663,
+        "tokens_per_cycle": 6.562465297057191,
+        "cycles": 1801,
+        "acceptance_ratio": 0.8476182418140282,
+        "acceptance_first_20_avg": 7.2,
+        "acceptance_last_20_avg": 7.85,
+        "peak_memory_gb": 21.0444122
+      },
+      "speedup": 1.051435308193939
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1589.633417010191,
+        "generation_tps": 117.07619774650723,
+        "peak_memory_gb": 19.912992884
+      },
+      "dflash": {
+        "ttft_ms": 1434.873041,
+        "generation_tps": 121.75910663218083,
+        "tokens_per_cycle": 6.562465297057191,
+        "cycles": 1801,
+        "acceptance_ratio": 0.8476182418140282,
+        "acceptance_first_20_avg": 7.2,
+        "acceptance_last_20_avg": 7.85,
+        "peak_memory_gb": 21.044334688
+      },
+      "speedup": 1.0399988125324415
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1653.7539589917287,
+        "generation_tps": 117.85950962984518,
+        "peak_memory_gb": 19.91357931
+      },
+      "dflash": {
+        "ttft_ms": 1499.760167,
+        "generation_tps": 122.98281024089871,
+        "tokens_per_cycle": 6.562465297057191,
+        "cycles": 1801,
+        "acceptance_ratio": 0.8476182418140282,
+        "acceptance_first_20_avg": 7.2,
+        "acceptance_last_20_avg": 7.85,
+        "peak_memory_gb": 21.044658048
+      },
+      "speedup": 1.0434695564841905
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 117.85950962984518,
+    "dflash_tps_median": 122.98281024089871,
+    "dflash_tps_min": 121.75910663218083,
+    "dflash_tps_max": 130.7130611729663,
+    "speedup_median": 1.0434695564841905,
+    "acceptance_ratio_median": 0.8476182418140282
+  }
+}

--- a/benchmark/results/qwen3-5-35b-a3b-4bit-2048.json
+++ b/benchmark/results/qwen3-5-35b-a3b-4bit-2048.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-35B-A3B-DFlash",
     "max_new_tokens": 2048,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 533.4856659992511,
-        "generation_tps": 142.11849258933555,
-        "peak_memory_gb": 19.599891194
+        "ttft_ms": 531.1731670080917,
+        "generation_tps": 147.2518763601981,
+        "peak_memory_gb": 19.600040094
       },
       "dflash": {
-        "ttft_ms": 442.097833,
-        "generation_tps": 240.20976244316435,
+        "ttft_ms": 478.210667,
+        "generation_tps": 243.00345747466932,
         "tokens_per_cycle": 8.827586206896552,
         "cycles": 232,
         "acceptance_ratio": 0.88671875,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 6.4,
-        "peak_memory_gb": 20.745298066
+        "peak_memory_gb": 20.739511668
       },
-      "speedup": 1.6902076434012887
+      "speedup": 1.650257120528976
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 488.5804169989569,
-        "generation_tps": 138.93311420602998,
-        "peak_memory_gb": 19.600064838
+        "ttft_ms": 540.2123749954626,
+        "generation_tps": 145.4216327898413,
+        "peak_memory_gb": 19.599284246
       },
       "dflash": {
-        "ttft_ms": 449.980041,
-        "generation_tps": 236.20654932646602,
+        "ttft_ms": 455.719875,
+        "generation_tps": 243.31697352336695,
         "tokens_per_cycle": 8.827586206896552,
         "cycles": 232,
         "acceptance_ratio": 0.88671875,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 6.4,
-        "peak_memory_gb": 20.745289554
+        "peak_memory_gb": 20.739508324
       },
-      "speedup": 1.7001457908456943
+      "speedup": 1.6731827916896027
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 491.96037500041706,
-        "generation_tps": 146.1477290847584,
-        "peak_memory_gb": 19.600042534
+        "ttft_ms": 547.4470000044676,
+        "generation_tps": 145.40879366198521,
+        "peak_memory_gb": 19.600007244
       },
       "dflash": {
-        "ttft_ms": 447.87379100000004,
-        "generation_tps": 240.97448056129878,
+        "ttft_ms": 458.83891700000004,
+        "generation_tps": 241.97296101881386,
         "tokens_per_cycle": 8.827586206896552,
         "cycles": 232,
         "acceptance_ratio": 0.88671875,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 6.4,
-        "peak_memory_gb": 20.745355154
+        "peak_memory_gb": 20.739497684
       },
-      "speedup": 1.6488417717496355
+      "speedup": 1.6640875350448203
     }
   ],
   "summary": {
-    "baseline_tps_median": 142.11849258933555,
-    "dflash_tps_median": 240.20976244316435,
-    "dflash_tps_min": 236.20654932646602,
-    "dflash_tps_max": 240.97448056129878,
-    "speedup_median": 1.6902076434012887,
+    "baseline_tps_median": 145.4216327898413,
+    "dflash_tps_median": 243.00345747466932,
+    "dflash_tps_min": 241.97296101881386,
+    "dflash_tps_max": 243.31697352336695,
+    "speedup_median": 1.6640875350448203,
     "acceptance_ratio_median": 0.88671875
   }
 }

--- a/benchmark/results/qwen3-5-35b-a3b-4bit-4096.json
+++ b/benchmark/results/qwen3-5-35b-a3b-4bit-4096.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-35B-A3B-DFlash",
     "max_new_tokens": 4096,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 530.104500001471,
-        "generation_tps": 145.72715273694988,
-        "peak_memory_gb": 19.649121844
+        "ttft_ms": 574.3283339979826,
+        "generation_tps": 145.63818524517615,
+        "peak_memory_gb": 19.64912584
       },
       "dflash": {
-        "ttft_ms": 448.693417,
-        "generation_tps": 193.09236802768933,
+        "ttft_ms": 476.345583,
+        "generation_tps": 195.30453789842525,
         "tokens_per_cycle": 7.670411985018727,
         "cycles": 534,
         "acceptance_ratio": 0.86962890625,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 3.75,
-        "peak_memory_gb": 20.798884114
+        "peak_memory_gb": 20.793054044
       },
-      "speedup": 1.325026698190129
+      "speedup": 1.3410256216090426
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 508.540124999854,
-        "generation_tps": 139.76501177404432,
-        "peak_memory_gb": 19.649147064
+        "ttft_ms": 644.6924579940969,
+        "generation_tps": 143.98782332491987,
+        "peak_memory_gb": 19.648305134
       },
       "dflash": {
-        "ttft_ms": 533.443334,
-        "generation_tps": 189.44616104751444,
+        "ttft_ms": 468.959542,
+        "generation_tps": 195.85399189162305,
         "tokens_per_cycle": 7.670411985018727,
         "cycles": 534,
         "acceptance_ratio": 0.86962890625,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 3.75,
-        "peak_memory_gb": 20.798818514
+        "peak_memory_gb": 20.793018204
       },
-      "speedup": 1.3554619903999205
+      "speedup": 1.3602121857878433
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 509.3578329997399,
-        "generation_tps": 140.7311028896581,
-        "peak_memory_gb": 19.648972578
+        "ttft_ms": 802.5357500009704,
+        "generation_tps": 145.13657065363134,
+        "peak_memory_gb": 19.649093376
       },
       "dflash": {
-        "ttft_ms": 486.845375,
-        "generation_tps": 189.621913439917,
+        "ttft_ms": 499.54420799999997,
+        "generation_tps": 194.974366704539,
         "tokens_per_cycle": 7.670411985018727,
         "cycles": 534,
         "acceptance_ratio": 0.86962890625,
         "acceptance_first_20_avg": 7.2,
         "acceptance_last_20_avg": 3.75,
-        "peak_memory_gb": 20.798842074
+        "peak_memory_gb": 20.793070004
       },
-      "speedup": 1.3474058651312661
+      "speedup": 1.343385514942651
     }
   ],
   "summary": {
-    "baseline_tps_median": 140.7311028896581,
-    "dflash_tps_median": 189.621913439917,
-    "dflash_tps_min": 189.44616104751444,
-    "dflash_tps_max": 193.09236802768933,
-    "speedup_median": 1.3474058651312661,
+    "baseline_tps_median": 145.13657065363134,
+    "dflash_tps_median": 195.30453789842525,
+    "dflash_tps_min": 194.974366704539,
+    "dflash_tps_max": 195.85399189162305,
+    "speedup_median": 1.343385514942651,
     "acceptance_ratio_median": 0.86962890625
   }
 }

--- a/benchmark/results/qwen3-5-35b-a3b-4bit-8192.json
+++ b/benchmark/results/qwen3-5-35b-a3b-4bit-8192.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "mlx-community/Qwen3.5-35B-A3B-4bit",
+    "draft_model": "z-lab/Qwen3.5-35B-A3B-DFlash",
+    "max_new_tokens": 8192,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 801.8936250009574,
+        "generation_tps": 142.26590548963895,
+        "peak_memory_gb": 19.746133568
+      },
+      "dflash": {
+        "ttft_ms": 529.689875,
+        "generation_tps": 160.87986149275034,
+        "tokens_per_cycle": 6.809642560266002,
+        "cycles": 1203,
+        "acceptance_ratio": 0.8531494140625,
+        "acceptance_first_20_avg": 7.2,
+        "acceptance_last_20_avg": 5.1,
+        "peak_memory_gb": 20.914890908
+      },
+      "speedup": 1.130839191154391
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1262.6607910060557,
+        "generation_tps": 140.1048908105833,
+        "peak_memory_gb": 19.72795969
+      },
+      "dflash": {
+        "ttft_ms": 545.264458,
+        "generation_tps": 159.21187272734292,
+        "tokens_per_cycle": 6.809642560266002,
+        "cycles": 1203,
+        "acceptance_ratio": 0.8531494140625,
+        "acceptance_first_20_avg": 7.2,
+        "acceptance_last_20_avg": 5.1,
+        "peak_memory_gb": 20.914753724
+      },
+      "speedup": 1.1363762664259278
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1162.9385829874082,
+        "generation_tps": 134.25581663513154,
+        "peak_memory_gb": 19.727725976
+      },
+      "dflash": {
+        "ttft_ms": 558.448875,
+        "generation_tps": 155.55040927507895,
+        "tokens_per_cycle": 6.809642560266002,
+        "cycles": 1203,
+        "acceptance_ratio": 0.8531494140625,
+        "acceptance_first_20_avg": 7.2,
+        "acceptance_last_20_avg": 5.1,
+        "peak_memory_gb": 20.914792572
+      },
+      "speedup": 1.158612067422151
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 140.1048908105833,
+    "dflash_tps_median": 159.21187272734292,
+    "dflash_tps_min": 155.55040927507895,
+    "dflash_tps_max": 160.87986149275034,
+    "speedup_median": 1.1363762664259278,
+    "acceptance_ratio_median": 0.8531494140625
+  }
+}

--- a/benchmark/results/qwen3-5-4b-1024.json
+++ b/benchmark/results/qwen3-5-4b-1024.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-4B-DFlash",
     "max_new_tokens": 1024,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 674.4975829988107,
-        "generation_tps": 56.596568008156716,
-        "peak_memory_gb": 8.497592835
+        "ttft_ms": 272.59558299556375,
+        "generation_tps": 54.069249970717365,
+        "peak_memory_gb": 8.497595573
       },
       "dflash": {
-        "ttft_ms": 200.824083,
-        "generation_tps": 192.42694425183436,
+        "ttft_ms": 233.76829199999997,
+        "generation_tps": 213.30451131669517,
         "tokens_per_cycle": 8.827586206896552,
         "cycles": 116,
         "acceptance_ratio": 0.88671875,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 9.35,
-        "peak_memory_gb": 9.75433584
+        "peak_memory_gb": 9.756652572
       },
-      "speedup": 3.3999754936395035
+      "speedup": 3.9450244165069033
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 238.11291699894355,
-        "generation_tps": 53.48319631354195,
-        "peak_memory_gb": 8.497594935
+        "ttft_ms": 247.4022079986753,
+        "generation_tps": 54.2670758652942,
+        "peak_memory_gb": 8.497589982
       },
       "dflash": {
-        "ttft_ms": 200.85829199999998,
-        "generation_tps": 197.48912222007533,
+        "ttft_ms": 215.027875,
+        "generation_tps": 219.5466895705263,
         "tokens_per_cycle": 8.827586206896552,
         "cycles": 116,
         "acceptance_ratio": 0.88671875,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 9.35,
-        "peak_memory_gb": 9.754350816
+        "peak_memory_gb": 9.756688156
       },
-      "speedup": 3.6925452447214915
+      "speedup": 4.045670161323995
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 237.1160000002419,
-        "generation_tps": 53.20822979426412,
-        "peak_memory_gb": 8.497589598
+        "ttft_ms": 247.96333399717696,
+        "generation_tps": 54.201748858427074,
+        "peak_memory_gb": 8.497592503
       },
       "dflash": {
-        "ttft_ms": 193.4195,
-        "generation_tps": 199.6134519810948,
+        "ttft_ms": 211.845041,
+        "generation_tps": 218.36544369958338,
         "tokens_per_cycle": 8.827586206896552,
         "cycles": 116,
         "acceptance_ratio": 0.88671875,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 9.35,
-        "peak_memory_gb": 9.75435504
+        "peak_memory_gb": 9.75666614
       },
-      "speedup": 3.75155220823778
+      "speedup": 4.02875273028451
     }
   ],
   "summary": {
-    "baseline_tps_median": 53.48319631354195,
-    "dflash_tps_median": 197.48912222007533,
-    "dflash_tps_min": 192.42694425183436,
-    "dflash_tps_max": 199.6134519810948,
-    "speedup_median": 3.6925452447214915,
+    "baseline_tps_median": 54.201748858427074,
+    "dflash_tps_median": 218.36544369958338,
+    "dflash_tps_min": 213.30451131669517,
+    "dflash_tps_max": 219.5466895705263,
+    "speedup_median": 4.02875273028451,
     "acceptance_ratio_median": 0.88671875
   }
 }

--- a/benchmark/results/qwen3-5-4b-16384.json
+++ b/benchmark/results/qwen3-5-4b-16384.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "Qwen/Qwen3.5-4B",
+    "draft_model": "z-lab/Qwen3.5-4B-DFlash",
+    "max_new_tokens": 16384,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 274.66995899158064,
+        "generation_tps": 54.204843782458155,
+        "peak_memory_gb": 8.518433424
+      },
+      "dflash": {
+        "ttft_ms": 267.480375,
+        "generation_tps": 165.32942669628378,
+        "tokens_per_cycle": 8.354920958694544,
+        "cycles": 1961,
+        "acceptance_ratio": 0.88031005859375,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 10.9,
+        "peak_memory_gb": 10.434430932
+      },
+      "speedup": 3.050085843984812
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 257.84554200072307,
+        "generation_tps": 54.109870092507954,
+        "peak_memory_gb": 8.518435538
+      },
+      "dflash": {
+        "ttft_ms": 244.81370800000002,
+        "generation_tps": 165.21842711338127,
+        "tokens_per_cycle": 8.354920958694544,
+        "cycles": 1961,
+        "acceptance_ratio": 0.88031005859375,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 10.9,
+        "peak_memory_gb": 10.434462292
+      },
+      "speedup": 3.053387983207474
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 257.155999992392,
+        "generation_tps": 54.33095250894397,
+        "peak_memory_gb": 8.518431314
+      },
+      "dflash": {
+        "ttft_ms": 247.368,
+        "generation_tps": 165.37329933743882,
+        "tokens_per_cycle": 8.354920958694544,
+        "cycles": 1961,
+        "acceptance_ratio": 0.88031005859375,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 10.9,
+        "peak_memory_gb": 10.43449506
+      },
+      "speedup": 3.043813732332689
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 54.204843782458155,
+    "dflash_tps_median": 165.32942669628378,
+    "dflash_tps_min": 165.21842711338127,
+    "dflash_tps_max": 165.37329933743882,
+    "speedup_median": 3.050085843984812,
+    "acceptance_ratio_median": 0.88031005859375
+  }
+}

--- a/benchmark/results/qwen3-5-4b-2048.json
+++ b/benchmark/results/qwen3-5-4b-2048.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-4B-DFlash",
     "max_new_tokens": 2048,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 255.722333000449,
-        "generation_tps": 54.11140954600346,
-        "peak_memory_gb": 8.539407223
+        "ttft_ms": 258.52554199809674,
+        "generation_tps": 53.831534716730744,
+        "peak_memory_gb": 8.518433065
       },
       "dflash": {
-        "ttft_ms": 195.410875,
-        "generation_tps": 227.04994265493949,
+        "ttft_ms": 227.293667,
+        "generation_tps": 228.24331395651652,
         "tokens_per_cycle": 9.309090909090909,
         "cycles": 220,
         "acceptance_ratio": 0.892578125,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 12.1,
-        "peak_memory_gb": 9.807426357
+        "peak_memory_gb": 9.802151155
       },
-      "speedup": 4.195971691735553
+      "speedup": 4.239955541999045
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 237.81787500047358,
-        "generation_tps": 53.605651848329494,
-        "peak_memory_gb": 8.539411794
+        "ttft_ms": 238.90816699713469,
+        "generation_tps": 54.09849673667133,
+        "peak_memory_gb": 8.51842992
       },
       "dflash": {
-        "ttft_ms": 210.89275,
-        "generation_tps": 219.82982957221353,
+        "ttft_ms": 211.035333,
+        "generation_tps": 226.69826771889308,
         "tokens_per_cycle": 9.309090909090909,
         "cycles": 220,
         "acceptance_ratio": 0.892578125,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 12.1,
-        "peak_memory_gb": 9.807422133
+        "peak_memory_gb": 9.802149747
       },
-      "speedup": 4.1008703745305555
+      "speedup": 4.190472589698095
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 239.12012500022686,
-        "generation_tps": 53.742076932901355,
-        "peak_memory_gb": 8.539407314
+        "ttft_ms": 239.4334169948706,
+        "generation_tps": 54.19794984957738,
+        "peak_memory_gb": 8.518432018
       },
       "dflash": {
-        "ttft_ms": 203.6515,
-        "generation_tps": 208.04611932078,
+        "ttft_ms": 210.733125,
+        "generation_tps": 228.4809351015669,
         "tokens_per_cycle": 9.309090909090909,
         "cycles": 220,
         "acceptance_ratio": 0.892578125,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 12.1,
-        "peak_memory_gb": 9.807423541
+        "peak_memory_gb": 9.802155379
       },
-      "speedup": 3.8711961128806394
+      "speedup": 4.215674868435056
     }
   ],
   "summary": {
-    "baseline_tps_median": 53.742076932901355,
-    "dflash_tps_median": 219.82982957221353,
-    "dflash_tps_min": 208.04611932078,
-    "dflash_tps_max": 227.04994265493949,
-    "speedup_median": 4.1008703745305555,
+    "baseline_tps_median": 54.09849673667133,
+    "dflash_tps_median": 228.24331395651652,
+    "dflash_tps_min": 226.69826771889308,
+    "dflash_tps_max": 228.4809351015669,
+    "speedup_median": 4.215674868435056,
     "acceptance_ratio_median": 0.892578125
   }
 }

--- a/benchmark/results/qwen3-5-4b-32768.json
+++ b/benchmark/results/qwen3-5-4b-32768.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "Qwen/Qwen3.5-4B",
+    "draft_model": "z-lab/Qwen3.5-4B-DFlash",
+    "max_new_tokens": 32768,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 272.82562499749474,
+        "generation_tps": 54.20324033885197,
+        "peak_memory_gb": 8.518432016
+      },
+      "dflash": {
+        "ttft_ms": 253.92791699999998,
+        "generation_tps": 139.55125540914963,
+        "tokens_per_cycle": 8.285208596713021,
+        "cycles": 3955,
+        "acceptance_ratio": 0.879302978515625,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 14.15,
+        "peak_memory_gb": 11.033306064
+      },
+      "speedup": 2.5745924881380504
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 259.10687498981133,
+        "generation_tps": 54.32532721374335,
+        "peak_memory_gb": 8.51843413
+      },
+      "dflash": {
+        "ttft_ms": 245.537625,
+        "generation_tps": 138.71460234544617,
+        "tokens_per_cycle": 8.285208596713021,
+        "cycles": 3955,
+        "acceptance_ratio": 0.879302978515625,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 14.15,
+        "peak_memory_gb": 11.033286864
+      },
+      "speedup": 2.5534057401932007
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 258.31566599663347,
+        "generation_tps": 54.297639512907516,
+        "peak_memory_gb": 8.518432018
+      },
+      "dflash": {
+        "ttft_ms": 248.300375,
+        "generation_tps": 137.92697863082637,
+        "tokens_per_cycle": 8.285208596713021,
+        "cycles": 3955,
+        "acceptance_ratio": 0.879302978515625,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 14.15,
+        "peak_memory_gb": 11.03328968
+      },
+      "speedup": 2.5402021131699226
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 54.297639512907516,
+    "dflash_tps_median": 138.71460234544617,
+    "dflash_tps_min": 137.92697863082637,
+    "dflash_tps_max": 139.55125540914963,
+    "speedup_median": 2.5534057401932007,
+    "acceptance_ratio_median": 0.879302978515625
+  }
+}

--- a/benchmark/results/qwen3-5-4b-4096.json
+++ b/benchmark/results/qwen3-5-4b-4096.json
@@ -14,77 +14,37 @@
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
-    "repeat": 3,
-    "git_hash": "da458e2"
+    "repeat": 1,
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 253.83675000011863,
-        "generation_tps": 53.57625169724865,
-        "peak_memory_gb": 8.62330568
+        "ttft_ms": 272.985375020653,
+        "generation_tps": 52.30635461187024,
+        "peak_memory_gb": 8.518433065
       },
       "dflash": {
-        "ttft_ms": 199.07916699999998,
-        "generation_tps": 181.7844919503726,
+        "ttft_ms": 241.29920800000002,
+        "generation_tps": 178.9535921374385,
         "tokens_per_cycle": 8.031372549019608,
         "cycles": 510,
         "acceptance_ratio": 0.87548828125,
         "acceptance_first_20_avg": 7.05,
         "acceptance_last_20_avg": 3.95,
-        "peak_memory_gb": 9.915348974
+        "peak_memory_gb": 9.910058796
       },
-      "speedup": 3.393005038456394
-    },
-    {
-      "run": 2,
-      "thermal_pressure": "unknown",
-      "baseline": {
-        "ttft_ms": 242.13537499963422,
-        "generation_tps": 54.7889673124539,
-        "peak_memory_gb": 8.623293394
-      },
-      "dflash": {
-        "ttft_ms": 209.892666,
-        "generation_tps": 155.19128830381044,
-        "tokens_per_cycle": 8.031372549019608,
-        "cycles": 510,
-        "acceptance_ratio": 0.87548828125,
-        "acceptance_first_20_avg": 7.05,
-        "acceptance_last_20_avg": 3.95,
-        "peak_memory_gb": 9.91534475
-      },
-      "speedup": 2.8325280784866047
-    },
-    {
-      "run": 3,
-      "thermal_pressure": "unknown",
-      "baseline": {
-        "ttft_ms": 241.21500000001106,
-        "generation_tps": 52.75827947881781,
-        "peak_memory_gb": 8.622715947
-      },
-      "dflash": {
-        "ttft_ms": 216.439083,
-        "generation_tps": 148.38160668466188,
-        "tokens_per_cycle": 8.031372549019608,
-        "cycles": 510,
-        "acceptance_ratio": 0.87548828125,
-        "acceptance_first_20_avg": 7.05,
-        "acceptance_last_20_avg": 3.95,
-        "peak_memory_gb": 9.915347566
-      },
-      "speedup": 2.812480015468214
+      "speedup": 3.421259108292501
     }
   ],
   "summary": {
-    "baseline_tps_median": 53.57625169724865,
-    "dflash_tps_median": 155.19128830381044,
-    "dflash_tps_min": 148.38160668466188,
-    "dflash_tps_max": 181.7844919503726,
-    "speedup_median": 2.8325280784866047,
+    "baseline_tps_median": 52.30635461187024,
+    "dflash_tps_median": 178.9535921374385,
+    "dflash_tps_min": 178.9535921374385,
+    "dflash_tps_max": 178.9535921374385,
+    "speedup_median": 3.421259108292501,
     "acceptance_ratio_median": 0.87548828125
   }
 }

--- a/benchmark/results/qwen3-5-4b-8192.json
+++ b/benchmark/results/qwen3-5-4b-8192.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "Qwen/Qwen3.5-4B",
+    "draft_model": "z-lab/Qwen3.5-4B-DFlash",
+    "max_new_tokens": 8192,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 262.0538750052219,
+        "generation_tps": 54.30400162249478,
+        "peak_memory_gb": 8.518435536
+      },
+      "dflash": {
+        "ttft_ms": 214.921375,
+        "generation_tps": 155.45607681547116,
+        "tokens_per_cycle": 7.198594024604569,
+        "cycles": 1138,
+        "acceptance_ratio": 0.861083984375,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 7.1,
+        "peak_memory_gb": 10.094820568
+      },
+      "speedup": 2.862700209390745
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 258.3180419896962,
+        "generation_tps": 53.95974204331971,
+        "peak_memory_gb": 8.518432018
+      },
+      "dflash": {
+        "ttft_ms": 259.64491699999996,
+        "generation_tps": 154.37060673221578,
+        "tokens_per_cycle": 7.198594024604569,
+        "cycles": 1138,
+        "acceptance_ratio": 0.861083984375,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 7.1,
+        "peak_memory_gb": 10.094807
+      },
+      "speedup": 2.8608477521683606
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 254.74995900003705,
+        "generation_tps": 54.30143265719952,
+        "peak_memory_gb": 8.518432722
+      },
+      "dflash": {
+        "ttft_ms": 221.28366699999998,
+        "generation_tps": 154.18105974886922,
+        "tokens_per_cycle": 7.198594024604569,
+        "cycles": 1138,
+        "acceptance_ratio": 0.861083984375,
+        "acceptance_first_20_avg": 7.05,
+        "acceptance_last_20_avg": 7.1,
+        "peak_memory_gb": 10.094770008
+      },
+      "speedup": 2.8393552840898613
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 54.30143265719952,
+    "dflash_tps_median": 154.37060673221578,
+    "dflash_tps_min": 154.18105974886922,
+    "dflash_tps_max": 155.45607681547116,
+    "speedup_median": 2.8608477521683606,
+    "acceptance_ratio_median": 0.861083984375
+  }
+}

--- a/benchmark/results/qwen3-5-9b-1024.json
+++ b/benchmark/results/qwen3-5-9b-1024.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-9B-DFlash",
     "max_new_tokens": 1024,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 1414.6240000000034,
-        "generation_tps": 31.0750886288349,
-        "peak_memory_gb": 17.993025449
+        "ttft_ms": 1367.000290993019,
+        "generation_tps": 31.036930590616002,
+        "peak_memory_gb": 17.993041833
       },
       "dflash": {
-        "ttft_ms": 469.79695899999996,
-        "generation_tps": 127.2038575774272,
+        "ttft_ms": 529.254458,
+        "generation_tps": 125.88913492095352,
         "tokens_per_cycle": 9.061946902654867,
         "cycles": 113,
         "acceptance_ratio": 0.8896484375,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 11.5,
-        "peak_memory_gb": 20.275736752
+        "peak_memory_gb": 20.279645616
       },
-      "speedup": 4.09343506938202
+      "speedup": 4.056107756964087
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 543.5094160002336,
-        "generation_tps": 31.0935277540944,
+        "ttft_ms": 736.7710420076037,
+        "generation_tps": 31.120731348528047,
         "peak_memory_gb": 17.993041835
       },
       "dflash": {
-        "ttft_ms": 482.677375,
-        "generation_tps": 128.99369486629658,
+        "ttft_ms": 518.621458,
+        "generation_tps": 126.1790393080361,
         "tokens_per_cycle": 9.061946902654867,
         "cycles": 113,
         "acceptance_ratio": 0.8896484375,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 11.5,
-        "peak_memory_gb": 20.275736752
+        "peak_memory_gb": 20.279645616
       },
-      "speedup": 4.148570592775877
+      "speedup": 4.054501094300412
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 543.9005409998573,
-        "generation_tps": 31.08715759427153,
+        "ttft_ms": 762.4646250042133,
+        "generation_tps": 31.054887051003323,
         "peak_memory_gb": 17.993058219
       },
       "dflash": {
-        "ttft_ms": 507.604,
-        "generation_tps": 127.4742523639767,
+        "ttft_ms": 516.317625,
+        "generation_tps": 126.16847985161253,
         "tokens_per_cycle": 9.061946902654867,
         "cycles": 113,
         "acceptance_ratio": 0.8896484375,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 11.5,
-        "peak_memory_gb": 20.275736752
+        "peak_memory_gb": 20.279645616
       },
-      "speedup": 4.100543833170085
+      "speedup": 4.062757647271375
     }
   ],
   "summary": {
-    "baseline_tps_median": 31.08715759427153,
-    "dflash_tps_median": 127.4742523639767,
-    "dflash_tps_min": 127.2038575774272,
-    "dflash_tps_max": 128.99369486629658,
-    "speedup_median": 4.100543833170085,
+    "baseline_tps_median": 31.054887051003323,
+    "dflash_tps_median": 126.16847985161253,
+    "dflash_tps_min": 125.88913492095352,
+    "dflash_tps_max": 126.1790393080361,
+    "speedup_median": 4.056107756964087,
     "acceptance_ratio_median": 0.8896484375
   }
 }

--- a/benchmark/results/qwen3-5-9b-16384.json
+++ b/benchmark/results/qwen3-5-9b-16384.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "Qwen/Qwen3.5-9B",
+    "draft_model": "z-lab/Qwen3.5-9B-DFlash",
+    "max_new_tokens": 16384,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1171.1898329958785,
+        "generation_tps": 31.018138565802175,
+        "peak_memory_gb": 18.045503401
+      },
+      "dflash": {
+        "ttft_ms": 509.875875,
+        "generation_tps": 82.76342388870285,
+        "tokens_per_cycle": 7.383046237533998,
+        "cycles": 2206,
+        "acceptance_ratio": 0.8645545527107509,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 6.05,
+        "peak_memory_gb": 20.877246019
+      },
+      "speedup": 2.668226647873396
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1160.1649160002125,
+        "generation_tps": 30.969238829390076,
+        "peak_memory_gb": 18.045487019
+      },
+      "dflash": {
+        "ttft_ms": 503.832625,
+        "generation_tps": 82.20196773515356,
+        "tokens_per_cycle": 7.383046237533998,
+        "cycles": 2206,
+        "acceptance_ratio": 0.8645545527107509,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 6.05,
+        "peak_memory_gb": 20.877246019
+      },
+      "speedup": 2.6543102395252665
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1182.953916999395,
+        "generation_tps": 30.847015908004888,
+        "peak_memory_gb": 18.045487019
+      },
+      "dflash": {
+        "ttft_ms": 500.21745899999996,
+        "generation_tps": 82.26128385112976,
+        "tokens_per_cycle": 7.383046237533998,
+        "cycles": 2206,
+        "acceptance_ratio": 0.8645545527107509,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 6.05,
+        "peak_memory_gb": 20.877246021
+      },
+      "speedup": 2.666750135457437
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 30.969238829390076,
+    "dflash_tps_median": 82.26128385112976,
+    "dflash_tps_min": 82.20196773515356,
+    "dflash_tps_max": 82.76342388870285,
+    "speedup_median": 2.666750135457437,
+    "acceptance_ratio_median": 0.8645545527107509
+  }
+}

--- a/benchmark/results/qwen3-5-9b-2048.json
+++ b/benchmark/results/qwen3-5-9b-2048.json
@@ -10,81 +10,81 @@
     "draft_model": "z-lab/Qwen3.5-9B-DFlash",
     "max_new_tokens": 2048,
     "block_tokens": 16,
-    "cooldown": 10,
+    "cooldown": 330,
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
     "repeat": 3,
-    "git_hash": "da458e2"
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 592.0233340002596,
-        "generation_tps": 30.96259253173809,
-        "peak_memory_gb": 18.035017641
+        "ttft_ms": 738.181667009485,
+        "generation_tps": 31.029801910757705,
+        "peak_memory_gb": 18.035034025
       },
       "dflash": {
-        "ttft_ms": 479.782833,
-        "generation_tps": 128.5223462791554,
+        "ttft_ms": 507.553666,
+        "generation_tps": 127.75878708215997,
         "tokens_per_cycle": 9.394495412844037,
         "cycles": 218,
         "acceptance_ratio": 0.8935546875,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 10.5,
-        "peak_memory_gb": 20.321775024
+        "peak_memory_gb": 20.325677424
       },
-      "speedup": 4.150890987161817
+      "speedup": 4.117293028476194
     },
     {
       "run": 2,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 546.1895419994107,
-        "generation_tps": 30.74705517955003,
-        "peak_memory_gb": 18.035034027
+        "ttft_ms": 728.1950420001522,
+        "generation_tps": 30.987376046429596,
+        "peak_memory_gb": 18.033969115
       },
       "dflash": {
-        "ttft_ms": 482.833792,
-        "generation_tps": 127.07103429811174,
+        "ttft_ms": 501.93395799999996,
+        "generation_tps": 127.4353608051336,
         "tokens_per_cycle": 9.394495412844037,
         "cycles": 218,
         "acceptance_ratio": 0.8935546875,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 10.5,
-        "peak_memory_gb": 20.321775024
+        "peak_memory_gb": 20.325677424
       },
-      "speedup": 4.13278714192529
+      "speedup": 4.11249279752478
     },
     {
       "run": 3,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 545.9269579987449,
-        "generation_tps": 32.025298046424595,
+        "ttft_ms": 744.5105410006363,
+        "generation_tps": 31.012652797810734,
         "peak_memory_gb": 18.035034027
       },
       "dflash": {
-        "ttft_ms": 498.8505,
-        "generation_tps": 111.48038686851403,
+        "ttft_ms": 506.761667,
+        "generation_tps": 127.09321965727537,
         "tokens_per_cycle": 9.394495412844037,
         "cycles": 218,
         "acceptance_ratio": 0.8935546875,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 10.5,
-        "peak_memory_gb": 20.321775024
+        "peak_memory_gb": 20.325677424
       },
-      "speedup": 3.481010128521194
+      "speedup": 4.0981086166949
     }
   ],
   "summary": {
-    "baseline_tps_median": 30.96259253173809,
-    "dflash_tps_median": 127.07103429811174,
-    "dflash_tps_min": 111.48038686851403,
-    "dflash_tps_max": 128.5223462791554,
-    "speedup_median": 4.13278714192529,
+    "baseline_tps_median": 31.012652797810734,
+    "dflash_tps_median": 127.4353608051336,
+    "dflash_tps_min": 127.09321965727537,
+    "dflash_tps_max": 127.75878708215997,
+    "speedup_median": 4.11249279752478,
     "acceptance_ratio_median": 0.8935546875
   }
 }

--- a/benchmark/results/qwen3-5-9b-32768.json
+++ b/benchmark/results/qwen3-5-9b-32768.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "Qwen/Qwen3.5-9B",
+    "draft_model": "z-lab/Qwen3.5-9B-DFlash",
+    "max_new_tokens": 32768,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1191.0484999971231,
+        "generation_tps": 30.939470296195676,
+        "peak_memory_gb": 18.045487017
+      },
+      "dflash": {
+        "ttft_ms": 512.901083,
+        "generation_tps": 82.08490549495204,
+        "tokens_per_cycle": 7.383046237533998,
+        "cycles": 2206,
+        "acceptance_ratio": 0.8645545527107509,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 6.05,
+        "peak_memory_gb": 20.877246019
+      },
+      "speedup": 2.653080505552327
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1159.851250005886,
+        "generation_tps": 30.999025871580052,
+        "peak_memory_gb": 18.045503403
+      },
+      "dflash": {
+        "ttft_ms": 499.77383299999997,
+        "generation_tps": 82.36843361569755,
+        "tokens_per_cycle": 7.383046237533998,
+        "cycles": 2206,
+        "acceptance_ratio": 0.8645545527107509,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 6.05,
+        "peak_memory_gb": 20.87724602
+      },
+      "speedup": 2.6571297419772484
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1170.1518330082763,
+        "generation_tps": 30.941418609046387,
+        "peak_memory_gb": 18.045503403
+      },
+      "dflash": {
+        "ttft_ms": 491.819625,
+        "generation_tps": 81.75518985824412,
+        "tokens_per_cycle": 7.383046237533998,
+        "cycles": 2206,
+        "acceptance_ratio": 0.8645545527107509,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 6.05,
+        "peak_memory_gb": 20.87724602
+      },
+      "speedup": 2.6422573215289242
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 30.941418609046387,
+    "dflash_tps_median": 82.08490549495204,
+    "dflash_tps_min": 81.75518985824412,
+    "dflash_tps_max": 82.36843361569755,
+    "speedup_median": 2.653080505552327,
+    "acceptance_ratio_median": 0.8645545527107509
+  }
+}

--- a/benchmark/results/qwen3-5-9b-4096.json
+++ b/benchmark/results/qwen3-5-9b-4096.json
@@ -14,77 +14,37 @@
     "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
     "prompt_tokens": 92,
     "prompt_id": "the_function_f_satisfies_the_functional_equation",
-    "repeat": 3,
-    "git_hash": "da458e2"
+    "repeat": 1,
+    "git_hash": "a52ed4f"
   },
   "runs": [
     {
       "run": 1,
       "thermal_pressure": "unknown",
       "baseline": {
-        "ttft_ms": 600.3910420004104,
-        "generation_tps": 31.11371735485262,
-        "peak_memory_gb": 18.100893915
+        "ttft_ms": 1496.7336249828804,
+        "generation_tps": 30.160974251043804,
+        "peak_memory_gb": 18.045511593
       },
       "dflash": {
-        "ttft_ms": 467.08304200000003,
-        "generation_tps": 115.95093366799479,
+        "ttft_ms": 851.912,
+        "generation_tps": 98.77121600227751,
         "tokens_per_cycle": 8.752136752136753,
         "cycles": 468,
         "acceptance_ratio": 0.8857421875,
         "acceptance_first_20_avg": 7.4,
         "acceptance_last_20_avg": 4.7,
-        "peak_memory_gb": 20.383171984
+        "peak_memory_gb": 20.387058896
       },
-      "speedup": 3.726682104409829
-    },
-    {
-      "run": 2,
-      "thermal_pressure": "unknown",
-      "baseline": {
-        "ttft_ms": 663.7116660003812,
-        "generation_tps": 31.578323158574467,
-        "peak_memory_gb": 18.100893917
-      },
-      "dflash": {
-        "ttft_ms": 472.373625,
-        "generation_tps": 103.89783952553638,
-        "tokens_per_cycle": 8.752136752136753,
-        "cycles": 468,
-        "acceptance_ratio": 0.8857421875,
-        "acceptance_first_20_avg": 7.4,
-        "acceptance_last_20_avg": 4.7,
-        "peak_memory_gb": 20.383171984
-      },
-      "speedup": 3.290163287132141
-    },
-    {
-      "run": 3,
-      "thermal_pressure": "unknown",
-      "baseline": {
-        "ttft_ms": 641.0905419998016,
-        "generation_tps": 32.67738439329625,
-        "peak_memory_gb": 18.100910301
-      },
-      "dflash": {
-        "ttft_ms": 484.657417,
-        "generation_tps": 102.10301667959163,
-        "tokens_per_cycle": 8.752136752136753,
-        "cycles": 468,
-        "acceptance_ratio": 0.8857421875,
-        "acceptance_first_20_avg": 7.4,
-        "acceptance_last_20_avg": 4.7,
-        "peak_memory_gb": 20.383171984
-      },
-      "speedup": 3.1245773973432835
+      "speedup": 3.2748019072646257
     }
   ],
   "summary": {
-    "baseline_tps_median": 31.578323158574467,
-    "dflash_tps_median": 103.89783952553638,
-    "dflash_tps_min": 102.10301667959163,
-    "dflash_tps_max": 115.95093366799479,
-    "speedup_median": 3.290163287132141,
+    "baseline_tps_median": 30.160974251043804,
+    "dflash_tps_median": 98.77121600227751,
+    "dflash_tps_min": 98.77121600227751,
+    "dflash_tps_max": 98.77121600227751,
+    "speedup_median": 3.2748019072646257,
     "acceptance_ratio_median": 0.8857421875
   }
 }

--- a/benchmark/results/qwen3-5-9b-8192.json
+++ b/benchmark/results/qwen3-5-9b-8192.json
@@ -1,0 +1,90 @@
+{
+  "hardware": {
+    "chip": "Apple M5 Max",
+    "memory_gb": "64",
+    "mlx_version": "0.31.1",
+    "python": "3.14.3"
+  },
+  "config": {
+    "target_model": "Qwen/Qwen3.5-9B",
+    "draft_model": "z-lab/Qwen3.5-9B-DFlash",
+    "max_new_tokens": 8192,
+    "block_tokens": 16,
+    "cooldown": 330,
+    "prompt": "The function $f$ satisfies the functional equation \\[ f(x) + f(y) = f(x + y) - xy - 1 \\] for all real numbers $x$ and $y$. If $f(1) = 1$, then find all integers $n$ such that $f(n) = n$. Enter all such integers, separated by commas. Please reason step by step, and put your final answer within \\boxed{}.",
+    "prompt_tokens": 92,
+    "prompt_id": "the_function_f_satisfies_the_functional_equation",
+    "repeat": 3,
+    "git_hash": "a52ed4f"
+  },
+  "runs": [
+    {
+      "run": 1,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 830.9370420029154,
+        "generation_tps": 30.94680484812413,
+        "peak_memory_gb": 18.045503401
+      },
+      "dflash": {
+        "ttft_ms": 510.911,
+        "generation_tps": 90.82741919049212,
+        "tokens_per_cycle": 7.641791044776119,
+        "cycles": 1072,
+        "acceptance_ratio": 0.869140625,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 10.7,
+        "peak_memory_gb": 20.54906018
+      },
+      "speedup": 2.9349530472124883
+    },
+    {
+      "run": 2,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1237.8123340022285,
+        "generation_tps": 30.97343457583257,
+        "peak_memory_gb": 18.045503403
+      },
+      "dflash": {
+        "ttft_ms": 499.69016700000003,
+        "generation_tps": 91.23743773636785,
+        "tokens_per_cycle": 7.641791044776119,
+        "cycles": 1072,
+        "acceptance_ratio": 0.869140625,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 10.7,
+        "peak_memory_gb": 20.549060179
+      },
+      "speedup": 2.945667440044155
+    },
+    {
+      "run": 3,
+      "thermal_pressure": "unknown",
+      "baseline": {
+        "ttft_ms": 1159.6937920112396,
+        "generation_tps": 30.981266326518288,
+        "peak_memory_gb": 18.045470635
+      },
+      "dflash": {
+        "ttft_ms": 503.818375,
+        "generation_tps": 91.40990593691964,
+        "tokens_per_cycle": 7.641791044776119,
+        "cycles": 1072,
+        "acceptance_ratio": 0.869140625,
+        "acceptance_first_20_avg": 7.4,
+        "acceptance_last_20_avg": 10.7,
+        "peak_memory_gb": 20.54906018
+      },
+      "speedup": 2.950489659574622
+    }
+  ],
+  "summary": {
+    "baseline_tps_median": 30.97343457583257,
+    "dflash_tps_median": 91.23743773636785,
+    "dflash_tps_min": 90.82741919049212,
+    "dflash_tps_max": 91.40990593691964,
+    "speedup_median": 2.945667440044155,
+    "acceptance_ratio_median": 0.869140625
+  }
+}

--- a/dflash_mlx/adapter.py
+++ b/dflash_mlx/adapter.py
@@ -1,0 +1,34 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+from typing import Any
+
+from dflash_mlx.engine import FullAttentionEngine, HybridGDNEngine
+
+
+def _target_text_wrapper(target_model: Any) -> Any:
+    if hasattr(target_model, "model"):
+        return target_model
+    if hasattr(target_model, "language_model"):
+        return target_model.language_model
+    raise AttributeError(f"Unsupported target model wrapper: {type(target_model)!r}")
+
+
+def _target_text_model(target_model: Any) -> Any:
+    wrapper = _target_text_wrapper(target_model)
+    if hasattr(wrapper, "model"):
+        return wrapper.model
+    raise AttributeError(f"Unsupported target text model: {type(wrapper)!r}")
+
+
+def detect_engine(target_model: Any) -> FullAttentionEngine | HybridGDNEngine:
+    inner = _target_text_model(target_model)
+    if hasattr(inner, "fa_idx") and hasattr(inner, "ssm_idx"):
+        return HybridGDNEngine()
+    has_linear = any(
+        hasattr(layer, "linear_attn") or hasattr(layer, "is_linear")
+        for layer in inner.layers
+    )
+    return HybridGDNEngine() if has_linear else FullAttentionEngine()

--- a/dflash_mlx/adapter.py
+++ b/dflash_mlx/adapter.py
@@ -1,5 +1,6 @@
 # Copyright 2026 bstnxbt
 # MIT License — see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
 
 from __future__ import annotations
 

--- a/dflash_mlx/draft_backend.py
+++ b/dflash_mlx/draft_backend.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 import mlx.core as mx
 

--- a/dflash_mlx/draft_backend.py
+++ b/dflash_mlx/draft_backend.py
@@ -1,5 +1,6 @@
 # Copyright 2026 bstnxbt
 # MIT License — see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
 
 from __future__ import annotations
 

--- a/dflash_mlx/draft_backend.py
+++ b/dflash_mlx/draft_backend.py
@@ -1,0 +1,75 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+
+from dflash_mlx.model import (
+    ContextOnlyDraftKVCache,
+    DFlashDraftModel,
+)
+
+
+class EagerDraftBackend:
+    kind = "eager"
+
+    def make_cache(
+        self,
+        *,
+        draft_model: DFlashDraftModel,
+        sink_size: int,
+        window_size: int,
+    ) -> list[Any]:
+        return [
+            ContextOnlyDraftKVCache(
+                sink_size=sink_size,
+                window_size=window_size,
+            )
+            for _ in range(len(draft_model.layers))
+        ]
+
+    def draft_greedy(
+        self,
+        *,
+        target_model: Any,
+        draft_model: DFlashDraftModel,
+        draft_cache: list[Any],
+        staged_first: mx.array,
+        target_hidden: mx.array,
+        block_len: int,
+        mask_token_tail: mx.array,
+        suppress_token_mask: Optional[mx.array],
+        async_launch: bool,
+    ) -> mx.array:
+        if int(block_len) <= 1:
+            raise ValueError("draft_greedy requires block_len > 1")
+
+        from dflash_mlx import runtime as runtime_mod
+
+        block_token_ids = mx.concatenate(
+            [staged_first[:1], mask_token_tail[: int(block_len) - 1]],
+            axis=0,
+        )
+        noise_embedding = runtime_mod._target_embed_tokens(target_model)(block_token_ids[None])
+        draft_hidden = draft_model(
+            noise_embedding=noise_embedding,
+            target_hidden=target_hidden,
+            cache=draft_cache,
+        )
+        draft_logits = runtime_mod._lm_head_logits(target_model, draft_hidden[:, 1:, :])
+        drafted = runtime_mod.greedy_tokens_with_mask(
+            draft_logits,
+            suppress_token_mask,
+        ).squeeze(0)
+        if async_launch:
+            mx.async_eval(drafted)
+        else:
+            mx.eval(draft_logits)
+        return drafted
+
+
+def make_draft_backend() -> EagerDraftBackend:
+    return EagerDraftBackend()

--- a/dflash_mlx/engine.py
+++ b/dflash_mlx/engine.py
@@ -1,5 +1,6 @@
 # Copyright 2026 bstnxbt
 # MIT License — see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
 
 from __future__ import annotations
 

--- a/dflash_mlx/engine.py
+++ b/dflash_mlx/engine.py
@@ -1,0 +1,70 @@
+# Copyright 2026 bstnxbt
+# MIT License — see LICENSE file
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import mlx.core as mx
+
+
+class _BaseEngine:
+    kind: str
+
+    def arm_rollback(
+        self,
+        target_cache: list[Any],
+        *,
+        prefix_len: int,
+    ) -> None:
+        from dflash_mlx import runtime as runtime_mod
+
+        runtime_mod._arm_target_rollback_with_prefix(target_cache, prefix_len=prefix_len)
+
+    def verify(
+        self,
+        *,
+        target_model: Any,
+        verify_ids: mx.array,
+        target_cache: list[Any],
+        verify_chunk_tokens: Optional[int],
+        capture_layer_ids: Optional[set[int]] = None,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        from dflash_mlx import runtime as runtime_mod
+
+        return runtime_mod._verify_target_block(
+            target_model=target_model,
+            verify_ids=verify_ids,
+            target_cache=target_cache,
+            verify_chunk_tokens=verify_chunk_tokens,
+            capture_layer_ids=capture_layer_ids,
+        )
+
+    def rollback(
+        self,
+        target_cache: list[Any],
+        *,
+        target_len: int,
+        acceptance_len: int,
+        drafted_tokens: int,
+    ) -> int:
+        from dflash_mlx import runtime as runtime_mod
+
+        return runtime_mod._restore_target_cache_after_acceptance(
+            target_cache,
+            target_len=target_len,
+            acceptance_length=acceptance_len,
+            drafted_tokens=drafted_tokens,
+        )
+
+
+class FullAttentionEngine(_BaseEngine):
+    """Verify + rollback backend for full-attention target models."""
+
+    kind = "full_attention"
+
+
+class HybridGDNEngine(_BaseEngine):
+    """Verify + rollback backend for hybrid GDN target models."""
+
+    kind = "hybrid_gdn"

--- a/dflash_mlx/kernels.py
+++ b/dflash_mlx/kernels.py
@@ -655,6 +655,279 @@ _batched_sdpa_2pass_reduce_kernel = _make_batched_sdpa_2pass_reduce_kernel()
 
 
 
+def _make_quartet_gqa_kernel(*, has_mask: bool = False):
+    if not mx.metal.is_available():
+        return None
+
+    inputs = [
+        "queries",
+        "keys",
+        "values",
+        "N",
+        "k_head_stride",
+        "k_seq_stride",
+        "v_head_stride",
+        "v_seq_stride",
+        "scale",
+        "blocks",
+    ]
+
+    mask_setup = ""
+    mask_use = ""
+    if has_mask:
+        inputs.append("mask")
+        mask_setup = """
+        auto mask_ = mask + q_offset * N;
+        """
+        mask_use = """
+                float mask_value = static_cast<float>(mask_[n]);
+                use_key = use_key && (mask_value >= Limits<InT>::finite_min);
+                if (use_key) {
+                    score += mask_value;
+                }
+        """
+
+    source = f"""
+        constexpr int BM = 4;
+        constexpr int BN = 32;
+        constexpr int QUARTET = 4;
+        constexpr int SIMDGROUP = 32;
+        constexpr int QK_PER_THREAD = D / SIMDGROUP;
+        constexpr int V_PER_THREAD = V / SIMDGROUP;
+        constexpr int THREADS_PER_TG = BM * QUARTET * SIMDGROUP;
+
+        auto group_idx = threadgroup_position_in_grid.x;
+        auto q_tile_idx = threadgroup_position_in_grid.y;
+        auto block_idx = threadgroup_position_in_grid.z;
+
+        auto lane = thread_index_in_simdgroup;
+        auto simd_gid = simdgroup_index_in_threadgroup;
+        auto head_local = simd_gid % QUARTET;
+        auto q_local = simd_gid / QUARTET;
+        auto flat_tid = simd_gid * SIMDGROUP + lane;
+
+        auto b_idx = group_idx / Hk;
+        auto hk_idx = group_idx % Hk;
+        auto q_head_idx = hk_idx * QUARTET + head_local;
+        auto q_seq_idx = q_tile_idx * BM + q_local;
+        auto q_offset = ((b_idx * Hq + q_head_idx) * M_FIXED + q_seq_idx);
+
+        auto q_ = queries + q_offset * D + lane * QK_PER_THREAD;
+        auto k_base = keys + ((b_idx * Hk + hk_idx) * k_head_stride);
+        auto v_base = values + ((b_idx * Hk + hk_idx) * v_head_stride);
+        partials += (q_offset * blocks + block_idx) * V + lane * V_PER_THREAD;
+        sums += q_offset * blocks + block_idx;
+        maxs += q_offset * blocks + block_idx;
+        {mask_setup}
+
+        thread float q[QK_PER_THREAD];
+        thread float o[V_PER_THREAD];
+        threadgroup InT tg_k[BN * D];
+        threadgroup InT tg_v[BN * V];
+
+        for (int i = 0; i < QK_PER_THREAD; ++i) {{
+            q[i] = static_cast<float>(scale) * static_cast<float>(q_[i]);
+        }}
+        for (int i = 0; i < V_PER_THREAD; ++i) {{
+            o[i] = 0.0f;
+        }}
+
+        float max_score = Limits<float>::finite_min;
+        float sum_exp_score = 0.0f;
+        auto causal_limit = N - M_FIXED + q_seq_idx;
+
+        for (int tile_base = block_idx * BN; tile_base < N; tile_base += blocks * BN) {{
+            for (int idx = flat_tid; idx < BN * D; idx += THREADS_PER_TG) {{
+                auto n_local = idx / D;
+                auto d_idx = idx - n_local * D;
+                auto n = tile_base + n_local;
+                tg_k[idx] = n < N
+                    ? k_base[n * int(k_seq_stride) + d_idx]
+                    : static_cast<InT>(0);
+            }}
+            for (int idx = flat_tid; idx < BN * V; idx += THREADS_PER_TG) {{
+                auto n_local = idx / V;
+                auto v_idx = idx - n_local * V;
+                auto n = tile_base + n_local;
+                tg_v[idx] = n < N
+                    ? v_base[n * int(v_seq_stride) + v_idx]
+                    : static_cast<InT>(0);
+            }}
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (int n_local = 0; n_local < BN; ++n_local) {{
+                auto n = tile_base + n_local;
+                if (n >= N) {{
+                    break;
+                }}
+
+                bool use_key = (n <= causal_limit);
+                float score = 0.0f;
+                if (use_key) {{
+                    for (int i = 0; i < QK_PER_THREAD; ++i) {{
+                        score += q[i] * static_cast<float>(tg_k[n_local * D + lane * QK_PER_THREAD + i]);
+                    }}
+                    score = simd_sum(score);
+        {mask_use}
+                }}
+
+                if (use_key) {{
+                    float new_max = metal::max(max_score, score);
+                    float factor = fast::exp(max_score - new_max);
+                    float exp_score = fast::exp(score - new_max);
+
+                    max_score = new_max;
+                    sum_exp_score = sum_exp_score * factor + exp_score;
+                    for (int i = 0; i < V_PER_THREAD; ++i) {{
+                        o[i] = o[i] * factor
+                             + exp_score * static_cast<float>(tg_v[n_local * V + lane * V_PER_THREAD + i]);
+                    }}
+                }}
+            }}
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }}
+
+        if (lane == 0) {{
+            sums[0] = sum_exp_score;
+            maxs[0] = max_score;
+        }}
+        for (int i = 0; i < V_PER_THREAD; ++i) {{
+            partials[i] = static_cast<InT>(o[i]);
+        }}
+    """
+
+    return mx.fast.metal_kernel(
+        name=f"quartet_gqa_sdpa_partials{'_mask' if has_mask else ''}",
+        input_names=inputs,
+        output_names=["partials", "sums", "maxs"],
+        source=source,
+    )
+
+
+_quartet_gqa_kernel = _make_quartet_gqa_kernel(has_mask=False)
+_quartet_gqa_kernel_masked = _make_quartet_gqa_kernel(has_mask=True)
+
+
+def quartet_gqa_applicable(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    mask: Optional[mx.array] = None,
+) -> bool:
+    if not mx.metal.is_available():
+        return False
+    if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
+        return False
+    bsz, hq, q_len, d = queries.shape
+    _, hk, n_kv, _ = keys.shape
+    if values.shape[:3] != (bsz, hk, n_kv):
+        return False
+    if q_len != 16:
+        return False
+    if queries.dtype != mx.bfloat16 or keys.dtype != mx.bfloat16 or values.dtype != mx.bfloat16:
+        return False
+    if hq != 32 or hk != 8 or d != 128 or int(values.shape[-1]) != 128:
+        return False
+    if hq != 4 * hk:
+        return False
+    if mask is not None and not isinstance(mask, mx.array):
+        return False
+    return True
+
+
+def quartet_gqa_sdpa_exact(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    scale: float,
+    mask: Optional[mx.array] = None,
+) -> Optional[mx.array]:
+    if not quartet_gqa_applicable(queries, keys, values, mask):
+        return None
+
+    bsz, hq, q_len, d = queries.shape
+    _, hk, n_kv, _ = keys.shape
+    vdim = values.shape[-1]
+    input_type = queries.dtype
+
+    queries = mx.contiguous(queries)
+    keys = mx.contiguous(keys)
+    values = mx.contiguous(values)
+
+    blocks = _compute_sdpa_2pass_blocks(4, n_kv)
+    if blocks <= 0 or blocks % 32 != 0:
+        return None
+
+    k_head_stride = keys.shape[2] * keys.shape[3]
+    k_seq_stride = keys.shape[3]
+    v_head_stride = values.shape[2] * values.shape[3]
+    v_seq_stride = values.shape[3]
+
+    kernel = _quartet_gqa_kernel
+    inputs = [
+        queries,
+        keys,
+        values,
+        n_kv,
+        k_head_stride,
+        k_seq_stride,
+        v_head_stride,
+        v_seq_stride,
+        float(scale),
+        blocks,
+    ]
+
+    if mask is not None:
+        if mask.dtype == mx.bool_:
+            mask_tensor = mx.where(
+                mask,
+                mx.zeros(mask.shape, dtype=input_type),
+                mx.full(mask.shape, mx.finfo(input_type).min, dtype=input_type),
+            )
+        else:
+            mask_tensor = mask.astype(input_type) if mask.dtype != input_type else mask
+        mask_tensor = mx.broadcast_to(mask_tensor, (bsz, hq, q_len, n_kv))
+        mask_tensor = mx.contiguous(mask_tensor)
+        kernel = _quartet_gqa_kernel_masked
+        inputs.append(mask_tensor)
+
+    if kernel is None or _batched_sdpa_2pass_reduce_kernel is None:
+        return None
+
+    partial_shape = (bsz * hq, q_len, blocks, vdim)
+    stats_shape = (bsz * hq, q_len, blocks)
+    partials, sums, maxs = kernel(
+        inputs=inputs,
+        template=[
+            ("InT", input_type),
+            ("D", d),
+            ("V", vdim),
+            ("Hq", hq),
+            ("Hk", hk),
+            ("M_FIXED", q_len),
+        ],
+        grid=(bsz * hk * 32, (q_len // 4) * 4, blocks * 4),
+        threadgroup=(32, 4, 4),
+        output_shapes=[partial_shape, stats_shape, stats_shape],
+        output_dtypes=[input_type, mx.float32, mx.float32],
+    )
+
+    (out,) = _batched_sdpa_2pass_reduce_kernel(
+        inputs=[partials, sums, maxs, blocks],
+        template=[
+            ("InT", mx.float32),
+            ("V", vdim),
+            ("M_FIXED", q_len),
+        ],
+        grid=((bsz * hq) * 1024, q_len, 1),
+        threadgroup=(1024, 1, 1),
+        output_shapes=[queries.shape],
+        output_dtypes=[mx.float32],
+    )
+    return out.astype(input_type)
+
+
 def batched_sdpa_2pass_exact(
     queries: mx.array,
     keys: mx.array,

--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -12,7 +12,6 @@ from mlx_lm.models.base import scaled_dot_product_attention
 from mlx_lm.models.qwen3 import MLP
 from mlx_lm.models.rope_utils import initialize_rope
 
-
 def build_target_layer_ids(num_target_layers: int, num_draft_layers: int) -> list[int]:
     if num_draft_layers <= 1:
         return [num_target_layers // 2]

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -20,8 +20,9 @@ from mlx_lm.models.base import (
 )
 from mlx_lm.utils import load, load_model
 
+from dflash_mlx.adapter import detect_engine
+from dflash_mlx.draft_backend import make_draft_backend
 from dflash_mlx.model import (
-    ContextOnlyDraftKVCache,
     DFlashDraftModel,
     DFlashDraftModelArgs,
     extract_context_feature,
@@ -858,35 +859,6 @@ def _cleanup_generation_caches(
     target_cache.clear()
 
 
-def _launch_prefetched_draft(
-    *,
-    target_model: Any,
-    draft_model: DFlashDraftModel,
-    draft_cache: list[Any],
-    staged_first: mx.array,
-    target_hidden: mx.array,
-    block_len: int,
-    mask_token_tail: mx.array,
-    suppress_token_mask: Optional[mx.array],
-) -> mx.array:
-    if int(block_len) <= 1:
-        raise ValueError("prefetched draft requires block_len > 1")
-    block_token_ids = mx.concatenate(
-        [staged_first[:1], mask_token_tail[: int(block_len) - 1]],
-        axis=0,
-    )
-    noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
-    draft_hidden = draft_model(
-        noise_embedding=noise_embedding,
-        target_hidden=target_hidden,
-        cache=draft_cache,
-    )
-    draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
-    drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
-    mx.async_eval(drafted)
-    return drafted
-
-
 def _restore_target_cache_after_acceptance(
     cache_entries: list[Any],
     *,
@@ -1200,19 +1172,19 @@ def generate_dflash_once(
     )
 
     use_speculative_linear_cache = verify_chunk_tokens is None
+    engine = detect_engine(target_model)
+    draft_backend = make_draft_backend()
     target_cache = make_target_cache(
         target_model,
         enable_speculative_linear_cache=use_speculative_linear_cache,
         quantize_kv_cache=quantize_kv_cache,
     )
 
-    draft_cache = [
-        ContextOnlyDraftKVCache(
-            sink_size=draft_sink_size,
-            window_size=draft_window_size,
-        )
-        for _ in range(len(draft_model.layers))
-    ]
+    draft_cache = draft_backend.make_cache(
+        draft_model=draft_model,
+        sink_size=draft_sink_size,
+        window_size=draft_window_size,
+    )
     target_layer_id_list = list(draft_model.target_layer_ids)
     capture_layer_ids = {int(layer_id) + 1 for layer_id in draft_model.target_layer_ids}
     mask_token_id = int(draft_model.mask_token_id)
@@ -1305,15 +1277,17 @@ def generate_dflash_once(
             if block_len > 1:
                 if profile_cycles:
                     draft_start_ns = time.perf_counter_ns()
-                    noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
-                    draft_hidden = draft_model(
-                        noise_embedding=noise_embedding,
+                    drafted = draft_backend.draft_greedy(
+                        target_model=target_model,
+                        draft_model=draft_model,
+                        draft_cache=draft_cache,
+                        staged_first=current_staged_first,
                         target_hidden=target_hidden,
-                        cache=draft_cache,
+                        block_len=block_len,
+                        mask_token_tail=mask_token_tail,
+                        suppress_token_mask=suppress_token_mask,
+                        async_launch=False,
                     )
-                    draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
-                    drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
-                    mx.eval(draft_logits)
                     block_token_ids[1:block_len] = drafted
                     draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
                 else:
@@ -1325,7 +1299,7 @@ def generate_dflash_once(
                         current_staged_first = prefetched_draft["staged_first"]
                     else:
                         draft_start_ns = time.perf_counter_ns()
-                        drafted = _launch_prefetched_draft(
+                        drafted = draft_backend.draft_greedy(
                             target_model=target_model,
                             draft_model=draft_model,
                             draft_cache=draft_cache,
@@ -1334,6 +1308,7 @@ def generate_dflash_once(
                             block_len=block_len,
                             mask_token_tail=mask_token_tail,
                             suppress_token_mask=suppress_token_mask,
+                            async_launch=True,
                         )
                         draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
                     prefetched_draft = None
@@ -1356,9 +1331,9 @@ def generate_dflash_once(
                 )
             verify_ids = verify_token_ids[None]
             if use_speculative_linear_cache:
-                _arm_target_rollback_with_prefix(target_cache, prefix_len=start)
+                engine.arm_rollback(target_cache, prefix_len=start)
             verify_start_ns = time.perf_counter_ns()
-            verify_logits, verify_hidden_states = _verify_target_block(
+            verify_logits, verify_hidden_states = engine.verify(
                 target_model=target_model,
                 verify_ids=verify_ids,
                 target_cache=target_cache,
@@ -1403,7 +1378,7 @@ def generate_dflash_once(
                 next_block_len = max(1, min(effective_block_tokens, next_remaining))
                 if next_remaining > 0 and next_block_len > 1:
                     draft_start_ns = time.perf_counter_ns()
-                    next_drafted = _launch_prefetched_draft(
+                    next_drafted = draft_backend.draft_greedy(
                         target_model=target_model,
                         draft_model=draft_model,
                         draft_cache=draft_cache,
@@ -1412,6 +1387,7 @@ def generate_dflash_once(
                         block_len=next_block_len,
                         mask_token_tail=mask_token_tail,
                         suppress_token_mask=suppress_token_mask,
+                        async_launch=True,
                     )
                     launch_ns = time.perf_counter_ns() - draft_start_ns
                     draft_ns_total += launch_ns
@@ -1427,10 +1403,10 @@ def generate_dflash_once(
             commit_start_ns = time.perf_counter_ns()
             start += commit_count
             target_hidden = committed_hidden
-            replay_cycle_ns = _restore_target_cache_after_acceptance(
+            replay_cycle_ns = engine.rollback(
                 target_cache,
                 target_len=start,
-                acceptance_length=acceptance_len,
+                acceptance_len=acceptance_len,
                 drafted_tokens=block_len - 1,
             )
             replay_ns_total += replay_cycle_ns
@@ -1585,18 +1561,18 @@ def stream_dflash_generate(
     )
 
     use_speculative_linear_cache = verify_chunk_tokens is None
+    engine = detect_engine(target_model)
+    draft_backend = make_draft_backend()
     target_cache = make_target_cache(
         target_model,
         enable_speculative_linear_cache=use_speculative_linear_cache,
         quantize_kv_cache=quantize_kv_cache,
     )
-    draft_cache = [
-        ContextOnlyDraftKVCache(
-            sink_size=draft_sink_size,
-            window_size=draft_window_size,
-        )
-        for _ in range(len(draft_model.layers))
-    ]
+    draft_cache = draft_backend.make_cache(
+        draft_model=draft_model,
+        sink_size=draft_sink_size,
+        window_size=draft_window_size,
+    )
     target_layer_id_list = list(draft_model.target_layer_ids)
     capture_layer_ids = {int(layer_id) + 1 for layer_id in draft_model.target_layer_ids}
     profile_cycles = _profile_dflash_cycles_enabled()
@@ -1712,15 +1688,17 @@ def stream_dflash_generate(
             if block_len > 1:
                 if profile_cycles:
                     draft_start_ns = time.perf_counter_ns()
-                    noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
-                    draft_hidden = draft_model(
-                        noise_embedding=noise_embedding,
+                    drafted = draft_backend.draft_greedy(
+                        target_model=target_model,
+                        draft_model=draft_model,
+                        draft_cache=draft_cache,
+                        staged_first=current_staged_first,
                         target_hidden=target_hidden,
-                        cache=draft_cache,
+                        block_len=block_len,
+                        mask_token_tail=mask_token_tail,
+                        suppress_token_mask=suppress_token_mask,
+                        async_launch=False,
                     )
-                    draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
-                    drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
-                    mx.eval(draft_logits)
                     block_token_ids[1:block_len] = drafted
                 else:
                     if (
@@ -1731,7 +1709,7 @@ def stream_dflash_generate(
                         current_staged_first = prefetched_draft["staged_first"]
                     else:
                         draft_start_ns = time.perf_counter_ns()
-                        drafted = _launch_prefetched_draft(
+                        drafted = draft_backend.draft_greedy(
                             target_model=target_model,
                             draft_model=draft_model,
                             draft_cache=draft_cache,
@@ -1740,6 +1718,7 @@ def stream_dflash_generate(
                             block_len=block_len,
                             mask_token_tail=mask_token_tail,
                             suppress_token_mask=suppress_token_mask,
+                            async_launch=True,
                         )
                         draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
                     prefetched_draft = None
@@ -1761,9 +1740,9 @@ def stream_dflash_generate(
                     axis=0,
                 )
             verify_ids = verify_token_ids[None]
-            _arm_target_rollback_with_prefix(target_cache, prefix_len=start)
+            engine.arm_rollback(target_cache, prefix_len=start)
             verify_start_ns = time.perf_counter_ns()
-            verify_logits, verify_hidden_states = _verify_target_block(
+            verify_logits, verify_hidden_states = engine.verify(
                 target_model=target_model,
                 verify_ids=verify_ids,
                 target_cache=target_cache,
@@ -1799,10 +1778,10 @@ def stream_dflash_generate(
             commit_start_ns = time.perf_counter_ns()
             start += commit_count
             target_hidden = committed_hidden
-            replay_cycle_ns = _restore_target_cache_after_acceptance(
+            replay_cycle_ns = engine.rollback(
                 target_cache,
                 target_len=start,
-                acceptance_length=acceptance_len,
+                acceptance_len=acceptance_len,
                 drafted_tokens=block_len - 1,
             )
             replay_ns_total += replay_cycle_ns
@@ -1818,7 +1797,7 @@ def stream_dflash_generate(
                 next_block_len = max(1, min(effective_block_tokens, next_remaining))
                 if next_remaining > 0 and next_block_len > 1:
                     draft_start_ns = time.perf_counter_ns()
-                    next_drafted = _launch_prefetched_draft(
+                    next_drafted = draft_backend.draft_greedy(
                         target_model=target_model,
                         draft_model=draft_model,
                         draft_cache=draft_cache,
@@ -1827,6 +1806,7 @@ def stream_dflash_generate(
                         block_len=next_block_len,
                         mask_token_tail=mask_token_tail,
                         suppress_token_mask=suppress_token_mask,
+                        async_launch=True,
                     )
                     launch_ns = time.perf_counter_ns() - draft_start_ns
                     draft_ns_total += launch_ns

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -1657,6 +1657,7 @@ def stream_dflash_generate(
         replay_ns_total = 0
         commit_ns_total = 0
         seen_draft_cycle = False
+        acceptance_history: list[int] = []
         cycle_profiles: list[dict[str, Any]] = []
         profile_totals_ns = {
             "draft": 0,
@@ -1761,6 +1762,7 @@ def stream_dflash_generate(
             acceptance_len = int(
                 _match_acceptance_length(verify_token_ids[1:], posterior[:-1]).item()
             )
+            acceptance_history.append(acceptance_len)
             acceptance_cycle_ns = time.perf_counter_ns() - acceptance_start_ns
             hidden_extract_start_ns = time.perf_counter_ns()
             committed_hidden = extract_context_feature_from_dict(
@@ -1885,6 +1887,8 @@ def stream_dflash_generate(
                 profile_totals_ns["cycle_total"] += cycle_total_ns
 
         elapsed_us = (time.perf_counter_ns() - start_ns) / 1_000.0
+        first_20 = acceptance_history[:20]
+        last_20 = acceptance_history[-20:]
         summary = {
             "event": "summary",
             "elapsed_us": elapsed_us,
@@ -1910,6 +1914,10 @@ def stream_dflash_generate(
             "speculative_linear_cache": bool(use_speculative_linear_cache),
             "verify_chunk_tokens": int(verify_chunk_tokens) if verify_chunk_tokens else None,
             "quantize_kv_cache": bool(quantize_kv_cache),
+            "tokens_per_cycle": (len(generated_token_ids) / cycles_completed) if cycles_completed > 0 else 0.0,
+            "acceptance_first_20_avg": (sum(first_20) / len(first_20)) if first_20 else 0.0,
+            "acceptance_last_20_avg": (sum(last_20) / len(last_20)) if last_20 else 0.0,
+            "peak_memory_gb": float(mx.get_peak_memory()) / 1e9 if hasattr(mx, "get_peak_memory") else None,
         }
         if profile_cycles:
             summary["cycle_profile_us"] = cycle_profiles

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -858,6 +858,35 @@ def _cleanup_generation_caches(
     target_cache.clear()
 
 
+def _launch_prefetched_draft(
+    *,
+    target_model: Any,
+    draft_model: DFlashDraftModel,
+    draft_cache: list[Any],
+    staged_first: mx.array,
+    target_hidden: mx.array,
+    block_len: int,
+    mask_token_tail: mx.array,
+    suppress_token_mask: Optional[mx.array],
+) -> mx.array:
+    if int(block_len) <= 1:
+        raise ValueError("prefetched draft requires block_len > 1")
+    block_token_ids = mx.concatenate(
+        [staged_first[:1], mask_token_tail[: int(block_len) - 1]],
+        axis=0,
+    )
+    noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
+    draft_hidden = draft_model(
+        noise_embedding=noise_embedding,
+        target_hidden=target_hidden,
+        cache=draft_cache,
+    )
+    draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
+    drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
+    mx.async_eval(drafted)
+    return drafted
+
+
 def _restore_target_cache_after_acceptance(
     cache_entries: list[Any],
     *,
@@ -1184,7 +1213,9 @@ def generate_dflash_once(
         )
         for _ in range(len(draft_model.layers))
     ]
+    target_layer_id_list = list(draft_model.target_layer_ids)
     capture_layer_ids = {int(layer_id) + 1 for layer_id in draft_model.target_layer_ids}
+    mask_token_id = int(draft_model.mask_token_id)
 
     try:
         start_ns = time.perf_counter_ns()
@@ -1205,7 +1236,7 @@ def generate_dflash_once(
             target_hidden_chunks.append(
                 extract_context_feature_from_dict(
                     prefill_hidden_states,
-                    list(draft_model.target_layer_ids),
+                    target_layer_id_list,
                 )
             )
         prefill_ns = time.perf_counter_ns() - prefill_start_ns
@@ -1221,8 +1252,13 @@ def generate_dflash_once(
         draft_block_size = int(draft_model.block_size)
         requested_block_tokens = draft_block_size if block_tokens is None else int(block_tokens)
         effective_block_tokens = max(1, min(requested_block_tokens, draft_block_size))
-        generated_token_buffer = mx.full((max_new_tokens,), draft_model.mask_token_id, dtype=mx.uint32)
-        block_token_buffer = mx.full((effective_block_tokens,), draft_model.mask_token_id, dtype=mx.uint32)
+        generated_token_buffer = mx.full((max_new_tokens,), mask_token_id, dtype=mx.uint32)
+        block_token_buffer = mx.full((effective_block_tokens,), mask_token_id, dtype=mx.uint32)
+        mask_token_tail = mx.full(
+            (max(0, effective_block_tokens - 1),),
+            mask_token_id,
+            dtype=mx.uint32,
+        )
         generated_token_count = 0
         accepted_from_draft = 0
         cycles_completed = 0
@@ -1248,6 +1284,7 @@ def generate_dflash_once(
             "other": 0,
             "cycle_total": 0,
         }
+        prefetched_draft: Optional[dict[str, Any]] = None
 
         while generated_token_count < max_new_tokens:
             cycle_start_ns = time.perf_counter_ns()
@@ -1259,24 +1296,47 @@ def generate_dflash_once(
             hidden_extract_cycle_ns = 0
             remaining = max_new_tokens - generated_token_count
             block_len = max(1, min(effective_block_tokens, remaining))
-            block_token_buffer[:block_len] = draft_model.mask_token_id
+            block_token_buffer[:block_len] = mask_token_id
             block_token_buffer[:1] = staged_first
             block_token_ids = block_token_buffer[:block_len]
+            current_staged_first = staged_first
+            drafted = None
 
             if block_len > 1:
-                draft_start_ns = time.perf_counter_ns()
-                noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
-                draft_hidden = draft_model(
-                    noise_embedding=noise_embedding,
-                    target_hidden=target_hidden,
-                    cache=draft_cache,
-                )
-                draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
-                mx.async_eval(draft_logits)
-                mx.eval(draft_logits)
-                drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
-                block_token_ids[1:block_len] = drafted
-                draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
+                if profile_cycles:
+                    draft_start_ns = time.perf_counter_ns()
+                    noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
+                    draft_hidden = draft_model(
+                        noise_embedding=noise_embedding,
+                        target_hidden=target_hidden,
+                        cache=draft_cache,
+                    )
+                    draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
+                    drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
+                    mx.eval(draft_logits)
+                    block_token_ids[1:block_len] = drafted
+                    draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
+                else:
+                    if (
+                        prefetched_draft is not None
+                        and int(prefetched_draft["block_len"]) == block_len
+                    ):
+                        drafted = prefetched_draft["drafted"]
+                        current_staged_first = prefetched_draft["staged_first"]
+                    else:
+                        draft_start_ns = time.perf_counter_ns()
+                        drafted = _launch_prefetched_draft(
+                            target_model=target_model,
+                            draft_model=draft_model,
+                            draft_cache=draft_cache,
+                            staged_first=current_staged_first,
+                            target_hidden=target_hidden,
+                            block_len=block_len,
+                            mask_token_tail=mask_token_tail,
+                            suppress_token_mask=suppress_token_mask,
+                        )
+                        draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
+                    prefetched_draft = None
                 draft_ns_total += draft_cycle_ns
                 if not seen_draft_cycle:
                     draft_prefill_ns += draft_cycle_ns
@@ -1284,7 +1344,16 @@ def generate_dflash_once(
                 else:
                     draft_incremental_ns += draft_cycle_ns
 
-            verify_token_ids = block_token_ids[: min(block_len, verify_len_cap)]
+            verify_token_count = min(block_len, verify_len_cap)
+            if profile_cycles or block_len <= 1:
+                verify_token_ids = block_token_ids[:verify_token_count]
+            elif verify_token_count <= 1:
+                verify_token_ids = current_staged_first[:1]
+            else:
+                verify_token_ids = mx.concatenate(
+                    [current_staged_first[:1], drafted[: verify_token_count - 1]],
+                    axis=0,
+                )
             verify_ids = verify_token_ids[None]
             if use_speculative_linear_cache:
                 _arm_target_rollback_with_prefix(target_cache, prefix_len=start)
@@ -1303,6 +1372,8 @@ def generate_dflash_once(
 
             acceptance_start_ns = time.perf_counter_ns()
             posterior = greedy_tokens_with_mask(verify_logits[0], suppress_token_mask)
+            if not profile_cycles:
+                mx.async_eval(posterior, *verify_hidden_states.values())
             acceptance_len = int(
                 _match_acceptance_length(verify_token_ids[1:], posterior[:-1]).item()
             )
@@ -1312,9 +1383,12 @@ def generate_dflash_once(
             hidden_extract_start_ns = time.perf_counter_ns()
             committed_hidden = extract_context_feature_from_dict(
                 verify_hidden_states,
-                list(draft_model.target_layer_ids),
+                target_layer_id_list,
             )[:, : (1 + acceptance_len), :]
-            mx.eval(committed_hidden, posterior)
+            if profile_cycles:
+                mx.eval(committed_hidden, posterior)
+            else:
+                mx.async_eval(committed_hidden)
             hidden_extract_cycle_ns = time.perf_counter_ns() - hidden_extract_start_ns
 
             commit_count = 1 + acceptance_len
@@ -1322,6 +1396,33 @@ def generate_dflash_once(
             generated_token_buffer[generated_token_count : generated_token_count + commit_count] = committed_segment
             generated_token_count += commit_count
             accepted_from_draft += acceptance_len
+            staged_first_next = posterior[acceptance_len : acceptance_len + 1]
+
+            if not profile_cycles:
+                next_remaining = max_new_tokens - generated_token_count
+                next_block_len = max(1, min(effective_block_tokens, next_remaining))
+                if next_remaining > 0 and next_block_len > 1:
+                    draft_start_ns = time.perf_counter_ns()
+                    next_drafted = _launch_prefetched_draft(
+                        target_model=target_model,
+                        draft_model=draft_model,
+                        draft_cache=draft_cache,
+                        staged_first=staged_first_next,
+                        target_hidden=committed_hidden,
+                        block_len=next_block_len,
+                        mask_token_tail=mask_token_tail,
+                        suppress_token_mask=suppress_token_mask,
+                    )
+                    launch_ns = time.perf_counter_ns() - draft_start_ns
+                    draft_ns_total += launch_ns
+                    draft_incremental_ns += launch_ns
+                    prefetched_draft = {
+                        "block_len": next_block_len,
+                        "staged_first": staged_first_next,
+                        "drafted": next_drafted,
+                    }
+                else:
+                    prefetched_draft = None
 
             commit_start_ns = time.perf_counter_ns()
             start += commit_count
@@ -1351,7 +1452,7 @@ def generate_dflash_once(
             if stop_hit:
                 break
 
-            staged_first = posterior[acceptance_len : acceptance_len + 1]
+            staged_first = staged_first_next
 
             if profile_cycles:
                 cycle_total_ns = time.perf_counter_ns() - cycle_start_ns
@@ -1494,7 +1595,9 @@ def stream_dflash_generate(
         )
         for _ in range(len(draft_model.layers))
     ]
+    target_layer_id_list = list(draft_model.target_layer_ids)
     capture_layer_ids = {int(layer_id) + 1 for layer_id in draft_model.target_layer_ids}
+    profile_cycles = _profile_dflash_cycles_enabled()
 
     try:
         start_ns = time.perf_counter_ns()
@@ -1515,7 +1618,7 @@ def stream_dflash_generate(
             target_hidden_chunks.append(
                 extract_context_feature_from_dict(
                     prefill_hidden_states,
-                    list(draft_model.target_layer_ids),
+                    target_layer_id_list,
                 )
             )
             yield {
@@ -1542,7 +1645,16 @@ def stream_dflash_generate(
         draft_block_size = int(draft_model.block_size)
         requested_block_tokens = draft_block_size if block_tokens is None else int(block_tokens)
         effective_block_tokens = max(1, min(requested_block_tokens, draft_block_size))
-        block_token_buffer = mx.full((effective_block_tokens,), draft_model.mask_token_id, dtype=mx.uint32)
+        block_token_buffer = mx.full(
+            (effective_block_tokens,),
+            int(draft_model.mask_token_id),
+            dtype=mx.uint32,
+        )
+        mask_token_tail = mx.full(
+            (max(0, effective_block_tokens - 1),),
+            int(draft_model.mask_token_id),
+            dtype=mx.uint32,
+        )
         generated_token_ids: list[int] = []
         accepted_from_draft = 0
         cycles_completed = 0
@@ -1556,7 +1668,6 @@ def stream_dflash_generate(
         replay_ns_total = 0
         commit_ns_total = 0
         seen_draft_cycle = False
-        profile_cycles = _profile_dflash_cycles_enabled()
         cycle_profiles: list[dict[str, Any]] = []
         profile_totals_ns = {
             "draft": 0,
@@ -1567,6 +1678,7 @@ def stream_dflash_generate(
             "other": 0,
             "cycle_total": 0,
         }
+        prefetched_draft: Optional[dict[str, Any]] = None
 
         while len(generated_token_ids) < max_new_tokens:
             cycle_start_ns = time.perf_counter_ns()
@@ -1578,24 +1690,46 @@ def stream_dflash_generate(
             hidden_extract_cycle_ns = 0
             remaining = max_new_tokens - len(generated_token_ids)
             block_len = max(1, min(effective_block_tokens, remaining))
-            block_token_buffer[:block_len] = draft_model.mask_token_id
+            block_token_buffer[:block_len] = int(draft_model.mask_token_id)
             block_token_buffer[:1] = staged_first
             block_token_ids = block_token_buffer[:block_len]
+            current_staged_first = staged_first
+            drafted = None
 
             if block_len > 1:
-                draft_start_ns = time.perf_counter_ns()
-                noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
-                draft_hidden = draft_model(
-                    noise_embedding=noise_embedding,
-                    target_hidden=target_hidden,
-                    cache=draft_cache,
-                )
-                draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
-                mx.async_eval(draft_logits)
-                mx.eval(draft_logits)
-                drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
-                block_token_ids[1:block_len] = drafted
-                draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
+                if profile_cycles:
+                    draft_start_ns = time.perf_counter_ns()
+                    noise_embedding = _target_embed_tokens(target_model)(block_token_ids[None])
+                    draft_hidden = draft_model(
+                        noise_embedding=noise_embedding,
+                        target_hidden=target_hidden,
+                        cache=draft_cache,
+                    )
+                    draft_logits = _lm_head_logits(target_model, draft_hidden[:, 1:, :])
+                    drafted = greedy_tokens_with_mask(draft_logits, suppress_token_mask).squeeze(0)
+                    mx.eval(draft_logits)
+                    block_token_ids[1:block_len] = drafted
+                else:
+                    if (
+                        prefetched_draft is not None
+                        and int(prefetched_draft["block_len"]) == block_len
+                    ):
+                        drafted = prefetched_draft["drafted"]
+                        current_staged_first = prefetched_draft["staged_first"]
+                    else:
+                        draft_start_ns = time.perf_counter_ns()
+                        drafted = _launch_prefetched_draft(
+                            target_model=target_model,
+                            draft_model=draft_model,
+                            draft_cache=draft_cache,
+                            staged_first=current_staged_first,
+                            target_hidden=target_hidden,
+                            block_len=block_len,
+                            mask_token_tail=mask_token_tail,
+                            suppress_token_mask=suppress_token_mask,
+                        )
+                        draft_cycle_ns = time.perf_counter_ns() - draft_start_ns
+                    prefetched_draft = None
                 draft_ns_total += draft_cycle_ns
                 if not seen_draft_cycle:
                     draft_prefill_ns += draft_cycle_ns
@@ -1603,7 +1737,16 @@ def stream_dflash_generate(
                 else:
                     draft_incremental_ns += draft_cycle_ns
 
-            verify_token_ids = block_token_ids[: min(block_len, verify_len_cap)]
+            verify_token_count = min(block_len, verify_len_cap)
+            if profile_cycles or block_len <= 1:
+                verify_token_ids = block_token_ids[:verify_token_count]
+            elif verify_token_count <= 1:
+                verify_token_ids = current_staged_first[:1]
+            else:
+                verify_token_ids = mx.concatenate(
+                    [current_staged_first[:1], drafted[: verify_token_count - 1]],
+                    axis=0,
+                )
             verify_ids = verify_token_ids[None]
             _arm_target_rollback_with_prefix(target_cache, prefix_len=start)
             verify_start_ns = time.perf_counter_ns()
@@ -1621,6 +1764,8 @@ def stream_dflash_generate(
 
             acceptance_start_ns = time.perf_counter_ns()
             posterior = greedy_tokens_with_mask(verify_logits[0], suppress_token_mask)
+            if not profile_cycles:
+                mx.async_eval(posterior, *verify_hidden_states.values())
             acceptance_len = int(
                 _match_acceptance_length(verify_token_ids[1:], posterior[:-1]).item()
             )
@@ -1628,9 +1773,12 @@ def stream_dflash_generate(
             hidden_extract_start_ns = time.perf_counter_ns()
             committed_hidden = extract_context_feature_from_dict(
                 verify_hidden_states,
-                list(draft_model.target_layer_ids),
+                target_layer_id_list,
             )[:, : (1 + acceptance_len), :]
-            mx.eval(committed_hidden, posterior)
+            if profile_cycles:
+                mx.eval(committed_hidden, posterior)
+            else:
+                mx.async_eval(committed_hidden)
             hidden_extract_cycle_ns = time.perf_counter_ns() - hidden_extract_start_ns
 
             commit_count = 1 + acceptance_len
@@ -1651,6 +1799,32 @@ def stream_dflash_generate(
             commit_cycle_ns = max(0, commit_wall_ns - replay_cycle_ns)
 
             accepted_from_draft += acceptance_len
+            staged_first_next = posterior[acceptance_len : acceptance_len + 1]
+            if not profile_cycles:
+                next_remaining = max_new_tokens - len(generated_token_ids) - commit_count
+                next_block_len = max(1, min(effective_block_tokens, next_remaining))
+                if next_remaining > 0 and next_block_len > 1:
+                    draft_start_ns = time.perf_counter_ns()
+                    next_drafted = _launch_prefetched_draft(
+                        target_model=target_model,
+                        draft_model=draft_model,
+                        draft_cache=draft_cache,
+                        staged_first=staged_first_next,
+                        target_hidden=committed_hidden,
+                        block_len=next_block_len,
+                        mask_token_tail=mask_token_tail,
+                        suppress_token_mask=suppress_token_mask,
+                    )
+                    launch_ns = time.perf_counter_ns() - draft_start_ns
+                    draft_ns_total += launch_ns
+                    draft_incremental_ns += launch_ns
+                    prefetched_draft = {
+                        "block_len": next_block_len,
+                        "staged_first": staged_first_next,
+                        "drafted": next_drafted,
+                    }
+                else:
+                    prefetched_draft = None
             committed_ids = [int(token_id) for token_id in committed_segment.tolist()]
             for token_id in committed_ids:
                 if len(generated_token_ids) >= max_new_tokens:
@@ -1679,7 +1853,7 @@ def stream_dflash_generate(
             if stop_hit:
                 break
 
-            staged_first = posterior[acceptance_len : acceptance_len + 1]
+            staged_first = staged_first_next
 
             if profile_cycles:
                 cycle_total_ns = time.perf_counter_ns() - cycle_start_ns

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -595,7 +595,44 @@ def _install_split_full_attention_hook(attn: Any) -> None:
             and int(queries.shape[-1]) in (128, 256)
             and int(values.shape[-1]) in (128, 256)
         )
-        if should_use_batched_2pass:
+        quartet_mask = mask if isinstance(mask, mx.array) else None
+        should_use_quartet = bool(getattr(self, "_dflash_quartet_enabled", False))
+        if should_use_quartet and should_use_batched_2pass:
+            from dflash_mlx.kernels import (
+                batched_sdpa_2pass_exact,
+                quartet_gqa_applicable,
+                quartet_gqa_sdpa_exact,
+            )
+
+            output = None
+            if quartet_gqa_applicable(queries, keys, values, quartet_mask):
+                output = quartet_gqa_sdpa_exact(
+                    queries=queries,
+                    keys=keys,
+                    values=values,
+                    scale=self.scale,
+                    mask=quartet_mask,
+                )
+            if output is None:
+                output = batched_sdpa_2pass_exact(
+                    queries=queries,
+                    keys=keys,
+                    values=values,
+                    scale=self.scale,
+                    mask=quartet_mask,
+                )
+            if output is None:
+                output = _split_sdpa_output(
+                    queries=queries,
+                    keys=keys,
+                    values=values,
+                    scale=self.scale,
+                    mask=mask,
+                    cache=cache,
+                    chunk_size=1,
+                    cached_prefix_len=cached_prefix_len,
+                )
+        elif should_use_batched_2pass:
             from dflash_mlx.kernels import batched_sdpa_2pass_exact
 
             output = batched_sdpa_2pass_exact(
@@ -603,7 +640,7 @@ def _install_split_full_attention_hook(attn: Any) -> None:
                 keys=keys,
                 values=values,
                 scale=self.scale,
-                mask=mask if isinstance(mask, mx.array) else None,
+                mask=quartet_mask,
             )
             if output is None:
                 output = _split_sdpa_output(
@@ -637,6 +674,8 @@ def _install_split_full_attention_hook(attn: Any) -> None:
 
     cls.__call__ = split_call
     cls._dflash_split_full_attention_installed = True
+    if not hasattr(attn, "_dflash_quartet_enabled"):
+        attn._dflash_quartet_enabled = False
 
 
 def _install_target_speculative_hooks(target_model: Any) -> None:
@@ -672,6 +711,23 @@ def configure_full_attention_split(
             layer.self_attn._dflash_split_sdpa_exact_kv_threshold = (
                 _HYBRID_SDPA_EXACT_KV_THRESHOLD
             )
+
+
+def configure_quartet_gqa(
+    target_model: Any,
+    *,
+    enabled: bool,
+) -> list[int]:
+    text_model = _target_text_model(target_model)
+    if detect_target_family(target_model) == "pure_attention":
+        return []
+    _install_target_speculative_hooks(target_model)
+    fa_layers: list[int] = []
+    for layer_index, layer in enumerate(text_model.layers):
+        if not getattr(layer, "is_linear", False) and hasattr(layer, "self_attn"):
+            layer.self_attn._dflash_quartet_enabled = bool(enabled)
+            fa_layers.append(layer_index)
+    return fa_layers
 
 
 def make_target_cache(

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -1543,6 +1543,7 @@ def stream_dflash_generate(
     max_new_tokens: int,
     use_chat_template: bool = False,
     block_tokens: Optional[int] = None,
+    verify_chunk_tokens: Optional[int] = None,
     stop_token_ids: Optional[list[int]] = None,
     suppress_token_ids: Optional[list[int]] = None,
     prompt_tokens_override: Optional[list[int]] = None,
@@ -1583,9 +1584,10 @@ def stream_dflash_generate(
         mx.array(stop_token_ids, dtype=mx.uint32) if stop_token_ids else None
     )
 
+    use_speculative_linear_cache = verify_chunk_tokens is None
     target_cache = make_target_cache(
         target_model,
-        enable_speculative_linear_cache=True,
+        enable_speculative_linear_cache=use_speculative_linear_cache,
         quantize_kv_cache=quantize_kv_cache,
     )
     draft_cache = [
@@ -1641,6 +1643,17 @@ def stream_dflash_generate(
             "prefill_us": prefill_ns / 1_000.0,
             "prompt_token_count": prompt_len,
         }
+
+        first_token_yielded = False
+        if max_new_tokens > 0:
+            first_token_yielded = True
+            yield {
+                "event": "token",
+                "token_id": int(staged_first.item()),
+                "generated_tokens": 1,
+                "acceptance_ratio": 0.0,
+                "cycles_completed": 0,
+            }
 
         draft_block_size = int(draft_model.block_size)
         requested_block_tokens = draft_block_size if block_tokens is None else int(block_tokens)
@@ -1754,7 +1767,7 @@ def stream_dflash_generate(
                 target_model=target_model,
                 verify_ids=verify_ids,
                 target_cache=target_cache,
-                verify_chunk_tokens=None,
+                verify_chunk_tokens=verify_chunk_tokens,
                 capture_layer_ids=capture_layer_ids,
             )
             if profile_cycles:
@@ -1830,6 +1843,9 @@ def stream_dflash_generate(
                 if len(generated_token_ids) >= max_new_tokens:
                     break
                 generated_token_ids.append(token_id)
+                if first_token_yielded:
+                    first_token_yielded = False
+                    continue
                 yield {
                     "event": "token",
                     "token_id": token_id,
@@ -1911,6 +1927,9 @@ def stream_dflash_generate(
                 "commit": commit_ns_total / 1_000.0,
             },
             "verify_len_cap": int(verify_len_cap),
+            "speculative_linear_cache": bool(use_speculative_linear_cache),
+            "verify_chunk_tokens": int(verify_chunk_tokens) if verify_chunk_tokens else None,
+            "quantize_kv_cache": bool(quantize_kv_cache),
         }
         if profile_cycles:
             summary["cycle_profile_us"] = cycle_profiles

--- a/dflash_mlx/serve.py
+++ b/dflash_mlx/serve.py
@@ -210,6 +210,7 @@ class DFlashResponseGenerator(mlx_server.ResponseGenerator):
             pending_state: Optional[str] = "normal"
             pending_match: Optional[tuple[int, ...]] = None
             pending_finish_reason: Optional[str] = None
+            first_token_flushed = False
             finish_reason: Optional[str] = None
             summary_event: Optional[dict[str, Any]] = None
             request_start_ns = time.perf_counter_ns()
@@ -301,6 +302,27 @@ class DFlashResponseGenerator(mlx_server.ResponseGenerator):
                     if token not in eos_token_ids:
                         detokenizer.add_token(token)
                         text = detokenizer.last_segment
+
+                    if not first_token_flushed:
+                        immediate_finish_reason = token_finish_reason
+                        if immediate_finish_reason is None:
+                            if token in eos_token_ids:
+                                immediate_finish_reason = "stop"
+                            elif live_token_count >= int(args.max_tokens):
+                                immediate_finish_reason = "length"
+                        rqueue.put(
+                            self._make_response(
+                                text=text,
+                                token=token,
+                                state=current_state or "normal",
+                                match=match_sequence,
+                                finish_reason=immediate_finish_reason,
+                            )
+                        )
+                        first_token_flushed = True
+                        if ctx._should_stop:
+                            break
+                        continue
 
                     if pending_token is not None:
                         rqueue.put(


### PR DESCRIPTION
## Summary
- add the quartet-GQA Metal verify kernel for Qwen3.5-9B full-attention layers behind `_dflash_quartet_enabled` / `--quartet-gqa`
- add numeric and perf validation scripts for kernel, hook-level, and e2e checks
- keep the runtime default OFF while wiring benchmark control and logging results in `STATUS.md`

## Validation
- `python3 -m benchmark.quartet_gqa_validate`
- `python3 -m benchmark.quartet_gqa_hook_check`
- `python3 -m benchmark.quartet_gqa_e2e_check`
- `python3 -m benchmark.quartet_gqa_microbench`

## Key results
- microbench stock/quartet ratio: `1.4286x` at `N=4096`
- hook-level check: `allclose=True`, `max_abs_diff=0.0` on all 8 FA layers of Qwen3.5-9B
- e2e token-match: `True` on 3 long prompts with matched acceptance
- benchmark single-run vs current `main` on exact 1024/2048/4096-token prompts, 256 generated tokens, `--no-eos`:
  - `ctx=1024`: main `29.1141 tok/s`, quartet `160.9654 tok/s`
  - `ctx=2048`: main `28.1646 tok/s`, quartet `117.0376 tok/s`
  - `ctx=4096`: main `23.3831 tok/s`, quartet `103.4183 tok/s`
