### PR TITLE
feat: draft model quantization with Metal MMA kernel support

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -96,8 +96,24 @@ def _slugify_model_ref(model_ref: str | None) -> str:
     return label or "model"
 
 
-def _default_results_path(*, target_model_ref: str | None, max_new_tokens: int) -> Path:
-    return Path("benchmark/results") / f"{_slugify_model_ref(target_model_ref)}-{int(max_new_tokens)}.json"
+def _slugify_chip(chip: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", chip.lower()).strip("-")
+    return re.sub(r"-+", "-", slug) or "unknown-chip"
+
+
+def _default_results_path(
+    *,
+    target_model_ref: str | None,
+    max_new_tokens: int,
+    chip: str | None = None,
+    draft_quant: str | None = None,
+) -> Path:
+    name = f"{_slugify_model_ref(target_model_ref)}-{int(max_new_tokens)}"
+    if draft_quant:
+        slug = re.sub(r"[^a-z0-9]+", "-", draft_quant.lower()).strip("-")
+        name = f"{name}-dq-{slug}"
+    folder = _slugify_chip(chip) if chip else "unknown-chip"
+    return Path("benchmark/results") / folder / f"{name}.json"
 
 
 def _strip_generation_payload(result: dict[str, Any], *, drop_phase_timings: bool = False) -> dict[str, Any]:
@@ -145,10 +161,12 @@ def _build_config(
     cooldown: int,
     target_model: str,
     draft_model: str,
+    draft_quant: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "target_model": target_model,
         "draft_model": draft_model,
+        "draft_quant": draft_quant,
         "max_new_tokens": int(max_new_tokens),
         "block_tokens": int(block_tokens),
         "cooldown": int(cooldown),
@@ -169,6 +187,7 @@ def _build_single_case_report(
     runs: list[dict[str, Any]],
     target_model: str,
     draft_model: str,
+    draft_quant: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     run_entries = [_format_run_entry(run) for run in runs]
     baseline_tps_values = [float(run["baseline_generation_tps"]) for run in runs]
@@ -192,6 +211,7 @@ def _build_single_case_report(
             cooldown=cooldown,
             target_model=target_model,
             draft_model=draft_model,
+            draft_quant=draft_quant,
         ),
         "runs": run_entries,
         "summary": {
@@ -426,7 +446,7 @@ def _run_once_sequential(
     use_chat_template: bool,
     target_model_ref: str | None,
     draft_model_ref: str | None,
-    quantize_draft: bool,
+    draft_quant: str | None,
     no_eos: bool,
     split_sdpa: bool,
 ) -> dict[str, Any]:
@@ -468,7 +488,7 @@ def _run_once_sequential(
     draft_model, draft_meta = load_draft_bundle(
         draft_model_ref,
         lazy=True,
-        quantize_draft=quantize_draft,
+        draft_quant=draft_quant,
     )
     # Cross-check: DFlash tokenizer is a different instance; tokens must match.
     if use_chat_template and hasattr(tokenizer, "apply_chat_template"):
@@ -540,7 +560,7 @@ def benchmark_once(
     use_chat_template: bool,
     target_model_ref: str | None,
     draft_model_ref: str | None,
-    quantize_draft: bool = False,
+    draft_quant: str | None = None,
     no_eos: bool = False,
     split_sdpa: bool = True,
     cooldown: int = 10,
@@ -555,7 +575,7 @@ def benchmark_once(
         use_chat_template=use_chat_template,
         target_model_ref=target_model_ref,
         draft_model_ref=draft_model_ref,
-        quantize_draft=quantize_draft,
+        draft_quant=draft_quant,
         no_eos=no_eos,
         split_sdpa=split_sdpa,
     )
@@ -572,6 +592,7 @@ def benchmark_once(
         runs=[result],
         target_model=target_meta["resolved_model_ref"],
         draft_model=draft_meta["resolved_model_ref"],
+        draft_quant=draft_meta.get("draft_quant"),
     )
 
 
@@ -585,7 +606,7 @@ def benchmark_matrix(
     use_chat_template: bool = False,
     target_model_ref: str | None = None,
     draft_model_ref: str | None = None,
-    quantize_draft: bool = False,
+    draft_quant: str | None = None,
     no_eos: bool = False,
     split_sdpa: bool = True,
     cooldown: int = 10,
@@ -609,7 +630,7 @@ def benchmark_matrix(
             use_chat_template=use_chat_template,
             target_model_ref=target_model_ref,
             draft_model_ref=draft_model_ref,
-            quantize_draft=quantize_draft,
+            draft_quant=draft_quant,
             no_eos=no_eos,
             split_sdpa=split_sdpa,
         )
@@ -636,6 +657,7 @@ def benchmark_matrix(
         runs=runs,
         target_model=target_meta["resolved_model_ref"] if target_meta is not None else "",
         draft_model=draft_meta["resolved_model_ref"] if draft_meta is not None else "",
+        draft_quant=draft_meta.get("draft_quant") if draft_meta is not None else None,
     )
 
 
@@ -664,7 +686,21 @@ def main() -> None:
     parser.add_argument("--no-chat-template", action="store_true")
     parser.add_argument("--model", default=None)
     parser.add_argument("--draft", default=None)
-    parser.add_argument("--quantize-draft", action="store_true")
+    parser.add_argument(
+        "--draft-quant",
+        default=None,
+        metavar="SPEC",
+        help=(
+            "Quantize the draft model. Format: w{W}[a{A}][:gs{G}] where "
+            "W=weight bits (2/4/8), A=activation bits (16=bfloat16, 32=float32), "
+            "G=group size (32/64/128). Examples: w4, w8a16, w4a32:gs128."
+        ),
+    )
+    parser.add_argument(
+        "--quantize-draft",
+        action="store_true",
+        help="Deprecated. Use --draft-quant w4a16 instead.",
+    )
     parser.add_argument("--no-eos", action="store_true")
     parser.add_argument(
         "--split-sdpa",
@@ -683,7 +719,7 @@ def main() -> None:
         "use_chat_template": not args.no_chat_template,
         "target_model_ref": args.model,
         "draft_model_ref": args.draft,
-        "quantize_draft": args.quantize_draft,
+        "draft_quant": args.draft_quant or ("w4a16" if args.quantize_draft else None),
         "no_eos": args.no_eos,
         "split_sdpa": args.split_sdpa,
         "cooldown": args.cooldown,
@@ -705,6 +741,8 @@ def main() -> None:
     output_path = _default_results_path(
         target_model_ref=args.model,
         max_new_tokens=args.max_tokens,
+        chip=result.get("hardware", {}).get("chip"),
+        draft_quant=common_kwargs.get("draft_quant"),
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(result, indent=2) + "\n")

--- a/dflash_mlx/generate.py
+++ b/dflash_mlx/generate.py
@@ -92,6 +92,7 @@ def load_runtime_components(
     *,
     model_ref: str,
     draft_ref: Optional[str],
+    draft_quant: Optional[str] = None,
 ):
     resolved_draft_ref = resolve_optional_draft_ref(model_ref, draft_ref)
     if not resolved_draft_ref:
@@ -102,7 +103,7 @@ def load_runtime_components(
         )
     target_model, tokenizer, _ = load_target_bundle(model_ref, lazy=True)
     try:
-        draft_model, _ = load_draft_bundle(resolved_draft_ref, lazy=True)
+        draft_model, _ = load_draft_bundle(resolved_draft_ref, lazy=True, draft_quant=draft_quant)
     except Exception as exc:
         raise ValueError(
             f"Failed to load DFlash draft model '{resolved_draft_ref}' for '{model_ref}'."

--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -3,9 +3,11 @@
 # Based on DFlash (arXiv:2602.06036)
 
 import os
+import re
 import sys
 import time
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -226,11 +228,65 @@ def _ns_to_us(ns: int | float) -> float:
     return float(ns) / 1_000.0
 
 
-def _should_quantize_draft(quantize_draft: bool = False) -> bool:
-    if quantize_draft:
-        return True
-    raw = os.environ.get("DFLASH_QUANTIZE_DRAFT", "").strip().lower()
-    return raw not in {"", "0", "false", "no"}
+@dataclass(frozen=True)
+class DraftQuantSpec:
+    """Parsed weight/activation quantization spec for the draft model.
+
+    Supported format: ``w{W}[a{A}][:gs{G}]``
+    - ``W`` – weight bits: 2, 4, or 8
+    - ``A`` – activation bits: 16 (bfloat16, default) or 32 (float32)
+    - ``G`` – group size: 32, 64 (default), or 128
+
+    Examples: ``w4``, ``w8a16``, ``w4a32:gs128``
+    """
+
+    weight_bits: int
+    group_size: int
+    act_bits: int
+
+
+_DRAFT_QUANT_RE = re.compile(
+    r"^w(?P<wb>2|4|8)"
+    r"(?:a(?P<ab>16|32))?"
+    r"(?::gs(?P<gs>32|64|128))?$",
+    re.IGNORECASE,
+)
+
+
+def parse_draft_quant_spec(spec: str) -> DraftQuantSpec:
+    """Parse a quantization spec string into a :class:`DraftQuantSpec`.
+
+    Raises :exc:`ValueError` for unrecognised formats.
+    """
+    m = _DRAFT_QUANT_RE.match(spec.strip())
+    if not m:
+        raise ValueError(
+            f"Invalid draft quant spec {spec!r}. "
+            "Expected format: w4, w8a16, w4a32:gs128, etc. "
+            "Weight bits: 2, 4, 8. Activation bits: 16 (bfloat16) or 32 (float32). "
+            "Group size: 32, 64, 128."
+        )
+    wb = int(m.group("wb"))
+    ab = int(m.group("ab") or 16)
+    gs = int(m.group("gs") or 64)
+    return DraftQuantSpec(weight_bits=wb, group_size=gs, act_bits=ab)
+
+
+def _resolve_draft_quant(draft_quant: str | None) -> DraftQuantSpec | None:
+    """Resolve the effective :class:`DraftQuantSpec` from arg + env vars.
+
+    Priority: explicit *draft_quant* arg > ``DFLASH_DRAFT_QUANT`` env var >
+    legacy ``DFLASH_QUANTIZE_DRAFT`` env var (maps to ``w4a16``).
+    """
+    spec = draft_quant or os.environ.get("DFLASH_DRAFT_QUANT", "").strip()
+    if not spec:
+        # Backward-compat: old boolean env var → default w4a16
+        raw_legacy = os.environ.get("DFLASH_QUANTIZE_DRAFT", "").strip().lower()
+        if raw_legacy not in {"", "0", "false", "no"}:
+            spec = "w4a16"
+    if not spec:
+        return None
+    return parse_draft_quant_spec(spec)
 
 
 
@@ -757,6 +813,8 @@ def load_draft_bundle(
     model_ref: str | Path | None = None,
     *,
     lazy: bool = True,
+    draft_quant: str | None = None,
+    # Deprecated: use draft_quant="w4a16" instead.
     quantize_draft: bool = False,
 ):
     resolved_ref = resolve_model_ref(model_ref, kind="draft")
@@ -766,13 +824,44 @@ def load_draft_bundle(
         lazy=lazy,
         get_model_classes=_get_dflash_model_classes,
     )
-    quantized = _should_quantize_draft(quantize_draft)
-    if quantized:
-        nn.quantize(model, bits=4, group_size=64)
+    # Backward compat: bool flag maps to w4a16
+    if quantize_draft and not draft_quant:
+        draft_quant = "w4a16"
+    quant_spec = _resolve_draft_quant(draft_quant)
+    if quant_spec is not None:
+        nn.quantize(model, bits=quant_spec.weight_bits, group_size=quant_spec.group_size)
+        if quant_spec.weight_bits in (4, 8):
+            # The draft always runs at M=16 (block_tokens) — the exact shape
+            # the verify MMA kernel is tuned for. Set the env flag before
+            # installing so VerifyQuantizedLinear actually routes to the Metal
+            # kernel and doesn't silently fall back to mx.quantized_matmul.
+            os.environ.setdefault("DFLASH_VERIFY_QMM", "1")
+            from dflash_mlx.verify_linear import install_verify_linears, prewarm_verify_kernels
+            install_verify_linears(model)
+            prewarm_verify_kernels(model)
+        if quant_spec.act_bits == 32:
+            # Cast non-packed parameters (norms, biases, quantization scales)
+            # to float32 AFTER install_verify_linears so the VerifyQuantizedLinear
+            # copies bfloat16 scales (half the memory) before we upcast the rest.
+            def _cast_to_f32(_, x: mx.array) -> mx.array:
+                if x.dtype not in (mx.uint32, mx.int32):
+                    return x.astype(mx.float32)
+                return x
+            model.apply(_cast_to_f32)
     return model, {
         "resolved_model_ref": str(model_ref) if model_ref is not None else str(resolved_ref),
         "config": config,
-        "quantize_draft": bool(quantized),
+        "draft_quant": (
+            {
+                "weight_bits": quant_spec.weight_bits,
+                "group_size": quant_spec.group_size,
+                "act_bits": quant_spec.act_bits,
+            }
+            if quant_spec is not None
+            else None
+        ),
+        # Kept for backward compat
+        "quantize_draft": quant_spec is not None,
     }
 
 

--- a/dflash_mlx/serve.py
+++ b/dflash_mlx/serve.py
@@ -77,9 +77,13 @@ class DFlashModelProvider(mlx_server.ModelProvider):
         self.model_key = None
         self.draft_model = None
 
+        draft_quant = getattr(self.cli_args, "draft_quant", None)
+        if not draft_quant and getattr(self.cli_args, "quantize_draft", False):
+            draft_quant = "w4a16"
         model, tokenizer, draft_model, resolved_draft_ref = load_runtime_components(
             model_ref=model_ref,
             draft_ref=draft_ref,
+            draft_quant=draft_quant or None,
         )
 
         if self.cli_args.chat_template:
@@ -518,6 +522,16 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         help=argparse.SUPPRESS,
         default=3,
+    )
+    parser.add_argument(
+        "--draft-quant",
+        default=None,
+        metavar="SPEC",
+        help=(
+            "Quantize the draft model. Format: w{W}[a{A}][:gs{G}] where "
+            "W=weight bits (2/4/8), A=activation bits (16=bfloat16, 32=float32), "
+            "G=group size (32/64/128). Examples: w4, w8a16, w4a32:gs128."
+        ),
     )
     parser.add_argument(
         "--quantize-draft",

--- a/dflash_mlx/verify_linear.py
+++ b/dflash_mlx/verify_linear.py
@@ -10,7 +10,14 @@ import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_map_with_path
 
-from dflash_mlx.verify_qmm import verify_matmul
+from dflash_mlx.verify_qmm import (
+    verify_matmul,
+    _auto_variant,
+    _build_kernel_mma2big,
+    _build_kernel_mma2big_8bit,
+    _build_kernel_mma2big_pipe,
+    _build_kernel_mma2big_pipe_8bit,
+)
 
 
 _VERIFY_MAX_N_DEFAULT = 100_000
@@ -47,7 +54,7 @@ def _path_tag(path: str) -> str:
 def is_verify_eligible(ql: nn.QuantizedLinear, path: str = "") -> bool:
     if not isinstance(ql, nn.QuantizedLinear):
         return False
-    if getattr(ql, "bits", None) != 4:
+    if getattr(ql, "bits", None) not in (4, 8):
         return False
     if getattr(ql, "group_size", None) not in (32, 64, 128):
         return False
@@ -110,21 +117,112 @@ def _build_dispatch(obj: "VerifyQuantizedLinear"):
     has_bias = "bias" in obj
     bias = obj.bias if has_bias else None
 
+    N = int(w.shape[0])
+    K = int(w.shape[1]) * (32 // bits)
+
+    # Fast path: pre-resolve kernel + pre-contiguous fixed tensors at install
+    # time so each forward call only needs contiguous(x) + one dtype branch.
+    # Eliminates: _should_use_verify, _auto_variant, _variant() env lookup,
+    # mx.contiguous for weights/scales/biases, and shape alignment checks.
+    if (
+        os.environ.get("DFLASH_VERIFY_QMM", "") == "1"
+        and N % 32 == 0
+        and K % 32 == 0
+    ):
+        variant, auto_kp = _auto_variant(K, N)
+        K_PARTS = auto_kp
+        if variant == "mma2big_pipe" and K % (32 * K_PARTS) != 0:
+            variant = "mma2big"
+            K_PARTS = 1
+
+        # Force fixed tensors contiguous once so the closure never has to.
+        w_c = mx.contiguous(w)
+        s_c = mx.contiguous(s)
+        b_c = mx.contiguous(b) if b is not None else b
+        mx.eval(w_c, s_c)
+        if b_c is not None:
+            mx.eval(b_c)
+
+        _kern_fn = (
+            (_build_kernel_mma2big_pipe_8bit if bits == 8 else _build_kernel_mma2big_pipe)
+            if variant == "mma2big_pipe" else
+            (_build_kernel_mma2big_8bit if bits == 8 else _build_kernel_mma2big)
+        )
+        kern_bf16 = _kern_fn(gs, mx.bfloat16)
+        kern_fp16 = _kern_fn(gs, mx.float16)
+
+        if variant == "mma2big_pipe":
+            def _run(x2: mx.array, kern) -> mx.array:
+                (partials,) = kern(
+                    inputs=[x2, w_c, s_c, b_c, 16, K, N, K_PARTS],
+                    template=[("T", x2.dtype)],
+                    grid=(64, N // 32, K_PARTS),
+                    threadgroup=(64, 1, 1),
+                    output_shapes=[(K_PARTS, 16, N)],
+                    output_dtypes=[mx.float32],
+                )
+                return partials.sum(axis=0).astype(x2.dtype)
+        else:
+            def _run(x2: mx.array, kern) -> mx.array:
+                (y,) = kern(
+                    inputs=[x2, w_c, s_c, b_c, 16, K, N],
+                    template=[("T", x2.dtype)],
+                    grid=(64, N // 32, 1),
+                    threadgroup=(64, 1, 1),
+                    output_shapes=[(16, N)],
+                    output_dtypes=[x2.dtype],
+                )
+                return y
+
+        if has_bias:
+            def call(x: mx.array) -> mx.array:
+                orig = x.shape
+                m = 1
+                for d in orig[:-1]:
+                    m *= d
+                if m == 16:
+                    x2 = mx.contiguous(x.reshape(16, orig[-1]))
+                    dtype = x2.dtype
+                    if dtype == mx.bfloat16:
+                        y = _run(x2, kern_bf16)
+                    elif dtype == mx.float16:
+                        y = _run(x2, kern_fp16)
+                    else:
+                        y = mx.quantized_matmul(x, w_c, scales=s_c, biases=b_c,
+                                                transpose=True, group_size=gs, bits=bits, mode=mode)
+                    return y.reshape(*orig[:-1], N) + bias
+                y = mx.quantized_matmul(x, w_c, scales=s_c, biases=b_c,
+                                        transpose=True, group_size=gs, bits=bits, mode=mode)
+                return y + bias
+        else:
+            def call(x: mx.array) -> mx.array:
+                orig = x.shape
+                m = 1
+                for d in orig[:-1]:
+                    m *= d
+                if m == 16:
+                    x2 = mx.contiguous(x.reshape(16, orig[-1]))
+                    dtype = x2.dtype
+                    if dtype == mx.bfloat16:
+                        return _run(x2, kern_bf16).reshape(*orig[:-1], N)
+                    if dtype == mx.float16:
+                        return _run(x2, kern_fp16).reshape(*orig[:-1], N)
+                return mx.quantized_matmul(x, w_c, scales=s_c, biases=b_c,
+                                           transpose=True, group_size=gs, bits=bits, mode=mode)
+        return call
+
+    # Fallback: runtime dispatch through verify_matmul (handles disabled env,
+    # non-aligned shapes, future bits values, etc.)
     if has_bias:
         def call(x):
             m = 1
             for d in x.shape[:-1]:
                 m *= d
             if m == 16:
-                y = verify_matmul(
-                    x, w, s, b,
-                    transpose=True, group_size=gs, bits=bits,
-                )
+                y = verify_matmul(x, w, s, b, transpose=True, group_size=gs, bits=bits)
             else:
-                y = mx.quantized_matmul(
-                    x, w, scales=s, biases=b,
-                    transpose=True, group_size=gs, bits=bits, mode=mode,
-                )
+                y = mx.quantized_matmul(x, w, scales=s, biases=b,
+                                        transpose=True, group_size=gs, bits=bits, mode=mode)
             return y + bias
     else:
         def call(x):
@@ -132,15 +230,36 @@ def _build_dispatch(obj: "VerifyQuantizedLinear"):
             for d in x.shape[:-1]:
                 m *= d
             if m == 16:
-                return verify_matmul(
-                    x, w, s, b,
-                    transpose=True, group_size=gs, bits=bits,
-                )
-            return mx.quantized_matmul(
-                x, w, scales=s, biases=b,
-                transpose=True, group_size=gs, bits=bits, mode=mode,
-            )
+                return verify_matmul(x, w, s, b, transpose=True, group_size=gs, bits=bits)
+            return mx.quantized_matmul(x, w, scales=s, biases=b,
+                                       transpose=True, group_size=gs, bits=bits, mode=mode)
     return call
+
+
+def prewarm_verify_kernels(model: nn.Module) -> int:
+    """Trigger Metal shader compilation for all installed VerifyQuantizedLinear layers.
+
+    Runs a dummy M=16 forward pass through one layer per unique (K, N, bits, gs)
+    shape so Metal compiles the kernel JIT before generation begins, eliminating
+    first-cycle latency.  Returns the number of unique shapes warmed.
+    """
+    from mlx.utils import tree_flatten
+
+    seen: set[tuple] = set()
+    warmed = 0
+    for _, m in tree_flatten(model.leaf_modules()):
+        if not isinstance(m, VerifyQuantizedLinear):
+            continue
+        K = int(m.weight.shape[1]) * (32 // m.bits)
+        N = int(m.weight.shape[0])
+        key = (K, N, m.bits, m.group_size)
+        if key in seen:
+            continue
+        seen.add(key)
+        dummy = mx.zeros((1, 16, K), dtype=mx.bfloat16)
+        mx.eval(m(dummy))
+        warmed += 1
+    return warmed
 
 
 def install_verify_linears(

--- a/dflash_mlx/verify_qmm.py
+++ b/dflash_mlx/verify_qmm.py
@@ -127,6 +127,113 @@ def _build_kernel_mma2big(group_size: int, dtype: mx.Dtype):
     return kernel
 
 
+def _build_kernel_mma2big_8bit(group_size: int, dtype: mx.Dtype):
+    # 8-bit variant: each uint32_t packs 4 bytes → K_by_4 = K/4.
+    # Each thread loads two consecutive uint32_t to cover the same 8 K-positions
+    # as the 4-bit kernel, keeping BK=32 and the simdgroup MMA tile identical.
+    key = ("mma2big_8bit", group_size, dtype)
+    if key in _VERIFY_KERNEL_CACHE:
+        return _VERIFY_KERNEL_CACHE[key]
+
+    source = f"""
+        using namespace metal;
+        constexpr int BM = 16;
+        constexpr int BN = 32;
+        constexpr int BK = 32;
+        constexpr int BK_SUB = 8;
+        constexpr int GS = {group_size};
+
+        uint tid   = thread_position_in_threadgroup.x;
+        uint sg_id = tid / 32;
+        uint tg_n  = threadgroup_position_in_grid.y;
+
+        int K = int(K_size);
+        int N = int(N_size);
+        int K_by_4  = K / 4;
+        int K_by_gs = K / GS;
+        int n0 = int(tg_n) * BN;
+
+        threadgroup T B_tile[BK * BN];
+
+        simdgroup_matrix<T, 8, 8> a_top, a_bot, b_L, b_R;
+        simdgroup_matrix<float, 8, 8> c_tL = simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_matrix<float, 8, 8> c_tR = simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_matrix<float, 8, 8> c_bL = simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_matrix<float, 8, 8> c_bR = simdgroup_matrix<float, 8, 8>(0.0f);
+
+        int t_a = int(tid);
+        int t_b = int(tid) + 64;
+        int dq_k_a = t_a / BN, dq_n_a = t_a % BN;
+        int dq_k_b = t_b / BN, dq_n_b = t_b % BN;
+
+        int sg_n_off = int(sg_id) * 16;
+
+        for (int k0 = 0; k0 < K; k0 += BK) {{
+            {{
+                int n_global = n0 + dq_n_a;
+                int k_base   = k0 + dq_k_a * 8;
+                float s = float(scales[n_global * K_by_gs + (k_base / GS)]);
+                float b = float(biases[n_global * K_by_gs + (k_base / GS)]);
+                uint32_t p0 = w_q[n_global * K_by_4 + (k_base >> 2)];
+                uint32_t p1 = w_q[n_global * K_by_4 + (k_base >> 2) + 1];
+                for (int ki = 0; ki < 4; ++ki)
+                    B_tile[(dq_k_a * 8 + ki)     * BN + dq_n_a] = T(float((p0 >> (ki * 8)) & 0xFFu) * s + b);
+                for (int ki = 0; ki < 4; ++ki)
+                    B_tile[(dq_k_a * 8 + 4 + ki) * BN + dq_n_a] = T(float((p1 >> (ki * 8)) & 0xFFu) * s + b);
+            }}
+            {{
+                int n_global = n0 + dq_n_b;
+                int k_base   = k0 + dq_k_b * 8;
+                float s = float(scales[n_global * K_by_gs + (k_base / GS)]);
+                float b = float(biases[n_global * K_by_gs + (k_base / GS)]);
+                uint32_t p0 = w_q[n_global * K_by_4 + (k_base >> 2)];
+                uint32_t p1 = w_q[n_global * K_by_4 + (k_base >> 2) + 1];
+                for (int ki = 0; ki < 4; ++ki)
+                    B_tile[(dq_k_b * 8 + ki)     * BN + dq_n_b] = T(float((p0 >> (ki * 8)) & 0xFFu) * s + b);
+                for (int ki = 0; ki < 4; ++ki)
+                    B_tile[(dq_k_b * 8 + 4 + ki) * BN + dq_n_b] = T(float((p1 >> (ki * 8)) & 0xFFu) * s + b);
+            }}
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (int ks = 0; ks < BK / BK_SUB; ++ks) {{
+                simdgroup_load(a_top, x + k0 + ks * BK_SUB,                  K);
+                simdgroup_load(a_bot, x + 8 * K + k0 + ks * BK_SUB,          K);
+                simdgroup_load(b_L, B_tile + ks * BK_SUB * BN + sg_n_off,         BN);
+                simdgroup_load(b_R, B_tile + ks * BK_SUB * BN + sg_n_off + 8,     BN);
+                simdgroup_multiply_accumulate(c_tL, a_top, b_L, c_tL);
+                simdgroup_multiply_accumulate(c_tR, a_top, b_R, c_tR);
+                simdgroup_multiply_accumulate(c_bL, a_bot, b_L, c_bL);
+                simdgroup_multiply_accumulate(c_bR, a_bot, b_R, c_bR);
+            }}
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }}
+
+        simdgroup_matrix<T, 8, 8> c_tL_T, c_tR_T, c_bL_T, c_bR_T;
+        c_tL_T.thread_elements()[0] = T(c_tL.thread_elements()[0]);
+        c_tL_T.thread_elements()[1] = T(c_tL.thread_elements()[1]);
+        c_tR_T.thread_elements()[0] = T(c_tR.thread_elements()[0]);
+        c_tR_T.thread_elements()[1] = T(c_tR.thread_elements()[1]);
+        c_bL_T.thread_elements()[0] = T(c_bL.thread_elements()[0]);
+        c_bL_T.thread_elements()[1] = T(c_bL.thread_elements()[1]);
+        c_bR_T.thread_elements()[0] = T(c_bR.thread_elements()[0]);
+        c_bR_T.thread_elements()[1] = T(c_bR.thread_elements()[1]);
+        simdgroup_store(c_tL_T, y + n0 + sg_n_off,             N);
+        simdgroup_store(c_tR_T, y + n0 + sg_n_off + 8,         N);
+        simdgroup_store(c_bL_T, y + 8 * N + n0 + sg_n_off,     N);
+        simdgroup_store(c_bR_T, y + 8 * N + n0 + sg_n_off + 8, N);
+    """
+
+    dtype_tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    kernel = mx.fast.metal_kernel(
+        name=f"verify_mma2big_8bit_gs{group_size}_{dtype_tag}",
+        input_names=["x", "w_q", "scales", "biases", "M_size", "K_size", "N_size"],
+        output_names=["y"],
+        source=source,
+    )
+    _VERIFY_KERNEL_CACHE[key] = kernel
+    return kernel
+
+
 def _build_kernel_mma2big_pipe(group_size: int, dtype: mx.Dtype):
     key = ("mma2big_pipe", group_size, dtype)
     if key in _VERIFY_KERNEL_CACHE:
@@ -243,6 +350,128 @@ def _build_kernel_mma2big_pipe(group_size: int, dtype: mx.Dtype):
     return kernel
 
 
+def _build_kernel_mma2big_pipe_8bit(group_size: int, dtype: mx.Dtype):
+    # 8-bit K-split + double-buffered variant. Same structure as mma2big_pipe
+    # but each thread loads two uint32_t to cover 8 K-positions (4 bytes each).
+    key = ("mma2big_pipe_8bit", group_size, dtype)
+    if key in _VERIFY_KERNEL_CACHE:
+        return _VERIFY_KERNEL_CACHE[key]
+
+    source = f"""
+        using namespace metal;
+        constexpr int BM = 16;
+        constexpr int BN = 32;
+        constexpr int BK = 32;
+        constexpr int BK_SUB = 8;
+        constexpr int GS = {group_size};
+
+        uint tid       = thread_position_in_threadgroup.x;
+        uint sg_id     = tid / 32;
+        uint tg_n      = threadgroup_position_in_grid.y;
+        uint tg_k_part = threadgroup_position_in_grid.z;
+
+        int K = int(K_size);
+        int N = int(N_size);
+        int KP = int(K_parts);
+        int K_by_4  = K / 4;
+        int K_by_gs = K / GS;
+        int n0 = int(tg_n) * BN;
+        int k_slice = K / KP;
+        int k_begin = k_slice * int(tg_k_part);
+        int k_end   = k_begin + k_slice;
+
+        threadgroup T B_tile[2][BK * BN];
+
+        simdgroup_matrix<T, 8, 8> a_top, a_bot, b_L, b_R;
+        simdgroup_matrix<float, 8, 8> c_tL = simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_matrix<float, 8, 8> c_tR = simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_matrix<float, 8, 8> c_bL = simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_matrix<float, 8, 8> c_bR = simdgroup_matrix<float, 8, 8>(0.0f);
+
+        int t_a = int(tid);
+        int t_b = int(tid) + 64;
+        int dq_k_a = t_a / BN, dq_n_a = t_a % BN;
+        int dq_k_b = t_b / BN, dq_n_b = t_b % BN;
+        int sg_n_off = int(sg_id) * 16;
+
+        #define STAGE_B(slot, k0_stage) {{                                                                                  \\
+            {{                                                                                                              \\
+                int n_global = n0 + dq_n_a;                                                                                 \\
+                int k_base   = (k0_stage) + dq_k_a * 8;                                                                     \\
+                float s = float(scales[n_global * K_by_gs + (k_base / GS)]);                                                \\
+                float b = float(biases[n_global * K_by_gs + (k_base / GS)]);                                                \\
+                uint32_t p0 = w_q[n_global * K_by_4 + (k_base >> 2)];                                                       \\
+                uint32_t p1 = w_q[n_global * K_by_4 + (k_base >> 2) + 1];                                                   \\
+                _Pragma("unroll")                                                                                           \\
+                for (int ki = 0; ki < 4; ++ki)                                                                              \\
+                    B_tile[slot][(dq_k_a * 8 + ki)     * BN + dq_n_a] = T(float((p0 >> (ki * 8)) & 0xFFu) * s + b);         \\
+                _Pragma("unroll")                                                                                           \\
+                for (int ki = 0; ki < 4; ++ki)                                                                              \\
+                    B_tile[slot][(dq_k_a * 8 + 4 + ki) * BN + dq_n_a] = T(float((p1 >> (ki * 8)) & 0xFFu) * s + b);         \\
+            }}                                                                                                              \\
+            {{                                                                                                              \\
+                int n_global = n0 + dq_n_b;                                                                                 \\
+                int k_base   = (k0_stage) + dq_k_b * 8;                                                                     \\
+                float s = float(scales[n_global * K_by_gs + (k_base / GS)]);                                                \\
+                float b = float(biases[n_global * K_by_gs + (k_base / GS)]);                                                \\
+                uint32_t p0 = w_q[n_global * K_by_4 + (k_base >> 2)];                                                       \\
+                uint32_t p1 = w_q[n_global * K_by_4 + (k_base >> 2) + 1];                                                   \\
+                _Pragma("unroll")                                                                                           \\
+                for (int ki = 0; ki < 4; ++ki)                                                                              \\
+                    B_tile[slot][(dq_k_b * 8 + ki)     * BN + dq_n_b] = T(float((p0 >> (ki * 8)) & 0xFFu) * s + b);         \\
+                _Pragma("unroll")                                                                                           \\
+                for (int ki = 0; ki < 4; ++ki)                                                                              \\
+                    B_tile[slot][(dq_k_b * 8 + 4 + ki) * BN + dq_n_b] = T(float((p1 >> (ki * 8)) & 0xFFu) * s + b);         \\
+            }}                                                                                                              \\
+        }}
+
+        STAGE_B(0, k_begin);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        int read_slot = 0;
+        for (int k0 = k_begin; k0 < k_end; k0 += BK) {{
+            int write_slot = 1 - read_slot;
+            int k0_next = k0 + BK;
+
+            if (k0_next < k_end) {{
+                STAGE_B(write_slot, k0_next);
+            }}
+
+            for (int ks = 0; ks < BK / BK_SUB; ++ks) {{
+                simdgroup_load(a_top, x + k0 + ks * BK_SUB,                  K);
+                simdgroup_load(a_bot, x + 8 * K + k0 + ks * BK_SUB,          K);
+                simdgroup_load(b_L, B_tile[read_slot] + ks * BK_SUB * BN + sg_n_off,         BN);
+                simdgroup_load(b_R, B_tile[read_slot] + ks * BK_SUB * BN + sg_n_off + 8,     BN);
+                simdgroup_multiply_accumulate(c_tL, a_top, b_L, c_tL);
+                simdgroup_multiply_accumulate(c_tR, a_top, b_R, c_tR);
+                simdgroup_multiply_accumulate(c_bL, a_bot, b_L, c_bL);
+                simdgroup_multiply_accumulate(c_bR, a_bot, b_R, c_bR);
+            }}
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            read_slot = write_slot;
+        }}
+
+        int part_off = int(tg_k_part) * BM * N;
+        simdgroup_store(c_tL, partials + part_off + n0 + sg_n_off,                     N);
+        simdgroup_store(c_tR, partials + part_off + n0 + sg_n_off + 8,                 N);
+        simdgroup_store(c_bL, partials + part_off + 8 * N + n0 + sg_n_off,             N);
+        simdgroup_store(c_bR, partials + part_off + 8 * N + n0 + sg_n_off + 8,         N);
+
+        #undef STAGE_B
+    """
+
+    dtype_tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    kernel = mx.fast.metal_kernel(
+        name=f"verify_mma2big_pipe_8bit_gs{group_size}_{dtype_tag}",
+        input_names=["x", "w_q", "scales", "biases", "M_size", "K_size", "N_size", "K_parts"],
+        output_names=["partials"],
+        source=source,
+    )
+    _VERIFY_KERNEL_CACHE[key] = kernel
+    return kernel
+
+
 def _should_use_verify(
     x: mx.array,
     group_size: int,
@@ -251,7 +480,7 @@ def _should_use_verify(
 ) -> bool:
     if not is_enabled():
         return False
-    if bits != 4 or group_size not in (32, 64, 128):
+    if bits not in (4, 8) or group_size not in (32, 64, 128):
         return False
     if x.dtype not in (mx.bfloat16, mx.float16):
         return False
@@ -302,7 +531,11 @@ def verify_matmul(
                 x, w, scales=scales, biases=biases,
                 transpose=transpose, group_size=group_size, bits=bits,
             )
-        kernel = _build_kernel_mma2big_pipe(group_size, x.dtype)
+        kernel = (
+            _build_kernel_mma2big_pipe_8bit(group_size, x.dtype)
+            if bits == 8 else
+            _build_kernel_mma2big_pipe(group_size, x.dtype)
+        )
         (partials,) = kernel(
             inputs=[x2, w_q, scales, biases, M, K, N, K_PARTS],
             template=[("T", x.dtype)],
@@ -319,7 +552,11 @@ def verify_matmul(
             x, w, scales=scales, biases=biases,
             transpose=transpose, group_size=group_size, bits=bits,
         )
-    kernel = _build_kernel_mma2big(group_size, x.dtype)
+    kernel = (
+        _build_kernel_mma2big_8bit(group_size, x.dtype)
+        if bits == 8 else
+        _build_kernel_mma2big(group_size, x.dtype)
+    )
     (y,) = kernel(
         inputs=[x2, w_q, scales, biases, M, K, N],
         template=[("T", x.dtype)],


### PR DESCRIPTION
## Summary

- Add `w{W}[a{A}][:gs{G}]` quantization spec system for draft models (`DraftQuantSpec`, `parse_draft_quant_spec`) — supports `w4`, `w8a16`, `w4a32:gs128`, etc.
- Write 8-bit Metal MMA kernel variants (`mma2big_8bit`, `mma2big_pipe_8bit`) so 8-bit quantized draft models hit the same fast path as 4-bit
- Pre-resolve dispatch closures and pre-warm Metal kernels at install time, eliminating per-call Python overhead and first-cycle JIT latency
- Automatically install `VerifyQuantizedLinear` on quantized draft models (4-bit and 8-bit) and set `DFLASH_VERIFY_QMM=1`
- Add `--draft-quant SPEC` CLI to both `dflash-serve` and `dflash-benchmark`; keep `--quantize-draft` as a deprecated alias mapping to `w4a16`
- Include `draft_quant` dict in saved benchmark JSON config
- Organize benchmark result files into per-chip subfolders (e.g. `benchmark/results/apple-m5-max/`)
- Append draft quant spec to benchmark output filename when set (e.g. `qwen3-5-27b-4bit-1024-dq-w4a16.json`)

## Test plan

- [ ] `dflash-serve --model mlx-community/Qwen3.5-27B-4bit --draft-quant w4a16` loads and generates correctly
- [ ] `dflash-serve --model mlx-community/Qwen3.5-27B-4bit --draft-quant w8a16` loads and routes to 8-bit Metal kernel
- [ ] `--quantize-draft` still works as a deprecated alias
- [ ] Benchmark output JSON includes `config.draft_quant` dict
- [ ] Benchmark result saved to `benchmark/results/<chip>/<model>-<tokens>-dq-<spec>.json`
- [ ] `uv run pytest tests/` passes