### PR TITLE
chore: bump version to 0.1.5.1

### DIFF
--- a/dflash_mlx/__init__.py
+++ b/dflash_mlx/__init__.py
@@ -2,4 +2,4 @@
 # MIT License — see LICENSE file
 # Based on DFlash (arXiv:2602.06036)
 
-__version__ = "0.1.5"
+__version__ = "0.1.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dflash-mlx"
-version = "0.1.5"
+version = "0.1.5.1"
 description = "DFlash speculative decoding for Apple Silicon (MLX)"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Hotfix release bump after PR #25 fixed benchmark prompt slug generation.\n\nValidation:\n- PYTHONPATH=/tmp/dflash-v0151 python3 -m pytest tests/test_benchmark_cli.py -q\n- PYTHONPATH=/tmp/dflash-v0151 python3 -m py_compile dflash_mlx/benchmark.py dflash_mlx/benchmark_suites.py dflash_mlx/__init__.py\n- Imported dflash_mlx.__version__ -> 0.1.5.1