### PR TITLE
perf: add adaptive fallback for low-yield speculation

### DIFF
--- a/dflash_mlx/engine/adaptive_fallback.py
+++ b/dflash_mlx/engine/adaptive_fallback.py
@@ -13,8 +13,7 @@ class AdaptiveFallbackConfig:
     min_tokens_per_cycle: float = 2.0
     probe_cycles: int = 8
     bad_probe_windows: int = 2
-    # Keep fallback in target-AR by default. Automatic reprobe changes verifier
-    # chunk shape, and near-tied greedy logits can drift across block sizes.
+    # Conservative hold after fallback.
     cooldown_tokens: int = 4096
     latency_margin: float = 1.0
     reprobe_block_tokens: Optional[int] = None
@@ -158,8 +157,7 @@ class AdaptiveFallbackState:
             self.bad_probe_windows_seen = 0
             return None
 
-        # Do not change decode policy on a single bad window; transient low
-        # acceptance can recover, and early fallback can drift sensitive output.
+        # Require sustained bad probe windows before changing policy.
         self.bad_probe_windows_seen += 1
         if self.bad_probe_windows_seen < max(1, int(self.config.bad_probe_windows)):
             return None
@@ -368,8 +366,6 @@ def resolve_adaptive_fallback_config(
         cooldown_tokens=_int_env(
             env,
             "DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN",
-            # Long enough to avoid automatic smaller-block reprobe for normal
-            # single-request continuations unless explicitly configured lower.
             4096,
             min_value=1,
         ),

--- a/dflash_mlx/engine/adaptive_fallback.py
+++ b/dflash_mlx/engine/adaptive_fallback.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+
+
+_FALSE_VALUES = {"", "0", "false", "no", "off"}
+
+
+@dataclass(frozen=True)
+class AdaptiveFallbackConfig:
+    enabled: bool = False
+    min_tokens_per_cycle: float = 2.0
+    probe_cycles: int = 8
+    cooldown_tokens: int = 32
+    reprobe_block_tokens: Optional[int] = None
+
+
+@dataclass
+class AdaptiveDecision:
+    action: str
+    reason: str
+    tokens_per_cycle: float
+    probe_cycles: int
+    probe_tokens: int
+    cooldown_tokens: int
+    block_tokens: int
+    next_block_tokens: int
+    fallback_count: int
+    reprobe_count: int
+
+    def as_event(self) -> dict[str, object]:
+        return {
+            "event": "adaptive_fallback",
+            "action": self.action,
+            "reason": self.reason,
+            "tokens_per_cycle": self.tokens_per_cycle,
+            "probe_cycles": self.probe_cycles,
+            "probe_tokens": self.probe_tokens,
+            "cooldown_tokens": self.cooldown_tokens,
+            "block_tokens": self.block_tokens,
+            "next_block_tokens": self.next_block_tokens,
+            "fallback_count": self.fallback_count,
+            "reprobe_count": self.reprobe_count,
+        }
+
+
+@dataclass
+class AdaptiveFallbackState:
+    config: AdaptiveFallbackConfig
+    initial_block_tokens: int
+    active_block_tokens: int = field(init=False)
+    mode: str = field(default="probe", init=False)
+    cooldown_remaining: int = field(default=0, init=False)
+    pending_reprobe_block_tokens: Optional[int] = field(default=None, init=False)
+    probe_cycles_seen: int = field(default=0, init=False)
+    probe_tokens: int = field(default=0, init=False)
+    last_probe_tokens_per_cycle: float = field(default=0.0, init=False)
+    fallback_count: int = field(default=0, init=False)
+    reprobe_count: int = field(default=0, init=False)
+    fallback_tokens: int = field(default=0, init=False)
+    fallback_reason: Optional[str] = field(default=None, init=False)
+    decisions: list[AdaptiveDecision] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        self.initial_block_tokens = max(1, int(self.initial_block_tokens))
+        self.active_block_tokens = self.initial_block_tokens
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.enabled)
+
+    @property
+    def in_cooldown(self) -> bool:
+        return self.enabled and self.mode == "cooldown"
+
+    def block_tokens_for_cycle(self, remaining_tokens: int) -> int:
+        remaining_tokens = max(0, int(remaining_tokens))
+        if remaining_tokens <= 0:
+            return 0
+        if self.in_cooldown:
+            return 1
+        return max(1, min(self.active_block_tokens, remaining_tokens))
+
+    def record_cycle(
+        self,
+        *,
+        block_len: int,
+        commit_count: int,
+        can_continue: bool = True,
+    ) -> Optional[AdaptiveDecision]:
+        if not self.enabled:
+            return None
+
+        block_len = int(block_len)
+        commit_count = max(0, int(commit_count))
+
+        if self.in_cooldown:
+            self.fallback_tokens += commit_count
+            self.cooldown_remaining = max(0, self.cooldown_remaining - commit_count)
+            if self.cooldown_remaining > 0 or not can_continue:
+                return None
+            return self._begin_reprobe()
+
+        if block_len <= 1:
+            return None
+
+        self.probe_cycles_seen += 1
+        self.probe_tokens += commit_count
+        if self.probe_cycles_seen < self.config.probe_cycles:
+            return None
+
+        tokens_per_cycle = self.probe_tokens / max(1, self.probe_cycles_seen)
+        self.last_probe_tokens_per_cycle = tokens_per_cycle
+        probe_cycles = self.probe_cycles_seen
+        probe_tokens = self.probe_tokens
+        self._reset_probe()
+
+        if tokens_per_cycle >= self.config.min_tokens_per_cycle or not can_continue:
+            return None
+
+        next_block_tokens = self._next_reprobe_block_tokens()
+        self.mode = "cooldown"
+        self.cooldown_remaining = max(1, int(self.config.cooldown_tokens))
+        self.pending_reprobe_block_tokens = next_block_tokens
+        self.fallback_count += 1
+        self.fallback_reason = (
+            f"tokens_per_cycle={tokens_per_cycle:.3f} "
+            f"< {self.config.min_tokens_per_cycle:.3f}"
+        )
+        decision = AdaptiveDecision(
+            action="fallback",
+            reason=self.fallback_reason,
+            tokens_per_cycle=tokens_per_cycle,
+            probe_cycles=probe_cycles,
+            probe_tokens=probe_tokens,
+            cooldown_tokens=self.cooldown_remaining,
+            block_tokens=self.active_block_tokens,
+            next_block_tokens=next_block_tokens,
+            fallback_count=self.fallback_count,
+            reprobe_count=self.reprobe_count,
+        )
+        self.decisions.append(decision)
+        return decision
+
+    def summary_fields(self) -> dict[str, object]:
+        return {
+            "adaptive_fallback_enabled": bool(self.config.enabled),
+            "adaptive_fallback_triggered": self.fallback_count > 0,
+            "adaptive_fallback_count": int(self.fallback_count),
+            "adaptive_reprobe_count": int(self.reprobe_count),
+            "adaptive_fallback_tokens": int(self.fallback_tokens),
+            "adaptive_fallback_reason": self.fallback_reason,
+            "adaptive_min_tokens_per_cycle": float(self.config.min_tokens_per_cycle),
+            "adaptive_probe_window": int(self.config.probe_cycles),
+            "adaptive_cooldown_tokens": int(self.config.cooldown_tokens),
+            "adaptive_initial_block_tokens": int(self.initial_block_tokens),
+            "adaptive_final_block_tokens": int(self.active_block_tokens),
+            "adaptive_last_probe_tokens_per_cycle": float(self.last_probe_tokens_per_cycle),
+            "adaptive_pending_probe_cycles": int(self.probe_cycles_seen),
+            "adaptive_pending_probe_tokens": int(self.probe_tokens),
+            "adaptive_events": [
+                {k: v for k, v in decision.as_event().items() if k != "event"}
+                for decision in self.decisions
+            ],
+        }
+
+    def _begin_reprobe(self) -> AdaptiveDecision:
+        next_block_tokens = max(
+            1,
+            min(
+                int(self.pending_reprobe_block_tokens or self.active_block_tokens),
+                self.initial_block_tokens,
+            ),
+        )
+        previous_block_tokens = self.active_block_tokens
+        self.active_block_tokens = next_block_tokens
+        self.pending_reprobe_block_tokens = None
+        self.mode = "probe"
+        self.reprobe_count += 1
+        self._reset_probe()
+        decision = AdaptiveDecision(
+            action="reprobe",
+            reason="target_ar_cooldown_complete",
+            tokens_per_cycle=self.last_probe_tokens_per_cycle,
+            probe_cycles=0,
+            probe_tokens=0,
+            cooldown_tokens=0,
+            block_tokens=previous_block_tokens,
+            next_block_tokens=self.active_block_tokens,
+            fallback_count=self.fallback_count,
+            reprobe_count=self.reprobe_count,
+        )
+        self.decisions.append(decision)
+        return decision
+
+    def _reset_probe(self) -> None:
+        self.probe_cycles_seen = 0
+        self.probe_tokens = 0
+
+    def _next_reprobe_block_tokens(self) -> int:
+        configured = self.config.reprobe_block_tokens
+        if configured is not None:
+            return max(1, min(int(configured), self.initial_block_tokens))
+        if self.active_block_tokens <= 2:
+            return self.active_block_tokens
+        return max(2, self.active_block_tokens // 2)
+
+
+def resolve_adaptive_fallback_config(
+    env: Mapping[str, str],
+) -> AdaptiveFallbackConfig:
+    enabled_raw = str(env.get("DFLASH_ADAPTIVE_FALLBACK", "")).strip().lower()
+    enabled = enabled_raw not in _FALSE_VALUES
+    if not enabled:
+        return AdaptiveFallbackConfig(enabled=False)
+    return AdaptiveFallbackConfig(
+        enabled=True,
+        min_tokens_per_cycle=_float_env(
+            env,
+            "DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE",
+            2.0,
+            min_value=1.0,
+        ),
+        probe_cycles=_int_env(env, "DFLASH_ADAPTIVE_PROBE_CYCLES", 8, min_value=1),
+        cooldown_tokens=_int_env(
+            env,
+            "DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN",
+            32,
+            min_value=1,
+        ),
+        reprobe_block_tokens=_optional_int_env(
+            env,
+            "DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS",
+            min_value=1,
+        ),
+    )
+
+
+def _int_env(
+    env: Mapping[str, str],
+    name: str,
+    default: int,
+    *,
+    min_value: int,
+) -> int:
+    raw = str(env.get(name, "")).strip()
+    if not raw:
+        return int(default)
+    try:
+        value = int(raw)
+    except ValueError:
+        return int(default)
+    return max(int(min_value), value)
+
+
+def _optional_int_env(
+    env: Mapping[str, str],
+    name: str,
+    *,
+    min_value: int,
+) -> Optional[int]:
+    raw = str(env.get(name, "")).strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return max(int(min_value), value)
+
+
+def _float_env(
+    env: Mapping[str, str],
+    name: str,
+    default: float,
+    *,
+    min_value: float,
+) -> float:
+    raw = str(env.get(name, "")).strip()
+    if not raw:
+        return float(default)
+    try:
+        value = float(raw)
+    except ValueError:
+        return float(default)
+    return max(float(min_value), value)

--- a/dflash_mlx/engine/adaptive_fallback.py
+++ b/dflash_mlx/engine/adaptive_fallback.py
@@ -12,7 +12,11 @@ class AdaptiveFallbackConfig:
     enabled: bool = False
     min_tokens_per_cycle: float = 2.0
     probe_cycles: int = 8
-    cooldown_tokens: int = 32
+    bad_probe_windows: int = 2
+    # Keep fallback in target-AR by default. Automatic reprobe changes verifier
+    # chunk shape, and near-tied greedy logits can drift across block sizes.
+    cooldown_tokens: int = 4096
+    latency_margin: float = 1.0
     reprobe_block_tokens: Optional[int] = None
 
 
@@ -52,10 +56,20 @@ class AdaptiveFallbackState:
     active_block_tokens: int = field(init=False)
     mode: str = field(default="probe", init=False)
     cooldown_remaining: int = field(default=0, init=False)
+    cooldown_total_us: float = field(default=0.0, init=False)
+    cooldown_observed_tokens: int = field(default=0, init=False)
     pending_reprobe_block_tokens: Optional[int] = field(default=None, init=False)
     probe_cycles_seen: int = field(default=0, init=False)
     probe_tokens: int = field(default=0, init=False)
+    probe_total_us: float = field(default=0.0, init=False)
+    bad_probe_windows_seen: int = field(default=0, init=False)
     last_probe_tokens_per_cycle: float = field(default=0.0, init=False)
+    last_probe_us_per_token: Optional[float] = field(default=None, init=False)
+    ar_us_per_token: Optional[float] = field(default=None, init=False)
+    reference_block_tokens: Optional[int] = field(default=None, init=False)
+    reference_us_per_token: Optional[float] = field(default=None, init=False)
+    latency_reject_count: int = field(default=0, init=False)
+    latency_locked: bool = field(default=False, init=False)
     fallback_count: int = field(default=0, init=False)
     reprobe_count: int = field(default=0, init=False)
     fallback_tokens: int = field(default=0, init=False)
@@ -87,6 +101,7 @@ class AdaptiveFallbackState:
         *,
         block_len: int,
         commit_count: int,
+        cycle_us: float = 0.0,
         can_continue: bool = True,
     ) -> Optional[AdaptiveDecision]:
         if not self.enabled:
