### PR TITLE
Fix KeyError: None in _step_trie on long generations

### DIFF
--- a/dflash_mlx/serve.py
+++ b/dflash_mlx/serve.py
@@ -293,7 +293,7 @@ class DFlashResponseGenerator(mlx_server.ResponseGenerator):
                     current_state = "normal"
                     match_sequence: Optional[tuple[int, ...]] = None
                     token_finish_reason: Optional[str] = None
-                    if sm is not None:
+                    if sm is not None and sm_state is not None and sm_state[0] is not None:
                         sm_state, match_sequence, current_state = sm.match(sm_state, token)
                         if match_sequence is not None and current_state is None:
                             token_finish_reason = "stop"


### PR DESCRIPTION
Fixes #17.

After a successful stop-token transition, `mlx-lm`'s state machine returns `(None, ...)` for `sm_state` to indicate no further state to track. The current guard at `serve.py:296` only checks `sm is not None`, so the next call into `sm.match` dereferences `None` deep inside `mlx_lm.generate._step_trie` and raises `KeyError: None` mid-stream.

This kills any request whose generation actually exercises the stop-token state machine — in practice, anything with `max_tokens > 256` that produces enough tokens to hit the trie tail (~70% of `max_tokens >= 1024` runs in my benchmark).

The fix is a one-line tightening of the guard:

```diff
-                    if sm is not None:
+                    if sm is not None and sm_state is not None and sm_state[0] is not None:
                         sm_state, match_sequence, current_state = sm.match(sm_state, token)
```

### Verification

Locally patched on Mac Studio M3 Ultra 512GB (`mlx-community/Qwen3.6-27B-Instruct-8bit` + `z-lab/Qwen3.6-27B-DFlash`, mlx-lm 0.31.3):

- 30+ multi-hour generation runs with `max_tokens` ∈ {512, 1024, 2048} across prompt sizes 2K-32K all complete cleanly.
- Without the guard, ~70% of `max_tokens >= 1024` runs crashed before completion.
- No behavioural change for short generations (the guard is strictly tighter than the old condition).