### PR TITLE
perf: replace copyspec one-strike disable with cooldown gate (+17% on edit workloads)

### DIFF
--- a/dflash_mlx/engine/copyspec.py
+++ b/dflash_mlx/engine/copyspec.py
@@ -7,10 +7,64 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 COPYSPEC_WINDOW_SIZE = 6
+COPYSPEC_MISS_LIMIT = 3
+COPYSPEC_COOLDOWN_BLOCKS = 64
 
 _FNV_OFFSET_BASIS = 14695981039346656037
 _FNV_PRIME = 1099511628211
 _U64_MASK = (1 << 64) - 1
+
+
+class CopySpecGate:
+    """Tolerance gate deciding whether copyspec drafting may run.
+
+    Replaces the previous one-strike permanent disable. Copyspec pauses
+    only after ``miss_limit`` consecutive zero-acceptance copy blocks,
+    and then only for ``cooldown_blocks`` draft cycles before probing
+    again. An accepted copy block fully restores the miss tolerance, so
+    a few coincidental window matches early in a generation (e.g. during
+    a reasoning phase) no longer forfeit copy drafting for the rest of
+    the request when the output later turns copy-heavy.
+    """
+
+    def __init__(
+        self,
+        *,
+        miss_limit: int = COPYSPEC_MISS_LIMIT,
+        cooldown_blocks: int = COPYSPEC_COOLDOWN_BLOCKS,
+    ) -> None:
+        if miss_limit <= 0:
+            raise ValueError("copyspec miss_limit must be positive")
+        if cooldown_blocks <= 0:
+            raise ValueError("copyspec cooldown_blocks must be positive")
+        self.miss_limit = int(miss_limit)
+        self.cooldown_blocks = int(cooldown_blocks)
+        self._consecutive_misses = 0
+        self._cooldown_remaining = 0
+
+    @property
+    def enabled(self) -> bool:
+        """Non-consuming view of the gate state (for tests/diagnostics)."""
+        return self._cooldown_remaining == 0
+
+    def should_attempt(self) -> bool:
+        """Whether copyspec may draft this cycle. Ticks the cooldown."""
+        if self._cooldown_remaining > 0:
+            self._cooldown_remaining -= 1
+            return False
+        return True
+
+    def record_block(self, accepted_tokens: int) -> None:
+        if int(accepted_tokens) > 0:
+            self._consecutive_misses = 0
+            return
+        self._consecutive_misses += 1
+        if self._consecutive_misses >= self.miss_limit:
+            self._cooldown_remaining = self.cooldown_blocks
+            # Leave one remaining strike so a failed post-cooldown probe
+            # re-enters cooldown immediately instead of burning the full
+            # miss budget again.
+            self._consecutive_misses = self.miss_limit - 1
 
 
 class CopySpecIndex:

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -21,7 +21,7 @@ from dflash_mlx.cache.snapshot import (
 )
 from dflash_mlx.draft_backend import DraftBackend
 from dflash_mlx.engine.acceptance import match_acceptance_length as _match_acceptance_length
-from dflash_mlx.engine.copyspec import CopySpecIndex
+from dflash_mlx.engine.copyspec import CopySpecGate, CopySpecIndex
 from dflash_mlx.engine.ddtree import (
     build_flat_ddtree,
     build_flat_tree_inputs,
@@ -1089,7 +1089,7 @@ class SpeculativeSession:
             block_len: int,
             draft_context: mx.array,
         ) -> mx.array | None:
-            if state.copyspec_disabled:
+            if not state.copyspec_gate.should_attempt():
                 return None
             candidate = self.copyspec_index.draft_after(
                 int(staged_first.item()),
@@ -1597,8 +1597,7 @@ class SpeculativeSession:
             if best.source == "copyspec":
                 copyspec_hits_total += 1
                 copyspec_tokens_total += copyspec_tokens_cycle or max(0, int(block_len) - 1)
-                if acceptance_len == 0:
-                    state.copyspec_disabled = True
+                state.copyspec_gate.record_block(acceptance_len)
             if profile_cycles:
                 acceptance_cycle_ns = time.perf_counter_ns() - acceptance_start_ns
 
@@ -1864,7 +1863,7 @@ class SpeculativeSession:
             block_len: int,
             draft_context: mx.array,
         ) -> mx.array | None:
-            if state.copyspec_disabled:
+            if not state.copyspec_gate.should_attempt():
                 return None
             candidate = self.copyspec_index.draft_after(
                 int(staged_first.item()),
@@ -2124,8 +2123,7 @@ class SpeculativeSession:
             if draft_source == "copyspec":
                 state.copyspec_hits += 1
                 state.copyspec_tokens += copyspec_tokens or max(0, int(block_len) - 1)
-                if acceptance_len == 0:
-                    state.copyspec_disabled = True
+                state.copyspec_gate.record_block(acceptance_len)
             staged_first_next = posterior[acceptance_len : acceptance_len + 1]
             if adaptive_block_policy is not None:
                 cycle_wall_ns = time.perf_counter_ns() - cycle_start_ns
@@ -2450,7 +2448,7 @@ class _RequestState:
     prefetched_draft: dict[str, Any] | None = None
     copyspec_hits: int = 0
     copyspec_tokens: int = 0
-    copyspec_disabled: bool = False
+    copyspec_gate: CopySpecGate = field(default_factory=CopySpecGate)
 
 
 @dataclass

--- a/dflash_mlx/generate.py
+++ b/dflash_mlx/generate.py
@@ -108,14 +108,22 @@ def run_generate(
     if summary is None:
         return 1
 
+    sys.stderr.write(f"\n{format_generation_summary(summary)}\n")
+    sys.stderr.flush()
+    return 0
+
+def format_generation_summary(summary: SummaryEvent) -> str:
     tps = generation_tps_from_summary(summary)
     acceptance_pct = float(summary.acceptance_ratio) * 100.0
     token_count = int(summary.generation_tokens)
-    sys.stderr.write(
-        f"\n{token_count} tokens | {tps:.1f} tok/s | {acceptance_pct:.1f}% acceptance\n"
-    )
-    sys.stderr.flush()
-    return 0
+    line = f"{token_count} tokens | {tps:.1f} tok/s | {acceptance_pct:.1f}% acceptance"
+    copyspec_hits = int(summary.copyspec_hits)
+    if copyspec_hits > 0:
+        line += (
+            f" | copyspec {copyspec_hits} blocks"
+            f" / {int(summary.copyspec_tokens)} tokens"
+        )
+    return line
 
 def main(argv: Sequence[str] | None = None, *, prog: str | None = None) -> None:
     apply_metal_limits()

--- a/tests/test_copyspec.py
+++ b/tests/test_copyspec.py
@@ -47,3 +47,104 @@ def test_copyspec_skips_forbidden_tokens() -> None:
 def test_copyspec_rejects_invalid_window_size() -> None:
     with pytest.raises(ValueError, match="window_size"):
         CopySpecIndex([1, 2, 3], window_size=0)
+
+
+def test_copyspec_gate_starts_enabled() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate()
+
+    assert gate.enabled
+    assert gate.should_attempt()
+
+
+def test_copyspec_gate_tolerates_misses_below_limit() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate(miss_limit=3, cooldown_blocks=4)
+    gate.record_block(0)
+    gate.record_block(0)
+
+    assert gate.should_attempt()
+
+
+def test_copyspec_gate_enters_cooldown_after_consecutive_misses() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate(miss_limit=3, cooldown_blocks=4)
+    for _ in range(3):
+        gate.record_block(0)
+
+    assert not gate.enabled
+    assert not gate.should_attempt()
+
+
+def test_copyspec_gate_accepted_block_resets_miss_count() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate(miss_limit=3, cooldown_blocks=4)
+    gate.record_block(0)
+    gate.record_block(0)
+    gate.record_block(5)
+    gate.record_block(0)
+    gate.record_block(0)
+
+    assert gate.should_attempt()
+
+
+def test_copyspec_gate_reenables_after_cooldown() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate(miss_limit=3, cooldown_blocks=4)
+    for _ in range(3):
+        gate.record_block(0)
+
+    for _ in range(4):
+        assert not gate.should_attempt()
+
+    assert gate.should_attempt()
+
+
+def test_copyspec_gate_probe_miss_reenters_cooldown() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate(miss_limit=3, cooldown_blocks=4)
+    for _ in range(3):
+        gate.record_block(0)
+    for _ in range(4):
+        gate.should_attempt()
+    assert gate.should_attempt()
+
+    gate.record_block(0)
+
+    assert not gate.should_attempt()
+
+
+def test_copyspec_gate_probe_accept_fully_restores_tolerance() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    gate = CopySpecGate(miss_limit=3, cooldown_blocks=4)
+    for _ in range(3):
+        gate.record_block(0)
+    for _ in range(4):
+        gate.should_attempt()
+    gate.record_block(10)
+
+    gate.record_block(0)
+    gate.record_block(0)
+
+    assert gate.should_attempt()
+
+
+def test_copyspec_gate_rejects_invalid_miss_limit() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    with pytest.raises(ValueError, match="miss_limit"):
+        CopySpecGate(miss_limit=0)
+
+
+def test_copyspec_gate_rejects_invalid_cooldown() -> None:
+    from dflash_mlx.engine.copyspec import CopySpecGate
+
+    with pytest.raises(ValueError, match="cooldown_blocks"):
+        CopySpecGate(cooldown_blocks=0)

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from dflash_mlx.engine.events import SummaryEvent
+from dflash_mlx.generate import format_generation_summary
+
+
+def _summary(**overrides: Any) -> SummaryEvent:
+    defaults: dict[str, Any] = dict(
+        elapsed_us=2_000_000.0,
+        prompt_token_count=10,
+        generated_token_ids=(),
+        generation_tokens=100,
+        accepted_from_draft=75,
+        acceptance_ratio=0.75,
+        cycles_completed=25,
+        phase_timings_us={"prefill": 1_000_000.0},
+    )
+    defaults.update(overrides)
+    return SummaryEvent(**defaults)
+
+
+def test_summary_line_without_copyspec() -> None:
+    line = format_generation_summary(_summary())
+
+    assert line == "100 tokens | 100.0 tok/s | 75.0% acceptance"
+
+
+def test_summary_line_includes_copyspec_when_active() -> None:
+    line = format_generation_summary(
+        _summary(copyspec_hits=4, copyspec_tokens=60)
+    )
+
+    assert line == (
+        "100 tokens | 100.0 tok/s | 75.0% acceptance"
+        " | copyspec 4 blocks / 60 tokens"
+    )


### PR DESCRIPTION
## Summary

Fixes the copyspec one-strike kill switch that effectively disables prompt-lookup drafting on reasoning models (full diagnosis in #35). A single zero-acceptance copy block set `state.copyspec_disabled = True` permanently for the request — and on Qwen3.6-style thinking models that almost always happens within the first ~50 tokens of the reasoning phase, before the copy-heavy part of the answer begins.

**Measured impact on a code-edit workload: copyspec goes from drafting 1 block per 3072 tokens to drafting 51% of all generated tokens, +16.8% end-to-end throughput, with no regression on non-copyable output.**

## Changes

- **`CopySpecGate`** (new, in `engine/copyspec.py`): copyspec pauses only after **3 consecutive** zero-acceptance copy blocks, and only for a **64-draft-cycle cooldown**, then probes again. An accepted copy block fully restores the miss tolerance; a failed post-cooldown probe re-enters cooldown immediately. Worst-case overhead on never-copyable output is ~1 dud block per 65 draft cycles.
- `spec_epoch.py`: `copyspec_disabled: bool` → `copyspec_gate: CopySpecGate`; the two check sites use `gate.should_attempt()`, the two record sites use `gate.record_block(acceptance_len)`.
- `generate.py`: summary line now reports copyspec activity when present — `… | copyspec 161 blocks / 1583 tokens` — so gate behaviour is visible to users (extracted `format_generation_summary()` for testability).
- Tests: 9 new gate tests + 2 summary-line tests. Full suite: **1098 passed, 6 skipped**.

## Benchmarks

M5 32 GB, `mlx-community/Qwen3.6-35B-A3B-4bit` + `z-lab/Qwen3.6-35B-A3B-DFlash`, greedy, 3072 generated tokens, identical harness/prompts/machine on both sides (this branch vs `main` @ 8a0e5fb).

**Code-edit prompt** (model re-emits a ~100-line Python file with a small refactor — the copyspec-favourable case):

| | tok/s | acceptance | tokens/cycle | copyspec |
|---|---|---|---|---|
| main | 78.1 | 78.3% | 4.61 | 1 block / 15 tokens (0.5%) |
| this PR | **91.2** | **81.8%** | **5.50** | 161 blocks / 1,583 tokens (51.5%) |

**Fresh-code prompt** (write a rate limiter from scratch — nothing to copy from input):

| | tok/s | acceptance | copyspec |
|---|---|---|---|
| main | 62.7 | 70.7% | 7 blocks / 21 tokens |
| this PR | 64.5 | 69.0% | 144 blocks / 540 tokens |

No regression on the unfavourable case (the small gain comes from code's natural self-repetition — imports, signatures, the usage example).

Diagnostic ceiling: with the gate forced permanently open, the edit task reaches 94.1 tok/s — the cooldown design captures ~97% of that while keeping waste bounded.

## Notes

- Defaults (`COPYSPEC_MISS_LIMIT = 3`, `COPYSPEC_COOLDOWN_BLOCKS = 64`) are conservative; happy to tune or expose them if you'd prefer.
- The window-size knob discussed in #35 is intentionally left out to keep this focused; the offline replay there suggests `w=8` halves dud blocks for ~7% fewer useful tokens if you want a follow-up.

Refs #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