@@ -97,29 +112,65 @@ class AdaptiveFallbackState:
 
         if self.in_cooldown:
             self.fallback_tokens += commit_count
+            if cycle_us > 0.0 and commit_count > 0:
+                self.cooldown_total_us += float(cycle_us)
+                self.cooldown_observed_tokens += commit_count
             self.cooldown_remaining = max(0, self.cooldown_remaining - commit_count)
             if self.cooldown_remaining > 0 or not can_continue:
                 return None
+            if self._cooldown_loses_to_reference():
+                return self._restore_reference_block(
+                    reason="target_ar_not_faster_than_reference"
+                )
             return self._begin_reprobe()
 
-        if block_len <= 1:
+        if block_len <= 1 or self.latency_locked:
             return None
 
         self.probe_cycles_seen += 1
         self.probe_tokens += commit_count
+        if cycle_us > 0.0:
+            self.probe_total_us += float(cycle_us)
         if self.probe_cycles_seen < self.config.probe_cycles:
             return None
 
         tokens_per_cycle = self.probe_tokens / max(1, self.probe_cycles_seen)
+        probe_us_per_token = (
+            self.probe_total_us / self.probe_tokens
+            if self.probe_total_us > 0.0 and self.probe_tokens > 0
+            else None
+        )
         self.last_probe_tokens_per_cycle = tokens_per_cycle
+        self.last_probe_us_per_token = probe_us_per_token
         probe_cycles = self.probe_cycles_seen
         probe_tokens = self.probe_tokens
         self._reset_probe()
 
+        if self._smaller_probe_loses_to_reference(block_len, probe_us_per_token):
+            return self._restore_reference_block(
+                reason="reprobe_not_faster_than_reference"
+            )
+        if block_len < self.initial_block_tokens and probe_us_per_token is not None:
+            self.reference_block_tokens = block_len
+            self.reference_us_per_token = probe_us_per_token
+
         if tokens_per_cycle >= self.config.min_tokens_per_cycle or not can_continue:
