### PR TITLE
Make speculative-decoding fast-path threshold configurable (--fastpath-max-tokens)

### DIFF
--- a/dflash_mlx/serve.py
+++ b/dflash_mlx/serve.py
@@ -154,11 +154,16 @@ class DFlashResponseGenerator(mlx_server.ResponseGenerator):
         request_tuple = request
         rqueue, request, args = request_tuple
 
-        if args.max_tokens <= 256:
-            sys.stderr.write(
-                f"{time.strftime('%Y-%m-%d %H:%M:%S')} [dflash] fast-path AR | max_tokens={args.max_tokens}\n"
+        fastpath_threshold = getattr(
+            self.model_provider.cli_args, "fastpath_max_tokens", 256
+        )
+        if fastpath_threshold > 0 and args.max_tokens <= fastpath_threshold:
+            logging.info(
+                "[dflash] fast-path AR (skipping speculative decoding) | "
+                "max_tokens=%d <= fastpath_max_tokens=%d",
+                args.max_tokens,
+                fastpath_threshold,
             )
-            sys.stderr.flush()
             saved_draft_model = self.model_provider.draft_model
             try:
                 self.model_provider.draft_model = None
@@ -512,6 +517,16 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Maximum prompt token count for DFlash speculative decoding.",
+    )
+    parser.add_argument(
+        "--fastpath-max-tokens",
+        type=int,
+        default=256,
+        help=(
+            "Requests with max_tokens at or below this threshold skip "
+            "speculative decoding and fall back to vanilla mlx-lm AR "
+            "(default: 256). Set to 0 to disable the fast-path entirely."
+        ),
     )
     parser.add_argument(
         "--num-draft-tokens",


### PR DESCRIPTION
Refs #20.

The fast-path that skips speculative decoding for short generations was hardcoded to `max_tokens <= 256` and only logged via a raw `sys.stderr.write`, which gets dropped under systemd/launchd and is not surfaced through the HTTP response.

The result is that anyone benchmarking dflash with `max_tokens` around 200-256 (a very common OpenAI client default) is unknowingly measuring vanilla `mlx-lm` AR vs `llama.cpp` — and concluding that dflash is slow, when in reality the speculative engine never even ran. This trap is visible in #6 here and several reddit threads ("MLX with DFlash: Surprising results", `r/LocalLLM`).

### Changes

1. New `--fastpath-max-tokens` CLI flag, default `256` (preserves current behavior). Set to `0` to disable the fast-path entirely and force speculative decoding regardless of `max_tokens`.
2. Replace the raw `sys.stderr.write` with a structured `logging.info()` call so the fallback decision is captured by the existing logging config set up in `main()`.
3. Document the threshold in `--help` (was previously `argparse.SUPPRESS` territory and undocumented anywhere).

### Verification

- AST-clean.
- `dflash-serve --fastpath-max-tokens 0 ...` now uses the speculative engine for any `max_tokens`.
- `dflash-serve --log-level DEBUG ...` shows the fast-path decision in the standard log stream.
- Default behavior unchanged for users who don't set the flag.

Out of scope but related: a follow-up could add an `x-dflash-fastpath: 1` HTTP response header so clients/benchmarks can detect the fallback without reading server logs. Happy to add that here if you want — left it out to keep the diff focused.