### PR TITLE
Wire --prefill-step-size through to runtime; warn on no-op CLI flags

### DIFF
--- a/dflash_mlx/runtime.py
+++ b/dflash_mlx/runtime.py
@@ -211,6 +211,15 @@ def _resolve_dflash_max_ctx() -> int:
     return max_ctx
 
 
+def _resolve_prefill_step_size() -> int:
+    raw = os.environ.get("DFLASH_PREFILL_STEP_SIZE", "2048").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return 2048
+    return value if value > 0 else 2048
+
+
 def _resolve_draft_window() -> tuple[int, int]:
     sink = int(os.environ.get("DFLASH_DRAFT_SINK", "64").strip())
     window = int(os.environ.get("DFLASH_DRAFT_WINDOW", "1024").strip())
@@ -1218,7 +1227,7 @@ def generate_dflash_once(
     try:
         start_ns = time.perf_counter_ns()
         prefill_start_ns = time.perf_counter_ns()
-        prefill_step_size = 2048
+        prefill_step_size = _resolve_prefill_step_size()
         prefill_logits = None
         target_hidden: Optional[mx.array] = None
         for chunk_start in range(0, prompt_len, prefill_step_size):
@@ -1613,7 +1622,7 @@ def stream_dflash_generate(
         start_ns = time.perf_counter_ns()
         _yield_pause_ns = 0
         prefill_start_ns = time.perf_counter_ns()
-        prefill_step_size = 2048
+        prefill_step_size = _resolve_prefill_step_size()
         prefill_logits = None
         target_hidden: Optional[mx.array] = None
         for chunk_start in range(0, prompt_len, prefill_step_size):

--- a/dflash_mlx/serve.py
+++ b/dflash_mlx/serve.py
@@ -628,6 +628,29 @@ def main() -> None:
             raise SystemExit("--dflash-max-ctx must be > 0")
         os.environ["DFLASH_MAX_CTX"] = str(args.dflash_max_ctx)
 
+    # Wire --prefill-step-size through to the runtime via env var,
+    # following the same pattern as DFLASH_MAX_CTX above.
+    prefill_step_size = getattr(args, "prefill_step_size", None)
+    if prefill_step_size is not None and prefill_step_size > 0:
+        os.environ["DFLASH_PREFILL_STEP_SIZE"] = str(prefill_step_size)
+
+    # Warn about CLI flags that are accepted but currently have no effect
+    # in the single-stream MLX backend, so users tuning them know to stop.
+    _no_op_flags = (
+        ("num_draft_tokens", 3),
+        ("decode_concurrency", 32),
+        ("prompt_concurrency", 8),
+    )
+    for _attr, _default in _no_op_flags:
+        _value = getattr(args, _attr, _default)
+        if _value != _default:
+            sys.stderr.write(
+                f"[dflash] warning: --{_attr.replace('_', '-')}={_value} "
+                f"is currently a no-op in the single-stream MLX backend; "
+                f"see https://github.com/bstnxbt/dflash-mlx/issues/18\n"
+            )
+            sys.stderr.flush()
+
     if mx.metal.is_available():
         wired_limit = mx.device_info()["max_recommended_working_set_size"]
         mx.set_wired_limit(wired_limit)


### PR DESCRIPTION
Refs #18.

Four CLI flags were accepted by `argparse` but never read by the runtime:

| flag | status before | status after |
|---|---|---|
| `--prefill-step-size` | hardcoded to 2048 in `runtime.py` (twice) | wired through via `DFLASH_PREFILL_STEP_SIZE` env var |
| `--num-draft-tokens` | unused | unused, emits warning if set |
| `--decode-concurrency` | unused | unused, emits warning if set |
| `--prompt-concurrency` | unused | unused, emits warning if set |

### Changes

1. **`runtime.py`**: new `_resolve_prefill_step_size()` (mirrors `_resolve_dflash_max_ctx` / `_resolve_draft_window`), reads the new `DFLASH_PREFILL_STEP_SIZE` env var with the prior hardcoded 2048 as default. Both call sites now use it.

2. **`serve.py`**: `main()` now propagates `args.prefill_step_size` into `os.environ["DFLASH_PREFILL_STEP_SIZE"]`, following the existing `DFLASH_MAX_CTX` pattern. For the other three flags, a one-time stderr warning is emitted at startup if the user sets a non-default value, with a link to #18 so the silent fallback is discoverable.

I picked the env-var indirection (rather than threading a config dict down to `generate_dflash_once`) because it keeps the diff minimal and matches the established style in `runtime.py`. Happy to refactor if you'd prefer a more direct path.

### Verification

- `python -c "import ast; ast.parse(open('dflash_mlx/serve.py').read()); ast.parse(open('dflash_mlx/runtime.py').read())"` clean.
- Manual test: `dflash-serve --num-draft-tokens 12 --prefill-step-size 4096 ...` now (a) prints the warning for `--num-draft-tokens` and (b) actually uses 4096-token prefill chunks.

The remaining 3 flags are kept as warnings rather than removed because the related vLLM-side DFlash docs document them, and removing them would break command-line compatibility for users coming from that recipe. Wiring them through is more involved and out of scope for this PR.