+            self.bad_probe_windows_seen = 0
+            return None
+
+        # Do not change decode policy on a single bad window; transient low
+        # acceptance can recover, and early fallback can drift sensitive output.
+        self.bad_probe_windows_seen += 1
+        if self.bad_probe_windows_seen < max(1, int(self.config.bad_probe_windows)):
             return None
 
         next_block_tokens = self._next_reprobe_block_tokens()
+        if next_block_tokens >= self.active_block_tokens:
+            return None
+        self.bad_probe_windows_seen = 0
+        if probe_us_per_token is not None:
+            self.reference_block_tokens = self.active_block_tokens
+            self.reference_us_per_token = probe_us_per_token
         self.mode = "cooldown"
         self.cooldown_remaining = max(1, int(self.config.cooldown_tokens))
         self.pending_reprobe_block_tokens = next_block_tokens
@@ -153,10 +204,31 @@ class AdaptiveFallbackState:
             "adaptive_fallback_reason": self.fallback_reason,
             "adaptive_min_tokens_per_cycle": float(self.config.min_tokens_per_cycle),
             "adaptive_probe_window": int(self.config.probe_cycles),
+            "adaptive_bad_probe_windows": int(self.config.bad_probe_windows),
             "adaptive_cooldown_tokens": int(self.config.cooldown_tokens),
+            "adaptive_latency_margin": float(self.config.latency_margin),
             "adaptive_initial_block_tokens": int(self.initial_block_tokens),
             "adaptive_final_block_tokens": int(self.active_block_tokens),
             "adaptive_last_probe_tokens_per_cycle": float(self.last_probe_tokens_per_cycle),
+            "adaptive_last_probe_ms_per_token": (
+                self.last_probe_us_per_token / 1_000.0
+                if self.last_probe_us_per_token is not None
+                else None
+            ),
+            "adaptive_ar_ms_per_token": (
+                self.ar_us_per_token / 1_000.0
+                if self.ar_us_per_token is not None
+                else None
+            ),
+            "adaptive_reference_block_tokens": self.reference_block_tokens,
+            "adaptive_reference_ms_per_token": (
+                self.reference_us_per_token / 1_000.0
+                if self.reference_us_per_token is not None
+                else None
+            ),
+            "adaptive_latency_reject_count": int(self.latency_reject_count),
+            "adaptive_latency_locked": bool(self.latency_locked),
+            "adaptive_pending_bad_probe_windows": int(self.bad_probe_windows_seen),
             "adaptive_pending_probe_cycles": int(self.probe_cycles_seen),
             "adaptive_pending_probe_tokens": int(self.probe_tokens),
             "adaptive_events": [
@@ -166,6 +238,7 @@ class AdaptiveFallbackState:
         }
 
     def _begin_reprobe(self) -> AdaptiveDecision:
