### PR TITLE
Expose DFlash prefix cache lookup diagnostics

### DIFF
--- a/dflash_mlx/server/metrics.py
+++ b/dflash_mlx/server/metrics.py
@@ -103,6 +103,7 @@ class _RequestAccounting:
     cache_lookup_ms: Optional[float] = None
     cache_hit_tokens: int = 0
     cache_insert_ms: Optional[float] = None
+    cache_lookup_stats: Optional[dict[str, Any]] = None
     prompt_regime: Optional[dict[str, Any]] = None
     prefill_event_payload: Optional[dict[str, Any]] = None
     prefill_accounting: Optional[dict[str, int]] = None
@@ -147,6 +148,7 @@ class _RequestAccounting:
         cache_insert_ms: float,
         finish_reason: Optional[str],
         max_tokens: int,
+        cache_lookup_stats: Optional[dict[str, Any]] = None,
         prompt_regime: Optional[dict[str, Any]],
         memory_waterfall_peak: Optional[dict[str, Any]],
         memory_waterfall_start: Optional[dict[str, Any]] = None,
@@ -266,6 +268,7 @@ class _RequestAccounting:
             cache_lookup_ms=float(cache_lookup_ms),
             cache_hit_tokens=int(cache_hit_tokens),
             cache_insert_ms=float(cache_insert_ms),
+            cache_lookup_stats=dict(cache_lookup_stats or {}),
             prompt_regime=dict(prompt_regime or {}),
             prefill_event_payload=(
                 prefill_event.to_payload() if prefill_event is not None else {}
@@ -331,6 +334,8 @@ class _RequestAccounting:
         )
         if self.cycle_profile_totals_us:
             payload["cycle_profile_totals_us"] = dict(self.cycle_profile_totals_us)
+        if self.cache_lookup_stats:
+            payload["cache_lookup"] = dict(self.cache_lookup_stats)
         if self.adaptive_metrics:
             payload["adaptive_metrics"] = dict(self.adaptive_metrics)
         payload["mode_used"] = self.mode_used
@@ -362,6 +367,7 @@ class _RequestAccounting:
                 "decode_ms": self.decode_ms,
                 "cache_lookup_ms": self.cache_lookup_ms,
                 "cache_insert_ms": self.cache_insert_ms,
+                "cache_lookup": dict(self.cache_lookup_stats or {}),
                 "acceptance_ratio": self.acceptance_ratio,
                 "tokens_per_cycle": self.tokens_per_cycle,
                 "cycles_completed": self.cycles_completed,
