### PR TITLE
fix: add prompt slug helper for benchmark output naming

### DIFF
--- a/dflash_mlx/benchmark.py
+++ b/dflash_mlx/benchmark.py
@@ -144,6 +144,12 @@ def _slugify_model_ref(model_ref: str | None) -> str:
     label = re.sub(r"-+", "-", label).strip("-")
     return label or "model"
 
+def _slugify_prompt_id(prompt: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", prompt[:60].lower())
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug or "prompt"
+
+
 def _benchmark_mode(args: argparse.Namespace) -> str:
     suite = getattr(args, "suite", None)
     if suite:

--- a/dflash_mlx/benchmark.py
+++ b/dflash_mlx/benchmark.py
@@ -35,6 +35,7 @@ from dflash_mlx.benchmark_suites import (
     ctx_tokens as _ctx_tokens,
     default_limit_for_suite as _default_limit_for_suite,
     resolve_benchmark_prompts,
+    slugify_prompt_id,
 )
 from dflash_mlx.metal_limits import apply_metal_limits
 from dflash_mlx.runtime import (
@@ -143,12 +144,6 @@ def _slugify_model_ref(model_ref: str | None) -> str:
     label = re.sub(r"[^a-z0-9]+", "-", label.lower())
     label = re.sub(r"-+", "-", label).strip("-")
     return label or "model"
-
-def _slugify_prompt_id(prompt: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", prompt[:60].lower())
-    slug = re.sub(r"-+", "-", slug).strip("-")
-    return slug or "prompt"
-
 
 def _benchmark_mode(args: argparse.Namespace) -> str:
     suite = getattr(args, "suite", None)
@@ -270,7 +265,7 @@ def _build_config(
         "verify_len_cap": int(verify_len_cap),
         "prompt": prompt,
         "prompt_tokens": int(prompt_tokens),
-        "prompt_id": _slugify_prompt_id(prompt),
+        "prompt_id": slugify_prompt_id(prompt),
         "git_hash": _git_hash_short(),
     }
 

--- a/dflash_mlx/benchmark_suites.py
+++ b/dflash_mlx/benchmark_suites.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import random
 import re
@@ -87,7 +88,7 @@ def resolve_benchmark_prompts(args: argparse.Namespace) -> list[BenchmarkPrompt]
         if suite == "longctx":
             prompt = build_long_context_prompt(prompt, ctx_tokens(args) or DEFAULT_CTX_TOKENS)
         source = "synthetic" if suite == "longctx" else "smoke"
-        prompts = (BenchmarkPrompt(f"{suite}-custom-{_slugify_prompt_id(prompt)}", suite, prompt, source),)
+        prompts = (BenchmarkPrompt(f"{suite}-custom-{slugify_prompt_id(prompt)}", suite, prompt, source),)
     elif suite == "longctx":
         ctx_token_count = ctx_tokens(args) or DEFAULT_CTX_TOKENS
         prompts = (
@@ -198,7 +199,9 @@ def _format_hf_prompt(suite: str, row_index: int, row: dict[str, Any]) -> Benchm
         hf_dataset_split=str(meta["split"]),
     )
 
-def _slugify_prompt_id(prompt: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "_", prompt.lower()).strip("_")
-    slug = re.sub(r"_+", "_", slug)
-    return slug[:48] or "prompt"
+def slugify_prompt_id(prompt: str) -> str:
+    prompt_text = str(prompt)
+    head = re.sub(r"[^a-z0-9]+", "-", prompt_text[:48].lower())
+    head = re.sub(r"-+", "-", head).strip("-")
+    digest = hashlib.sha1(prompt_text.encode("utf-8")).hexdigest()[:8]
+    return f"{head}-{digest}" if head else digest

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -14,6 +14,15 @@ from dflash_mlx import benchmark_report
 from dflash_mlx import benchmark_suites
 from dflash_mlx.runtime_context import build_offline_runtime_context
 
+def test_prompt_slug_distinguishes_long_prompts_with_same_prefix():
+    prefix = "same prefix " * 8
+    first = benchmark_suites.slugify_prompt_id(prefix + "alpha")
+    second = benchmark_suites.slugify_prompt_id(prefix + "beta")
+
+    assert first != second
+    assert first.startswith("same-prefix")
+    assert second.startswith("same-prefix")
+
 def test_benchmark_help_documents_public_flags(capsys):
     parser = benchmark.build_parser()
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
Fixing NameError: name '_slugify_prompt_id' is not defined when running
```
dflash benchmark --model Qwen/Qwen3.5-4B --draft z-lab/Qwen3.5-4B-DFlash  --suite smoke
```