+        self._finish_cooldown_observation()
         next_block_tokens = max(
             1,
             min(
@@ -197,6 +270,69 @@ class AdaptiveFallbackState:
     def _reset_probe(self) -> None:
         self.probe_cycles_seen = 0
         self.probe_tokens = 0
+        self.probe_total_us = 0.0
+
+    def _finish_cooldown_observation(self) -> None:
+        if self.cooldown_total_us > 0.0 and self.cooldown_observed_tokens > 0:
+            self.ar_us_per_token = (
+                self.cooldown_total_us / self.cooldown_observed_tokens
+            )
+        self.cooldown_total_us = 0.0
+        self.cooldown_observed_tokens = 0
+
+    def _cooldown_loses_to_reference(self) -> bool:
+        self._finish_cooldown_observation()
+        if self.ar_us_per_token is None or self.reference_us_per_token is None:
+            return False
+        return not self._latency_beats_reference(self.ar_us_per_token)
+
+    def _smaller_probe_loses_to_reference(
+        self,
+        block_len: int,
+        probe_us_per_token: Optional[float],
+    ) -> bool:
+        if block_len >= self.initial_block_tokens:
+            return False
+        if probe_us_per_token is None or self.reference_us_per_token is None:
+            return False
+        return not self._latency_beats_reference(probe_us_per_token)
+
+    def _latency_beats_reference(self, us_per_token: float) -> bool:
+        assert self.reference_us_per_token is not None
+        return us_per_token <= (
+            self.reference_us_per_token * float(self.config.latency_margin)
+        )
+
+    def _restore_reference_block(self, *, reason: str) -> AdaptiveDecision:
+        previous_block_tokens = self.active_block_tokens
+        restored_block_tokens = max(
+            1,
+            min(
+                int(self.reference_block_tokens or self.initial_block_tokens),
+                self.initial_block_tokens,
+            ),
+        )
+        self.active_block_tokens = restored_block_tokens
+        self.pending_reprobe_block_tokens = None
+        self.cooldown_remaining = 0
+        self.mode = "probe"
+        self.latency_locked = True
+        self.latency_reject_count += 1
+        self._reset_probe()
+        decision = AdaptiveDecision(
+            action="restore",
+            reason=reason,
+            tokens_per_cycle=self.last_probe_tokens_per_cycle,
+            probe_cycles=0,
+            probe_tokens=0,
+            cooldown_tokens=0,
+            block_tokens=previous_block_tokens,
+            next_block_tokens=self.active_block_tokens,
+            fallback_count=self.fallback_count,
+            reprobe_count=self.reprobe_count,
+        )
+        self.decisions.append(decision)
+        return decision
 
     def _next_reprobe_block_tokens(self) -> int:
         configured = self.config.reprobe_block_tokens
@@ -223,11 +359,25 @@ def resolve_adaptive_fallback_config(
             min_value=1.0,
         ),
         probe_cycles=_int_env(env, "DFLASH_ADAPTIVE_PROBE_CYCLES", 8, min_value=1),
+        bad_probe_windows=_int_env(
+            env,
+            "DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS",
+            2,
+            min_value=1,
+        ),
         cooldown_tokens=_int_env(
             env,
             "DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN",
-            32,
+            # Long enough to avoid automatic smaller-block reprobe for normal
+            # single-request continuations unless explicitly configured lower.
+            4096,
             min_value=1,
+        ),
+        latency_margin=_float_env(
+            env,
+            "DFLASH_ADAPTIVE_LATENCY_MARGIN",
+            1.0,
+            min_value=0.0,
         ),
         reprobe_block_tokens=_optional_int_env(
             env,

--- a/dflash_mlx/engine/rollback.py
+++ b/dflash_mlx/engine/rollback.py
@@ -52,9 +52,10 @@ def restore_target_cache_after_acceptance(
     target_len: int,
     acceptance_length: int,
     drafted_tokens: int = 0,
+    force_replay: bool = False,
 ) -> int:
     replay_ns_total = 0
-    fully_accepted = acceptance_length == drafted_tokens
+    fully_accepted = acceptance_length == drafted_tokens and not force_replay
     for cache_entry in cache_entries:
         if hasattr(cache_entry, "rollback"):
             if fully_accepted:

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -483,6 +483,7 @@ def stream_dflash_generate_impl(
                 target_len=start,
                 acceptance_len=acceptance_len,
                 drafted_tokens=max(0, verify_token_count - 1),
+                force_replay=verify_token_count <= 1,
             )
             replay_ns_total += replay_cycle_ns
             cycles_completed += 1
@@ -504,9 +505,11 @@ def stream_dflash_generate_impl(
                     ).item()
                 )
             remaining_after_commit = max_new_tokens - len(generated_token_ids) - commit_count
+            observed_cycle_us = (time.perf_counter_ns() - cycle_start_ns) / 1_000.0
             adaptive_decision = adaptive_fallback.record_cycle(
                 block_len=block_len,
                 commit_count=commit_count,
+                cycle_us=observed_cycle_us,
                 can_continue=not stop_hit and remaining_after_commit > 0,
             )
             if adaptive_decision is not None:

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -17,6 +17,10 @@ from dflash_mlx.cache.snapshot import (
     validate_prefix_snapshot as _validate_prefix_snapshot,
 )
 from dflash_mlx.engine.acceptance import match_acceptance_length as _match_acceptance_length
+from dflash_mlx.engine.adaptive_fallback import (
+    AdaptiveFallbackState,
+    resolve_adaptive_fallback_config,
+)
 from dflash_mlx.engine.fallback import stream_baseline_generate
 from dflash_mlx.engine.prefill import (
     compute_snapshot_boundary,
@@ -313,6 +317,10 @@ def stream_dflash_generate_impl(
         draft_block_size = int(draft_model.block_size)
         requested_block_tokens = draft_block_size if block_tokens is None else int(block_tokens)
         effective_block_tokens = max(1, min(requested_block_tokens, draft_block_size))
+        adaptive_fallback = AdaptiveFallbackState(
+            config=resolve_adaptive_fallback_config(os.environ),
+            initial_block_tokens=effective_block_tokens,
+        )
         block_token_buffer = mx.full(
             (effective_block_tokens,),
             int(draft_model.mask_token_id),
@@ -358,7 +366,8 @@ def stream_dflash_generate_impl(
             acceptance_cycle_ns = 0
             hidden_extract_cycle_ns = 0
             remaining = max_new_tokens - len(generated_token_ids)
-            block_len = max(1, min(effective_block_tokens, remaining))
+            block_len = adaptive_fallback.block_tokens_for_cycle(remaining)
+            adaptive_ar_cycle = adaptive_fallback.in_cooldown
             block_token_buffer[:block_len] = int(draft_model.mask_token_id)
             block_token_buffer[:1] = staged_first
             block_token_ids = block_token_buffer[:block_len]
@@ -459,7 +468,14 @@ def stream_dflash_generate_impl(
             committed_segment = verify_token_ids[:commit_count]
             commit_start_ns = time.perf_counter_ns()
             start += commit_count
-            target_hidden = committed_hidden
+            if adaptive_ar_cycle and target_hidden is not None:
+                target_hidden = mx.concatenate([target_hidden, committed_hidden], axis=1)
+                if profile_cycles:
+                    mx.eval(target_hidden)
+                else:
+                    mx.async_eval(target_hidden)
+            else:
+                target_hidden = committed_hidden
             gen_hidden_chunks.append(committed_hidden)
             last_cycle_logits = verify_logits[:, acceptance_len, :]
             replay_cycle_ns = engine.rollback(
@@ -476,17 +492,38 @@ def stream_dflash_generate_impl(
 
             accepted_from_draft += acceptance_len
             staged_first_next = posterior[acceptance_len : acceptance_len + 1]
+
+            stop_hit = False
+            if stop_token_array is not None:
+                stop_hit = bool(
+                    mx.any(
+                        mx.equal(
+                            committed_segment[:, None],
+                            stop_token_array[None, :],
+                        )
+                    ).item()
+                )
+            remaining_after_commit = max_new_tokens - len(generated_token_ids) - commit_count
+            adaptive_decision = adaptive_fallback.record_cycle(
+                block_len=block_len,
+                commit_count=commit_count,
+                can_continue=not stop_hit and remaining_after_commit > 0,
+            )
+            if adaptive_decision is not None:
+                prefetched_draft = None
+                _pre_yield = time.perf_counter_ns()
+                yield adaptive_decision.as_event()
+                _yield_pause_ns += time.perf_counter_ns() - _pre_yield
             if not profile_cycles:
-                next_remaining = max_new_tokens - len(generated_token_ids) - commit_count
-                next_block_len = max(1, min(effective_block_tokens, next_remaining))
-                if next_remaining > 0 and next_block_len > 1:
+                next_block_len = adaptive_fallback.block_tokens_for_cycle(remaining_after_commit)
+                if not stop_hit and remaining_after_commit > 0 and next_block_len > 1:
                     draft_start_ns = time.perf_counter_ns()
                     next_drafted = draft_backend.draft_greedy(
                         target_model=target_model,
                         draft_model=draft_model,
                         draft_cache=draft_cache,
                         staged_first=staged_first_next,
-                        target_hidden=committed_hidden,
+                        target_hidden=target_hidden,
                         block_len=next_block_len,
                         mask_token_tail=mask_token_tail,
                         suppress_token_mask=suppress_token_mask,
@@ -522,16 +559,6 @@ def stream_dflash_generate_impl(
                 }
                 _yield_pause_ns += time.perf_counter_ns() - _pre_yield
 
-            stop_hit = False
-            if stop_token_array is not None:
-                stop_hit = bool(
-                    mx.any(
-                        mx.equal(
-                            committed_segment[:, None],
-                            stop_token_array[None, :],
-                        )
-                    ).item()
-                )
             if stop_hit:
                 break
 
@@ -642,6 +669,7 @@ def stream_dflash_generate_impl(
             "acceptance_last_20_avg": (sum(last_20) / len(last_20)) if last_20 else 0.0,
             "peak_memory_gb": float(mx.get_peak_memory()) / 1e9 if hasattr(mx, "get_peak_memory") else None,
         }
+        summary.update(adaptive_fallback.summary_fields())
         if profile_cycles:
             summary["cycle_profile_us"] = cycle_profiles
             summary["cycle_profile_totals_us"] = {

--- a/dflash_mlx/server/metrics.py
+++ b/dflash_mlx/server/metrics.py
@@ -105,6 +105,24 @@ def log_bench_post(
         adaptive_last_probe_tokens_per_cycle=float(
             (summary_event or {}).get("adaptive_last_probe_tokens_per_cycle", 0.0) or 0.0
         ),
+        adaptive_bad_probe_windows=int(
+            (summary_event or {}).get("adaptive_bad_probe_windows", 0) or 0
+        ),
+        adaptive_pending_bad_probe_windows=int(
+            (summary_event or {}).get("adaptive_pending_bad_probe_windows", 0) or 0
+        ),
+        adaptive_last_probe_ms_per_token=(
+            (summary_event or {}).get("adaptive_last_probe_ms_per_token")
+        ),
+        adaptive_ar_ms_per_token=(
+            (summary_event or {}).get("adaptive_ar_ms_per_token")
+        ),
+        adaptive_latency_reject_count=int(
+            (summary_event or {}).get("adaptive_latency_reject_count", 0) or 0
+        ),
+        adaptive_latency_locked=bool(
+            (summary_event or {}).get("adaptive_latency_locked", False)
+        ),
         adaptive_fallback_reason=(summary_event or {}).get("adaptive_fallback_reason"),
         finish_reason=finish_reason,
         max_tokens=int(max_tokens),

--- a/dflash_mlx/server/metrics.py
+++ b/dflash_mlx/server/metrics.py
@@ -84,6 +84,28 @@ def log_bench_post(
         cache_insert_ms=cache_insert_ms,
         acceptance_ratio=acceptance_ratio,
         cycles_completed=cycles_completed,
+        adaptive_fallback_enabled=bool(
+            (summary_event or {}).get("adaptive_fallback_enabled", False)
+        ),
+        adaptive_fallback_triggered=bool(
+            (summary_event or {}).get("adaptive_fallback_triggered", False)
+        ),
+        adaptive_fallback_count=int(
+            (summary_event or {}).get("adaptive_fallback_count", 0) or 0
+        ),
+        adaptive_reprobe_count=int(
+            (summary_event or {}).get("adaptive_reprobe_count", 0) or 0
+        ),
+        adaptive_fallback_tokens=int(
+            (summary_event or {}).get("adaptive_fallback_tokens", 0) or 0
+        ),
+        adaptive_final_block_tokens=int(
+            (summary_event or {}).get("adaptive_final_block_tokens", 0) or 0
+        ),
+        adaptive_last_probe_tokens_per_cycle=float(
+            (summary_event or {}).get("adaptive_last_probe_tokens_per_cycle", 0.0) or 0.0
+        ),
+        adaptive_fallback_reason=(summary_event or {}).get("adaptive_fallback_reason"),
         finish_reason=finish_reason,
         max_tokens=int(max_tokens),
     )

--- a/dflash_mlx/verify_backend.py
+++ b/dflash_mlx/verify_backend.py
@@ -43,6 +43,7 @@ class _BaseEngine:
         target_len: int,
         acceptance_len: int,
         drafted_tokens: int,
+        force_replay: bool = False,
     ) -> int:
         from dflash_mlx.engine.rollback import restore_target_cache_after_acceptance
 
@@ -51,6 +52,7 @@ class _BaseEngine:
             target_len=target_len,
             acceptance_length=acceptance_len,
             drafted_tokens=drafted_tokens,
+            force_replay=force_replay,
         )
 
 class FullAttentionEngine(_BaseEngine):

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -215,6 +215,20 @@ On the fast-path AR branch, a smaller row is emitted directly from
 | `cache_insert_ms` | float | Cumulative time spent inserting snapshots for this request. |
 | `acceptance_ratio` | float | Final speculative-decoding acceptance ratio (0.0 – 1.0). |
 | `cycles_completed` | int | Number of speculative cycles run for this request. |
+| `adaptive_fallback_enabled` | bool | Whether `DFLASH_ADAPTIVE_FALLBACK` was enabled for this request. |
+| `adaptive_fallback_triggered` | bool | Whether adaptive fallback entered target-AR mode at least once. |
+| `adaptive_fallback_count` | int | Number of adaptive fallback transitions to target-AR mode. |
+| `adaptive_reprobe_count` | int | Number of post-cooldown reprobe transitions. Defaults to `0` with the conservative cooldown unless generation continues past the cooldown. |
+| `adaptive_fallback_tokens` | int | Tokens emitted while adaptive fallback was in target-AR cooldown. |
+| `adaptive_final_block_tokens` | int | Active speculative block size at request end. |
+| `adaptive_last_probe_tokens_per_cycle` | float | Average committed tokens per cycle in the most recent completed adaptive probe window. |
+| `adaptive_bad_probe_windows` | int | Configured number of consecutive bad probe windows required before fallback. |
+| `adaptive_pending_bad_probe_windows` | int | Consecutive bad probe windows observed but not yet acted on at request end. |
+| `adaptive_last_probe_ms_per_token` | float \| null | Milliseconds per committed token in the most recent completed adaptive probe window, when cycle timing was available. |
+| `adaptive_ar_ms_per_token` | float \| null | Milliseconds per token observed during the most recent target-AR cooldown, when available. |
+| `adaptive_latency_reject_count` | int | Number of cooldown or reprobe paths rejected by the latency guard. |
+| `adaptive_latency_locked` | bool | Whether adaptive fallback locked back to the reference block after a latency rejection. |
+| `adaptive_fallback_reason` | string \| null | Reason string for the latest adaptive fallback transition. |
 | `finish_reason` | string \| null | `stop` or `length`. |
 | `max_tokens` | int | Upper bound from the request body. |
 

--- a/docs/RUNTIME_FLAGS.md
+++ b/docs/RUNTIME_FLAGS.md
@@ -116,6 +116,27 @@ readers see a single source of truth.
 | `DFLASH_DRAFT_SINK` | `64` | Number of leading tokens kept as a permanent attention sink in the draft KV window. Set to `0` to disable. Example: `DFLASH_DRAFT_SINK=128`. |
 | `DFLASH_DRAFT_WINDOW` | `1024` | Sliding window length the draft uses for non-sink tokens. Setting any non-empty value also flips an internal "user override" bit, so explicit assignment is honoured even if it matches the default. Example: `DFLASH_DRAFT_WINDOW=2048`. |
 
+### Adaptive fallback
+
+Adaptive fallback is disabled by default. When enabled, the engine watches
+speculative decode progress over probe windows; if sustained low committed
+tokens per cycle indicates harmful speculation, it falls back to target
+autoregressive decoding for a cooldown window. The default cooldown is
+conservative, so most single requests remain in target-AR after fallback instead
+of automatically reprobeing with a smaller verifier block. Smaller-block
+reprobe is available for experiments, but changing verifier chunk shape can
+alter greedy output in near-tie cases.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `DFLASH_ADAPTIVE_FALLBACK` | unset (off) | Master switch. Truthy values enable adaptive fallback; `0`, `false`, `no`, `off`, or empty disable it. Example: `DFLASH_ADAPTIVE_FALLBACK=1`. |
+| `DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE` | `2.0` | Minimum average committed tokens per probe cycle. Probe windows below this threshold count as bad speculation. Example: `DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE=2.5`. |
+| `DFLASH_ADAPTIVE_PROBE_CYCLES` | `8` | Number of speculative cycles in each probe window. Clamped to `>= 1`. Example: `DFLASH_ADAPTIVE_PROBE_CYCLES=12`. |
+| `DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS` | `2` | Consecutive bad probe windows required before entering fallback. Clamped to `>= 1`. Example: `DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS=3`. |
+| `DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN` | `4096` | Number of generated tokens to hold target-AR mode after fallback before considering reprobe. Clamped to `>= 1`. Example: `DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN=512`. |
+| `DFLASH_ADAPTIVE_LATENCY_MARGIN` | `1.0` | Latency guard for cooldown/reprobe paths. A new path must be no slower than the reference path multiplied by this margin. Example: `DFLASH_ADAPTIVE_LATENCY_MARGIN=1.1`. |
+| `DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS` | unset | Explicit block size for the post-cooldown reprobe. When unset and the cooldown completes, the runtime probes a smaller block derived from the current block. Example: `DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS=2`. |
+
 ### Prefix cache
 
 These variables are overridden by the corresponding CLI flags on
@@ -160,6 +181,13 @@ benchmark protocol.
 | `DFLASH_DRAFT_SINK` | Env-only draft cache tuning. No CLI yet. |
 | `DFLASH_DRAFT_WINDOW` | Env-only draft cache tuning. No CLI yet. |
 | `DFLASH_PREFILL_STEP_SIZE` | Env-only in the runtime path. `dflash-serve` has an old hidden parser argument, but it is not a public wired flag. |
+| `DFLASH_ADAPTIVE_FALLBACK` | Env-only adaptive fallback switch. No CLI yet. |
+| `DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE` | Env-only adaptive fallback threshold. No CLI yet. |
+| `DFLASH_ADAPTIVE_PROBE_CYCLES` | Env-only adaptive fallback probe window size. No CLI yet. |
+| `DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS` | Env-only adaptive fallback confirmation count. No CLI yet. |
+| `DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN` | Env-only adaptive fallback target-AR hold length. No CLI yet. |
+| `DFLASH_ADAPTIVE_LATENCY_MARGIN` | Env-only adaptive fallback latency guard. No CLI yet. |
+| `DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS` | Env-only experimental adaptive fallback reprobe block override. No CLI yet. |
 | `DFLASH_VERIFY_LINEAR` | Env-only verify kernel override. No CLI yet. |
 | `DFLASH_VERIFY_QMM` | Env-only verify-QMM switch, also auto-set by runtime in some load paths. No CLI yet. |
 | `DFLASH_VERIFY_VARIANT` | Env-only verify-QMM kernel variant selector. No CLI yet. |

--- a/tests/test_adaptive_fallback.py
+++ b/tests/test_adaptive_fallback.py
@@ -23,6 +23,7 @@ def test_low_tokens_per_cycle_enters_target_ar_cooldown():
             enabled=True,
             min_tokens_per_cycle=3.0,
             probe_cycles=2,
+            bad_probe_windows=1,
             cooldown_tokens=4,
         ),
         initial_block_tokens=8,
@@ -48,6 +49,7 @@ def test_cooldown_completion_starts_reprobe_with_smaller_block():
             enabled=True,
             min_tokens_per_cycle=3.0,
             probe_cycles=1,
+            bad_probe_windows=1,
             cooldown_tokens=2,
         ),
         initial_block_tokens=8,
@@ -77,6 +79,7 @@ def test_configured_reprobe_block_is_used_and_clamped():
             enabled=True,
             min_tokens_per_cycle=9.0,
             probe_cycles=1,
+            bad_probe_windows=1,
             cooldown_tokens=1,
             reprobe_block_tokens=6,
         ),
@@ -94,13 +97,14 @@ def test_configured_reprobe_block_is_used_and_clamped():
         enabled=True,
         min_tokens_per_cycle=9.0,
         probe_cycles=1,
+        bad_probe_windows=1,
         cooldown_tokens=1,
         reprobe_block_tokens=64,
     )
     clamped = AdaptiveFallbackState(config=clamped_cfg, initial_block_tokens=16)
     clamped_fallback = clamped.record_cycle(block_len=16, commit_count=1)
-    assert clamped_fallback is not None
-    assert clamped_fallback.next_block_tokens == 16
+    assert clamped_fallback is None
+    assert clamped.summary_fields()["adaptive_fallback_count"] == 0
 
 
 def test_probe_window_pass_resets_without_fallback():
@@ -122,6 +126,120 @@ def test_probe_window_pass_resets_without_fallback():
     assert summary["adaptive_last_probe_tokens_per_cycle"] == 2.0
     assert summary["adaptive_pending_probe_cycles"] == 0
     assert state.block_tokens_for_cycle(32) == 8
+
+
+def test_single_bad_probe_window_waits_for_confirmation():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=2,
+            bad_probe_windows=2,
+            cooldown_tokens=4,
+        ),
+        initial_block_tokens=8,
+    )
+
+    assert state.record_cycle(block_len=8, commit_count=1) is None
+    assert state.record_cycle(block_len=8, commit_count=1) is None
+
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_count"] == 0
+    assert summary["adaptive_pending_bad_probe_windows"] == 1
+
+    assert state.record_cycle(block_len=8, commit_count=2) is None
+    assert state.record_cycle(block_len=8, commit_count=2) is None
+
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_count"] == 0
+    assert summary["adaptive_pending_bad_probe_windows"] == 0
+    assert state.block_tokens_for_cycle(32) == 8
+
+
+def test_sustained_bad_probe_windows_enter_fallback():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=2,
+            bad_probe_windows=2,
+            cooldown_tokens=4,
+        ),
+        initial_block_tokens=8,
+    )
+
+    assert state.record_cycle(block_len=8, commit_count=1) is None
+    assert state.record_cycle(block_len=8, commit_count=1) is None
+    assert state.record_cycle(block_len=8, commit_count=1) is None
+    decision = state.record_cycle(block_len=8, commit_count=1)
+
+    assert decision is not None
+    assert decision.action == "fallback"
+    assert decision.tokens_per_cycle == 1.0
+    assert state.in_cooldown is True
+
+
+def test_default_cooldown_holds_target_ar_for_coding_length_outputs():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=2,
+            bad_probe_windows=2,
+        ),
+        initial_block_tokens=16,
+    )
+
+    for _ in range(3):
+        assert state.record_cycle(block_len=16, commit_count=1) is None
+    fallback = state.record_cycle(block_len=16, commit_count=1)
+    assert fallback is not None
+    assert fallback.action == "fallback"
+    assert fallback.cooldown_tokens == 4096
+
+    for _ in range(1000):
+        assert state.record_cycle(block_len=1, commit_count=1) is None
+
+    assert state.in_cooldown is True
+    summary = state.summary_fields()
+    assert summary["adaptive_reprobe_count"] == 0
+    assert summary["adaptive_fallback_tokens"] == 1000
+
+
+def test_debug_trace_transient_bad_window_does_not_fallback():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=8,
+            bad_probe_windows=2,
+            cooldown_tokens=32,
+        ),
+        initial_block_tokens=16,
+    )
+    debug_acceptance_history = [
+        4, 0, 4, 1, 3, 1, 4, 0,
+        1, 5, 0, 2, 1, 1, 1, 1,
+        0, 0, 2, 1, 3, 0, 3, 1,
+        2, 2, 0, 0, 0, 0, 3, 1,
+        1, 0, 1, 1, 1, 1, 0, 3,
+        3, 4, 2, 3, 1, 1, 1, 3,
+        3, 0, 3, 0, 1, 0, 0, 2,
+        0, 4, 4, 0, 2, 1, 0, 1,
+        0, 1, 0, 1, 1, 0, 1, 1,
+        3, 2, 1, 1, 0, 0, 0, 2,
+    ]
+
+    for acceptance_len in debug_acceptance_history:
+        decision = state.record_cycle(
+            block_len=16,
+            commit_count=1 + acceptance_len,
+        )
+        assert decision is None
+
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_count"] == 0
+    assert state.in_cooldown is False
 
 
 def test_final_probe_cycle_does_not_enter_fallback():