@@ -668,6 +674,7 @@ def finalize_request_observability(
     cache_insert_ms: float,
     finish_reason: Optional[str],
     max_tokens: int,
+    cache_lookup_stats: Optional[dict[str, Any]] = None,
     prompt_regime: Optional[dict[str, Any]] = None,
     memory_waterfall_peak: Optional[dict[str, Any]] = None,
     memory_waterfall_start: Optional[dict[str, Any]] = None,
@@ -689,6 +696,7 @@ def finalize_request_observability(
         cache_hit_tokens=cache_hit_tokens,
         cache_insert_ms=cache_insert_ms,
         finish_reason=finish_reason,
+        cache_lookup_stats=cache_lookup_stats,
         max_tokens=max_tokens,
         prompt_regime=prompt_regime,
         memory_waterfall_peak=memory_waterfall_peak,

--- a/dflash_mlx/server/prefix_cache_flow.py
+++ b/dflash_mlx/server/prefix_cache_flow.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from dflash_mlx.cache.manager import (
@@ -74,6 +74,63 @@ def _last_chat_role(request: Any) -> str | None:
         return None
     return str(role)
 
+@dataclass(frozen=True)
+class PrefixCacheLookupStats:
+    prompt_tokens: int = 0
+    stable_prefix_tokens: int = 0
+    lookup_tokens: int = 0
+    hit_tokens: int = 0
+    lookup_ms: float = 0.0
+    hit_kind: str = "inactive"
+    snapshot_tokens: int = 0
+    snapshot_kind: Optional[str] = None
+    snapshot_nbytes: int = 0
+    snapshot_has_last_logits: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "prompt_tokens": int(self.prompt_tokens),
+            "stable_prefix_tokens": int(self.stable_prefix_tokens),
+            "lookup_tokens": int(self.lookup_tokens),
+            "hit_tokens": int(self.hit_tokens),
+            "lookup_ms": float(self.lookup_ms),
+            "hit_kind": self.hit_kind,
+            "snapshot_tokens": int(self.snapshot_tokens),
+            "snapshot_kind": self.snapshot_kind,
+            "snapshot_nbytes": int(self.snapshot_nbytes),
+            "snapshot_has_last_logits": bool(self.snapshot_has_last_logits),
+        }
+
+
+def _lookup_stats(
+    *,
+    prompt: list[int],
+    stable_prefix_len: int,
+    lookup_ms: float,
+    hit_tokens: int,
+    snapshot: Optional[DFlashPrefixSnapshot],
+) -> PrefixCacheLookupStats:
+    lookup_tokens = min(len(prompt), stable_prefix_len)
+    if hit_tokens <= 0:
+        hit_kind = "miss"
+    elif hit_tokens == lookup_tokens:
+        hit_kind = "exact"
+    else:
+        hit_kind = "prefix"
+    return PrefixCacheLookupStats(
+        prompt_tokens=len(prompt),
+        stable_prefix_tokens=stable_prefix_len,
+        lookup_tokens=lookup_tokens,
+        hit_tokens=hit_tokens,
+        lookup_ms=lookup_ms,
+        hit_kind=hit_kind,
+        snapshot_tokens=0 if snapshot is None else snapshot.prefix_len,
+        snapshot_kind=None if snapshot is None else snapshot.kind,
+        snapshot_nbytes=0 if snapshot is None else snapshot.nbytes,
+        snapshot_has_last_logits=snapshot is not None and snapshot.last_logits is not None,
+    )
+
+
 @dataclass
 class PrefixCacheFlow:
     cache_manager: Optional[RuntimeCacheManager]
@@ -83,6 +140,7 @@ class PrefixCacheFlow:
     snapshot: Optional[DFlashPrefixSnapshot] = None
     lookup_ms: float = 0.0
     hit_tokens: int = 0
+    lookup_stats: PrefixCacheLookupStats = field(default_factory=PrefixCacheLookupStats)
     snapshot_service: Optional[SnapshotService] = None
 
     @property
@@ -146,6 +204,13 @@ class PrefixCacheFlow:
         except RuntimeCacheManagerClosed:
             return cls(cache_manager=None)
         hit_tokens = int(lookup.matched_tokens)
+        lookup_stats = _lookup_stats(
+            prompt=prompt,
+            stable_prefix_len=stable_prefix_len,
+            lookup_ms=lookup.elapsed_ms,
+            hit_tokens=hit_tokens,
+            snapshot=lookup.snapshot,
+        )
         if lookup.matched_tokens > 0:
             sys.stderr.write(
                 f"{time.strftime('%Y-%m-%d %H:%M:%S')} [dflash] prefix cache hit "
@@ -164,6 +229,7 @@ class PrefixCacheFlow:
             snapshot=lookup.snapshot,
             lookup_ms=lookup.elapsed_ms,
             hit_tokens=hit_tokens,
+            lookup_stats=lookup_stats,
             snapshot_service=(
                 SnapshotService.from_request(
                     cache_manager=cache_manager,

--- a/dflash_mlx/server/request_loop.py
+++ b/dflash_mlx/server/request_loop.py
@@ -43,6 +43,7 @@ class RequestLoopResult:
     cache_lookup_ms: float
     cache_hit_tokens: int
     cache_insert_ms: float
+    cache_lookup_stats: Optional[dict[str, Any]] = None
     memory_waterfall_peak: Optional[dict[str, Any]] = None
     memory_waterfall_start: Optional[dict[str, Any]] = None
     memory_waterfall_end: Optional[dict[str, Any]] = None
@@ -370,10 +371,27 @@ def consume_dflash_events(
         cache_lookup_ms=prefix_flow.lookup_ms if prefix_flow is not None else 0.0,
         cache_hit_tokens=prefix_flow.hit_tokens if prefix_flow is not None else 0,
         cache_insert_ms=prefix_flow.insert_ms if prefix_flow is not None else 0.0,
+        cache_lookup_stats=_prefix_lookup_stats_payload(prefix_flow),
         memory_waterfall_peak=memory_peak,
         memory_waterfall_start=memory_start,
         memory_waterfall_end=memory_end,
     )
+
+def _prefix_lookup_stats_payload(
+    prefix_flow: Optional[PrefixCacheFlow],
+) -> dict[str, Any]:
+    if prefix_flow is None:
+        return {}
+    stats = getattr(prefix_flow, "lookup_stats", None)
+    if stats is None:
+        return {}
+    to_payload = getattr(stats, "to_payload", None)
+    if callable(to_payload):
+        return dict(to_payload())
+    if isinstance(stats, dict):
+        return dict(stats)
+    return {}
+
 
 def _with_prefix_cache_memory(
     event: dict[str, Any],

--- a/dflash_mlx/server/runtime.py
+++ b/dflash_mlx/server/runtime.py
@@ -201,6 +201,7 @@ class ServerRuntime:
             cache_lookup_ms=loop_result.cache_lookup_ms,
             cache_hit_tokens=loop_result.cache_hit_tokens,
             cache_insert_ms=loop_result.cache_insert_ms,
+            cache_lookup_stats=loop_result.cache_lookup_stats,
             finish_reason=loop_result.finish_reason,
             max_tokens=args.max_tokens,
             prompt_regime=build_prompt_regime(args, tokenizer, request),

--- a/tests/test_prefix_cache_integration.py
+++ b/tests/test_prefix_cache_integration.py
@@ -1259,6 +1259,53 @@ class TestContextConfigExposedCorrectly:
         assert flow.hit_tokens == len(prompt)
         assert flow.snapshot is snap
         assert flow.stable_prefix_len == len(prompt)
+        assert flow.lookup_stats.prompt_tokens == len(prompt)
+        assert flow.lookup_stats.stable_prefix_tokens == len(prompt)
+        assert flow.lookup_stats.lookup_tokens == len(prompt)
+        assert flow.lookup_stats.hit_tokens == len(prompt)
+        assert flow.lookup_stats.hit_kind == "exact"
+        assert flow.lookup_stats.snapshot_tokens == len(prompt)
+        assert flow.lookup_stats.snapshot_kind == "prefill"
+        assert flow.lookup_stats.snapshot_nbytes == snap.nbytes
+        assert flow.lookup_stats.snapshot_has_last_logits is True
+
+    def test_prefix_flow_lookup_records_miss(self, monkeypatch):
+        import dflash_mlx.server.prefix_cache_flow as flow_mod
+
+        cache = DFlashPrefixCache(max_entries=4)
+        key = _make_key(
+            target_model_id="target/x",
+            draft_model_id="draft/y",
+            capture_layer_ids=(3, 7),
+        )
+        prompt = [11, 12, 13, 14]
+
+        monkeypatch.setattr(
+            flow_mod,
+            "get_runtime_cache_manager",
+            lambda _runtime_context, *, cache_identity=None: _manager(cache),
+        )
+        monkeypatch.setattr(flow_mod, "build_prefix_key", lambda *_args: key)
+
+        flow = flow_mod.PrefixCacheFlow.for_request(
+            model_provider=_FakeLoadedProvider(),
+            draft_model=_FakeDraft(),
+            tokenizer=_FakeTokenizer(),
+            prompt=prompt,
+            runtime_context=_runtime_context(prefix_cache=True),
+        )
+
+        assert flow.cache_active
+        assert flow.hit_tokens == 0
+        assert flow.snapshot is None
+        assert flow.lookup_stats.prompt_tokens == len(prompt)
+        assert flow.lookup_stats.lookup_tokens == len(prompt)
+        assert flow.lookup_stats.hit_tokens == 0
+        assert flow.lookup_stats.hit_kind == "miss"
+        assert flow.lookup_stats.snapshot_tokens == 0
+        assert flow.lookup_stats.snapshot_kind is None
+        assert flow.lookup_stats.snapshot_nbytes == 0
+        assert flow.lookup_stats.snapshot_has_last_logits is False
 
     def test_prefix_flow_keeps_generation_snapshots_for_tool_chat(self, monkeypatch):
         import dflash_mlx.server.prefix_cache_flow as flow_mod
@@ -1334,6 +1381,12 @@ class TestContextConfigExposedCorrectly:
         assert flow.hit_tokens == len(prompt)
         assert flow.snapshot is not None
         assert flow.lookup_ms == 0.25
+        assert flow.lookup_stats.lookup_ms == 0.25
+        assert flow.lookup_stats.hit_tokens == len(prompt)
+        assert flow.lookup_stats.hit_kind == "exact"
+        assert flow.lookup_stats.snapshot_tokens == len(prompt)
+        assert flow.lookup_stats.snapshot_nbytes == flow.snapshot.nbytes
+        assert flow.lookup_stats.snapshot_has_last_logits is True
         assert flow.snapshot_service is None
 
     def test_prefix_flow_treats_retired_lookup_manager_as_inactive(self, monkeypatch):

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -385,6 +385,7 @@ def test_finalize_request_observability_records_all_outputs(tmp_path, monkeypatc
         cache_lookup_ms=0.25,
         cache_hit_tokens=0,
         cache_insert_ms=0.5,
+        cache_lookup_stats={"hit_kind": "miss", "lookup_tokens": 8},
         finish_reason="stop",
         max_tokens=16,
         prompt_regime={"request_type": "chat"},
@@ -411,6 +412,7 @@ def test_finalize_request_observability_records_all_outputs(tmp_path, monkeypatc
     assert post["prefill_tok_s_restored"] == 0.0
     assert post["decode_tok_s"] == 2.0
     assert post["cache_status"] == "COLD"
+    assert post["cache_lookup"] == {"hit_kind": "miss", "lookup_tokens": 8}
     assert post["prefill_event"]["physical_prefill_tokens"] == 8
     assert post["memory_waterfall_peak"]["mlx_active_gb"] == 6.0
     summary = (tmp_path / "summary.md").read_text()
@@ -418,6 +420,7 @@ def test_finalize_request_observability_records_all_outputs(tmp_path, monkeypatc
     payload = get_live_metrics_payload()
     assert payload["last_request"]["request_id"] == 10
     assert payload["last_request"]["generated_tokens"] == 4
+    assert payload["last_request"]["cache_lookup"] == {"hit_kind": "miss", "lookup_tokens": 8}
     err = capsys.readouterr().err
     assert (
         "decode 2.0 tok/s | prefill logical 8.0 tok/s | "

--- a/tests/test_server_request_loop.py
+++ b/tests/test_server_request_loop.py
@@ -284,7 +284,12 @@ def test_consume_dflash_events_updates_live_cycle_metrics_before_summary(monkeyp
 
 
 def test_consume_dflash_events_ignores_snapshot_publication_metadata():
-    prefix_flow = SimpleNamespace(lookup_ms=0.1, hit_tokens=2, insert_ms=0.5)
+    prefix_flow = SimpleNamespace(
+        lookup_ms=0.1,
+        hit_tokens=2,
+        insert_ms=0.5,
+        lookup_stats={"hit_kind": "exact", "snapshot_tokens": 3},
+    )
     rqueue = SimpleQueue()
     events = ClosableEvents(
         [
@@ -333,6 +338,7 @@ def test_consume_dflash_events_ignores_snapshot_publication_metadata():
     assert result.cache_lookup_ms == 0.1
     assert result.cache_hit_tokens == 2
     assert result.cache_insert_ms == 0.5
+    assert result.cache_lookup_stats == {"hit_kind": "exact", "snapshot_tokens": 3}
 
 
 def test_consume_dflash_events_rejects_stale_dict_events():


### PR DESCRIPTION
## Summary
- Add request-level prefix-cache lookup diagnostics to DFlash observability payloads.
- Preserve lookup stats after prefix-cache manager retirement so hot-hit regressions are visible in traces and metrics.
- Include hit kind, lookup token counts, snapshot metadata, lookup timing, and last-logits availability in request observability.

## Environment
- macOS Darwin 25.4.0 arm64
- Apple M1 Max, 32 GB unified memory
- Local DFlash / MLX Python environment on Apple Silicon

## Real-weight runs

This PR is observability-only and does not change the DFlash decode algorithm. The real-weight runs below validate that the instrumentation path works on normal model weights and record the runtime context in which diagnostics are emitted.

### Smoke baseline vs DFlash

Command shape: `dflash_mlx.benchmark --suite smoke --model Qwen/Qwen3.5-4B --draft z-lab/Qwen3.5-4B-DFlash --max-tokens 32 --repeat 1 --cooldown 0 --no-eos`.

| Metric | Baseline MLX | DFlash |
| --- | ---: | ---: |
| Generation TPS median | 35.77 tok/s | 32.78 tok/s |
| Prefill TPS median | 34.20 tok/s | 60.86 tok/s physical / 60.86 apparent |
| Acceptance median | n/a | 0.875 |
| Peak memory median | 8.49 GB | 9.68 GB |
| End physical footprint | 8.77 GB | 10.03 GB |

### Long-context DFlash-only run

Command shape: `dflash_mlx.benchmark --suite longctx --ctx-tokens 50000 --model Qwen/Qwen3.5-4B --draft z-lab/Qwen3.5-4B-DFlash --max-tokens 5000 --repeat 1 --cooldown 0 --no-eos --only-dflash`.

| Metric | DFlash |
| --- | ---: |
| Logical context tokens | 54,579 |
| Generated tokens | 5,000 |
| TTFT | 92.56s |
| Generation TPS | 36.63 tok/s |
| Prefill TPS | 590.16 tok/s physical / 590.16 apparent |
| Acceptance ratio | 0.7926 |
| Accepted from draft | 3,963 tokens |
| Cycles | 1,037 |
| Peak memory | 15.64 GB |
| End physical footprint | 13.86 GB |

No speedup claim is made from the long-context DFlash-only run because the baseline leg was intentionally skipped for runtime. The smoke run provides the baseline-vs-DFlash comparison; the long run validates observability on a realistic long-context DFlash request.

## Test plan
- `pytest tests/test_prefix_cache_integration.py tests/test_server_request_loop.py tests/test_server_metrics.py -q`
- Real Qwen3.5-4B smoke benchmark above
- Real Qwen3.5-4B DFlash-only 50K/5K long-context benchmark above