@@ -155,6 +273,7 @@ def test_final_cooldown_cycle_does_not_record_reprobe():
             enabled=True,
             min_tokens_per_cycle=9.0,
             probe_cycles=1,
+            bad_probe_windows=1,
             cooldown_tokens=1,
         ),
         initial_block_tokens=8,
@@ -177,21 +296,138 @@ def test_final_cooldown_cycle_does_not_record_reprobe():
     assert summary["adaptive_fallback_tokens"] == 1
 
 
+def test_cooldown_restores_reference_when_target_ar_is_not_faster():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=1,
+            bad_probe_windows=1,
+            cooldown_tokens=2,
+        ),
+        initial_block_tokens=8,
+    )
+
+    fallback = state.record_cycle(block_len=8, commit_count=1, cycle_us=80_000)
+    assert fallback is not None
+    assert fallback.action == "fallback"
+
+    assert state.record_cycle(block_len=1, commit_count=1, cycle_us=90_000) is None
+    restore = state.record_cycle(block_len=1, commit_count=1, cycle_us=90_000)
+
+    assert restore is not None
+    assert restore.action == "restore"
+    assert state.block_tokens_for_cycle(32) == 8
+    summary = state.summary_fields()
+    assert summary["adaptive_latency_locked"] is True
+    assert summary["adaptive_latency_reject_count"] == 1
+    assert summary["adaptive_reprobe_count"] == 0
+    assert summary["adaptive_ar_ms_per_token"] == 90.0
+
+
+def test_reprobe_restores_reference_when_smaller_block_is_not_faster():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=1,
+            bad_probe_windows=1,
+            cooldown_tokens=1,
+        ),
+        initial_block_tokens=8,
+    )
+
+    fallback = state.record_cycle(block_len=8, commit_count=1, cycle_us=80_000)
+    assert fallback is not None
+    reprobe = state.record_cycle(block_len=1, commit_count=1, cycle_us=50_000)
+    assert reprobe is not None
+    assert reprobe.action == "reprobe"
+
+    restore = state.record_cycle(block_len=4, commit_count=1, cycle_us=90_000)
+
+    assert restore is not None
+    assert restore.action == "restore"
+    assert state.block_tokens_for_cycle(32) == 8
+    summary = state.summary_fields()
+    assert summary["adaptive_latency_locked"] is True
+    assert summary["adaptive_reference_block_tokens"] == 8
+    assert summary["adaptive_reference_ms_per_token"] == 80.0
+    assert summary["adaptive_last_probe_ms_per_token"] == 90.0
+
+
+def test_reprobe_can_continue_when_smaller_block_is_faster():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=1,
+            bad_probe_windows=1,
+            cooldown_tokens=1,
+        ),
+        initial_block_tokens=8,
+    )
+
+    fallback = state.record_cycle(block_len=8, commit_count=1, cycle_us=80_000)
+    assert fallback is not None
+    reprobe = state.record_cycle(block_len=1, commit_count=1, cycle_us=50_000)
+    assert reprobe is not None
+
+    second_fallback = state.record_cycle(block_len=4, commit_count=1, cycle_us=40_000)
+
+    assert second_fallback is not None
+    assert second_fallback.action == "fallback"
+    assert second_fallback.block_tokens == 4
+    assert second_fallback.next_block_tokens == 2
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_count"] == 2
+    assert summary["adaptive_reference_block_tokens"] == 4
+    assert summary["adaptive_reference_ms_per_token"] == 40.0
+
+
+def test_does_not_enter_cooldown_when_block_cannot_shrink():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=1,
+            bad_probe_windows=1,
+            cooldown_tokens=4,
+        ),
+        initial_block_tokens=2,
+    )
+
+    decision = state.record_cycle(block_len=2, commit_count=1, cycle_us=50_000)
+
+    assert decision is None
+    assert state.in_cooldown is False
+    assert state.summary_fields()["adaptive_fallback_count"] == 0
+
+
 def test_env_resolver_requires_opt_in():
     disabled = resolve_adaptive_fallback_config({"DFLASH_ADAPTIVE_FALLBACK": "0"})
+    enabled_default = resolve_adaptive_fallback_config({"DFLASH_ADAPTIVE_FALLBACK": "1"})
     enabled = resolve_adaptive_fallback_config(
         {
             "DFLASH_ADAPTIVE_FALLBACK": "1",
             "DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE": "2.5",
             "DFLASH_ADAPTIVE_PROBE_CYCLES": "3",
+            "DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS": "4",
             "DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN": "5",
+            "DFLASH_ADAPTIVE_LATENCY_MARGIN": "1.2",
             "DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS": "7",
         }
     )
 
     assert disabled.enabled is False
+    assert enabled_default.enabled is True
+    assert enabled_default.bad_probe_windows == 2
+    assert enabled_default.cooldown_tokens == 4096
+    assert enabled_default.latency_margin == 1.0
+    assert enabled_default.reprobe_block_tokens is None
     assert enabled.enabled is True
     assert enabled.min_tokens_per_cycle == 2.5
     assert enabled.probe_cycles == 3
+    assert enabled.bad_probe_windows == 4
     assert enabled.cooldown_tokens == 5
+    assert enabled.latency_margin == 1.2
     assert enabled.reprobe_block_tokens == 7

--- a/tests/test_adaptive_fallback.py
+++ b/tests/test_adaptive_fallback.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dflash_mlx.engine.adaptive_fallback import (
+    AdaptiveFallbackConfig,
+    AdaptiveFallbackState,
+    resolve_adaptive_fallback_config,
+)
+
+
+def test_adaptive_fallback_disabled_by_default():
+    cfg = resolve_adaptive_fallback_config({})
+    state = AdaptiveFallbackState(config=cfg, initial_block_tokens=8)
+
+    assert cfg.enabled is False
+    assert state.block_tokens_for_cycle(32) == 8
+    assert state.record_cycle(block_len=8, commit_count=1) is None
+    assert state.summary_fields()["adaptive_fallback_enabled"] is False
+
+
+def test_low_tokens_per_cycle_enters_target_ar_cooldown():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=3.0,
+            probe_cycles=2,
+            cooldown_tokens=4,
+        ),
+        initial_block_tokens=8,
+    )
+
+    assert state.record_cycle(block_len=8, commit_count=2) is None
+    decision = state.record_cycle(block_len=8, commit_count=1)
+
+    assert decision is not None
+    assert decision.action == "fallback"
+    assert decision.tokens_per_cycle == 1.5
+    assert decision.cooldown_tokens == 4
+    assert decision.block_tokens == 8
+    assert decision.next_block_tokens == 4
+    assert state.in_cooldown is True
+    assert state.block_tokens_for_cycle(32) == 1
+    assert state.summary_fields()["adaptive_fallback_triggered"] is True
+
+
+def test_cooldown_completion_starts_reprobe_with_smaller_block():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=3.0,
+            probe_cycles=1,
+            cooldown_tokens=2,
+        ),
+        initial_block_tokens=8,
+    )
+
+    fallback = state.record_cycle(block_len=8, commit_count=1)
+    assert fallback is not None
+    assert fallback.action == "fallback"
+
+    assert state.record_cycle(block_len=1, commit_count=1) is None
+    reprobe = state.record_cycle(block_len=1, commit_count=1)
+
+    assert reprobe is not None
+    assert reprobe.action == "reprobe"
+    assert reprobe.block_tokens == 8
+    assert reprobe.next_block_tokens == 4
+    assert state.in_cooldown is False
+    assert state.block_tokens_for_cycle(32) == 4
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_tokens"] == 2
+    assert summary["adaptive_reprobe_count"] == 1
+
+
+def test_configured_reprobe_block_is_used_and_clamped():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=9.0,
+            probe_cycles=1,
+            cooldown_tokens=1,
+            reprobe_block_tokens=6,
+        ),
+        initial_block_tokens=16,
+    )
+
+    fallback = state.record_cycle(block_len=16, commit_count=1)
+    assert fallback is not None
+    assert fallback.next_block_tokens == 6
+    reprobe = state.record_cycle(block_len=1, commit_count=1)
+    assert reprobe is not None
+    assert state.block_tokens_for_cycle(32) == 6
+
+    clamped_cfg = AdaptiveFallbackConfig(
+        enabled=True,
+        min_tokens_per_cycle=9.0,
+        probe_cycles=1,
+        cooldown_tokens=1,
+        reprobe_block_tokens=64,
+    )
+    clamped = AdaptiveFallbackState(config=clamped_cfg, initial_block_tokens=16)
+    clamped_fallback = clamped.record_cycle(block_len=16, commit_count=1)
+    assert clamped_fallback is not None
+    assert clamped_fallback.next_block_tokens == 16
+
+
+def test_probe_window_pass_resets_without_fallback():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=2.0,
+            probe_cycles=2,
+            cooldown_tokens=4,
+        ),
+        initial_block_tokens=8,
+    )
+
+    assert state.record_cycle(block_len=8, commit_count=2) is None
+    assert state.record_cycle(block_len=8, commit_count=2) is None
+
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_triggered"] is False
+    assert summary["adaptive_last_probe_tokens_per_cycle"] == 2.0
+    assert summary["adaptive_pending_probe_cycles"] == 0
+    assert state.block_tokens_for_cycle(32) == 8
+
+
+def test_final_probe_cycle_does_not_enter_fallback():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=9.0,
+            probe_cycles=1,
+            cooldown_tokens=4,
+        ),
+        initial_block_tokens=8,
+    )
+
+    decision = state.record_cycle(
+        block_len=8,
+        commit_count=1,
+        can_continue=False,
+    )
+
+    assert decision is None
+    assert state.in_cooldown is False
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_triggered"] is False
+    assert summary["adaptive_fallback_count"] == 0
+    assert summary["adaptive_last_probe_tokens_per_cycle"] == 1.0
+
+
+def test_final_cooldown_cycle_does_not_record_reprobe():
+    state = AdaptiveFallbackState(
+        config=AdaptiveFallbackConfig(
+            enabled=True,
+            min_tokens_per_cycle=9.0,
+            probe_cycles=1,
+            cooldown_tokens=1,
+        ),
+        initial_block_tokens=8,
+    )
+
+    fallback = state.record_cycle(block_len=8, commit_count=1)
+    assert fallback is not None
+    assert fallback.action == "fallback"
+
+    decision = state.record_cycle(
+        block_len=1,
+        commit_count=1,
+        can_continue=False,
+    )
+
+    assert decision is None
+    summary = state.summary_fields()
+    assert summary["adaptive_fallback_triggered"] is True
+    assert summary["adaptive_reprobe_count"] == 0
+    assert summary["adaptive_fallback_tokens"] == 1
+
+
+def test_env_resolver_requires_opt_in():
+    disabled = resolve_adaptive_fallback_config({"DFLASH_ADAPTIVE_FALLBACK": "0"})
+    enabled = resolve_adaptive_fallback_config(
+        {
+            "DFLASH_ADAPTIVE_FALLBACK": "1",
+            "DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE": "2.5",
+            "DFLASH_ADAPTIVE_PROBE_CYCLES": "3",
+            "DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN": "5",
+            "DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS": "7",
+        }
+    )
+
+    assert disabled.enabled is False
+    assert enabled.enabled is True
+    assert enabled.min_tokens_per_cycle == 2.5
+    assert enabled.probe_cycles == 3
+    assert enabled.cooldown_tokens == 5
+    assert enabled.reprobe_block_tokens == 7

--- a/tests/test_engine_rollback.py
+++ b/tests/test_engine_rollback.py
@@ -90,6 +90,20 @@ def test_full_acceptance_skips_rollback_replay():
     assert replay_ns == 0
 
 
+def test_force_replay_overrides_full_acceptance_fast_path():
+    c = _ArmableCache()
+    replay_ns = restore_target_cache_after_acceptance(
+        [c],
+        target_len=100,
+        acceptance_length=0,
+        drafted_tokens=0,
+        force_replay=True,
+    )
+
+    assert c.rolled_back_to == [0]
+    assert replay_ns >= 0
+
+
 def test_partial_acceptance_calls_rollback_with_acceptance_length():
     c = _ArmableCache()
     replay_ns = restore_target_cache_after_acceptance(


### PR DESCRIPTION
 ## Problem

  In long coding/chat workloads, DFlash can hit stretches where speculative acceptance drops but the
  runtime continues verifying the full draft block. In those regions, speculation becomes actively
  harmful: the verifier still pays the fixed cost of a large block, but only a small number of tokens are
  committed.

  We saw this clearly in a local Pi coding-chat harness. This is a fixed multi-turn coding prompt driven
  through the Pi CLI against the OpenAI-compatible server. With adaptive fallback disabled, the run stayed
  mostly at block_len=16. The target verify cost remained high per cycle, while committed tokens per cycle
  dropped low enough that continued speculation was no longer the best decode policy.

  ## Change

  This PR adds an opt-in adaptive fallback controller for DFlash decode.

  The controller tracks committed tokens per speculative cycle over a probe window. If the average
  committed-token yield falls below a configured threshold for sustained probe windows, the runtime enters
  a target-AR fallback cooldown by forcing block_len=1.

  During fallback cooldown, the runtime does not launch draft work for the next cycle, avoiding wasted
  draft and large-block verify work during low-acceptance regions. The controller also emits summary
  fields and adaptive fallback events so runs can be inspected after the fact.

  The default path is conservative: after fallback, most single requests remain in target-AR rather than
  automatically reprobeing with a smaller verifier block. Smaller-block reprobe remains available through
  env knobs for experimentation, but is not the default behavior.

  ## Algorithm

  1. Track committed tokens per speculative cycle.
  2. Aggregate the signal over DFLASH_ADAPTIVE_PROBE_CYCLES.
  3. Mark a probe window bad when average committed tokens per cycle is below
     DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE.
  4. Require DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS consecutive bad windows before changing policy.
  5. On trigger, enter target-AR cooldown for DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN generated tokens.
  6. In cooldown, force block_len=1, skip draft launch, and continue through the same target verifier/
     rollback path.
  7. Expose adaptive state in the final summary and bench logs.

Tested model pair for the benchmark matrix:
```text
Target: Huihui-Qwen3.6-27B-abliterated-4.5bit-msq
Draft:  Qwen3.6-27B-DFlash
Hardware: MacBook Pro, M3 Max, 128GB
```

  ## Results

  Focused validation:
```text
tests/test_adaptive_fallback.py
tests/test_engine_rollback.py

26 passed
py_compile passed
git diff --check passed
```
  Benchmark signal from a local Pi coding-chat harness with the conservative default path:

  adaptive off:
    decode throughput: baseline

  adaptive fallback target-AR hold:
    output hashes matched off across all default-path runs
    fallback_count: 1 / 1 / 1
    reprobe_count: 0 / 0 / 0
    average improvement vs off: +18.5%

  The speedup comes from avoiding harmful speculative stretches where large-block verification continues
  despite low committed-token yield. In those regions, target-AR cycles are cheaper and avoid wasted draft
  work.

  ## Validation Matrix

  No-fallback throughput deltas are treated as noise unless repeated benches reproduce them.

  | Harness | Adaptive action | Output parity | Avg throughput vs off |
  | --- | --- | --- | --- |
  | Local Pi coding-chat | fallback_count: 1/1/1, reprobe_count: 0/0/0 | matched hashes 3/3 | +18.5% |
  | Debug trace | fallback_count: 0/0/0, reprobe_count: 0/0/0 | matched hashes 3/3 | -4.7% |
  | GSM short | fallback_count: 0/0/0 | matched hashes 3/3 | -1.0% |
  | Structured JSON | fallback_count: 0/0/0 | matched hashes 3/3 | -2.8% |
  | Code patch long | fallback_count: 0/0/0 | matched hashes 3/3 | +11.4% |
  | Long-context summary | fallback_count: 0/0/0 | matched hashes 3/3 | +0.7% |

  ## New Environment Variables

  - `DFLASH_ADAPTIVE_FALLBACK`
  - `DFLASH_ADAPTIVE_MIN_TOKENS_PER_CYCLE`
  - `DFLASH_ADAPTIVE_PROBE_CYCLES`
  - `DFLASH_ADAPTIVE_BAD_PROBE_WINDOWS`
  - `DFLASH_ADAPTIVE_TARGET_AR_COOLDOWN`
  - `DFLASH_ADAPTIVE_LATENCY_MARGIN`
  - `DFLASH_ADAPTIVE_REPROBE_BLOCK_TOKENS`

  DFLASH_ADAPTIVE_FALLBACK is disabled by default.

  ## Future Work

  - Smaller-block reprobe/ramp-up after fallback, once verifier chunk-shape output stability is proven.
  - Latency-aware fallback decisions using measured ms/token, not only committed tokens per cycle.
  - Lower-overhead hot-path accounting if repeated benches show measurable no-op overhead.
  - Broader benchmark suite across more coding agents, long-form chat, and different Apple Silicon SKUs.