### PR TITLE
perf(cache): accelerate reusable DFlash prefix snapshots

### DIFF
--- a/dflash_mlx/cache/codecs.py
+++ b/dflash_mlx/cache/codecs.py
@@ -11,7 +11,11 @@ import mlx.core as mx
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
-from dflash_mlx.cache.snapshot import DFlashPrefixSnapshot, FAState
+from dflash_mlx.cache.snapshot import (
+    DFlashPrefixSnapshot,
+    FAState,
+    TargetHiddenChunks,
+)
 from dflash_mlx.engine.config import _effective_draft_window_size
 from dflash_mlx.recurrent_rollback_cache import RecurrentRollbackCache
 
@@ -58,8 +62,17 @@ def _requires_full_target_hidden(
     layer_types = tuple(str(kind) for kind in (getattr(args, "layer_types", ()) or ()))
     return any(kind == "full_attention" for kind in layer_types)
 
+def _target_hidden_slice(
+    target_hidden: mx.array | TargetHiddenChunks,
+    start: int,
+    end: int,
+) -> mx.array:
+    if isinstance(target_hidden, TargetHiddenChunks):
+        return target_hidden.slice(start, end)
+    return target_hidden[:, start:end, :]
+
 def _build_target_hidden_chunks(
-    target_hidden: mx.array,
+    target_hidden: mx.array | TargetHiddenChunks,
     *,
     draft_model: Optional[Any] = None,
     trim_target_hidden: bool = True,
@@ -69,7 +82,7 @@ def _build_target_hidden_chunks(
 ) -> tuple[tuple[mx.array, ...], tuple[tuple[int, int], ...], int]:
     total_len = int(target_hidden.shape[1])
     if not trim_target_hidden:
-        full = _clone_array(target_hidden)
+        full = _clone_array(_target_hidden_slice(target_hidden, 0, total_len))
         assert full is not None
         return (full,), ((0, total_len),), total_len
     sink, window = _resolve_effective_trim_window(
@@ -80,11 +93,13 @@ def _build_target_hidden_chunks(
         allow_full_attention_context=allow_full_attention_context,
     )
     if total_len <= sink + window or sink + window == 0:
-        full = _clone_array(target_hidden)
+        full = _clone_array(_target_hidden_slice(target_hidden, 0, total_len))
         assert full is not None
         return (full,), ((0, total_len),), total_len
-    sink_chunk = _clone_array(target_hidden[:, :sink, :])
-    tail_chunk = _clone_array(target_hidden[:, total_len - window :, :])
+    sink_chunk = _clone_array(_target_hidden_slice(target_hidden, 0, sink))
+    tail_chunk = _clone_array(
+        _target_hidden_slice(target_hidden, total_len - window, total_len)
+    )
     assert sink_chunk is not None and tail_chunk is not None
     return (
         (sink_chunk, tail_chunk),
@@ -215,7 +230,7 @@ def build_snapshot(
     *,
     token_ids: list[int],
     target_cache: list[Any],
-    target_hidden: mx.array,
+    target_hidden: mx.array | TargetHiddenChunks,
     last_logits: Optional[mx.array],
     key: DFlashPrefixKey,
     kind: str = "prefill",
@@ -234,7 +249,25 @@ def build_snapshot(
             f"< token prefix length {prefix_len}"
         )
     if hidden_len > prefix_len:
-        target_hidden = target_hidden[:, :prefix_len, :]
+        if isinstance(target_hidden, TargetHiddenChunks):
+            target_hidden = TargetHiddenChunks(
+                total_len=prefix_len,
+                chunks=tuple(
+                    chunk[:, : max(0, min(end, prefix_len) - start), :]
+                    for chunk, (start, end) in zip(
+                        target_hidden.chunks,
+                        target_hidden.spans,
+                    )
+                    if start < prefix_len
+                ),
+                spans=tuple(
+                    (start, min(end, prefix_len))
+                    for start, end in target_hidden.spans
+                    if start < prefix_len
+                ),
+            )
+        else:
+            target_hidden = target_hidden[:, :prefix_len, :]
 
     fa, gdn = serialize_target_cache(target_cache)
     _validate_snapshot_cache_prefix_len(fa, prefix_len=prefix_len)
@@ -272,7 +305,7 @@ class PrefixSnapshotBuilder:
         *,
         token_ids: list[int],
         target_cache: list[Any],
-        target_hidden: mx.array,
+        target_hidden: mx.array | TargetHiddenChunks,
         last_logits: Optional[mx.array],
         kind: str,
         allow_full_attention_context: bool = False,

--- a/dflash_mlx/cache/manager.py
+++ b/dflash_mlx/cache/manager.py
@@ -8,7 +8,9 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Literal, Optional
+
+HitKind = Literal["miss", "l1_exact", "l1_prefix", "l2_exact", "l2_prefix"]
 
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 from dflash_mlx.cache.prefix_l1 import DFlashPrefixCache
@@ -27,6 +29,7 @@ class PrefixCacheLookupResult:
     matched_tokens: int
     snapshot: Optional[DFlashPrefixSnapshot]
     elapsed_ms: float
+    hit_kind: HitKind = "miss"
 
 
 @dataclass(frozen=True)
@@ -94,10 +97,12 @@ class RuntimeCacheManager:
                 key,
                 request_id=request_id,
             )
+            hit_kind: HitKind = self._store._last_hit_kind  # type: ignore[assignment]
         return PrefixCacheLookupResult(
             matched_tokens=int(matched_len),
             snapshot=snapshot,
             elapsed_ms=(time.perf_counter_ns() - lookup_t0) / 1e6,
+            hit_kind=hit_kind,
         )
 
     def maybe_insert_snapshot(

--- a/dflash_mlx/cache/manager.py
+++ b/dflash_mlx/cache/manager.py
@@ -310,7 +310,12 @@ def _prefix_cache_frontier_stride(runtime_config: Any) -> int:
     prefill_step_size = max(0, int(getattr(runtime_config, "prefill_step_size", 0) or 0))
     if prefill_step_size <= 0:
         return 0
-    steps = max(1, (_MIN_L2_FRONTIER_STRIDE + prefill_step_size - 1) // prefill_step_size)
+    configured_stride = max(
+        0,
+        int(getattr(runtime_config, "prefix_cache_l2_frontier_stride", 0) or 0),
+    )
+    requested_stride = max(_MIN_L2_FRONTIER_STRIDE, configured_stride)
+    steps = max(1, (requested_stride + prefill_step_size - 1) // prefill_step_size)
     return int(steps * prefill_step_size)
 
 

--- a/dflash_mlx/cache/prefix_l1.py
+++ b/dflash_mlx/cache/prefix_l1.py
@@ -57,10 +57,18 @@ class DFlashPrefixCache:
             "prefill_tokens_saved": 0,
             "fingerprint_rejects": 0,
         }
+        # Updated on every record=True lookup; "miss" / "l1_exact" / "l1_prefix".
+        # Guarded by _lock; readable via last_hit_kind property.
+        self._last_hit_kind: str = "miss"
 
     @property
     def frontier_stride(self) -> int:
         return int(self._frontier_stride)
+
+    @property
+    def last_hit_kind(self) -> str:
+        with self._lock:
+            return self._last_hit_kind
 
     def lookup(
         self,
@@ -118,8 +126,10 @@ class DFlashPrefixCache:
                         self._lru_order.append(best_id)
                         if exact:
                             self._stats["exact_hits"] += 1
+                            self._last_hit_kind = "l1_exact"
                         else:
                             self._stats["prefix_hits"] += 1
+                            self._last_hit_kind = "l1_prefix"
                         self._stats["prefill_tokens_saved"] += best_len
                         entries_count_log = len(self._entries)
                         self._log_cache(
@@ -137,6 +147,7 @@ class DFlashPrefixCache:
                 return (0, None)
 
             self._stats["misses"] += 1
+            self._last_hit_kind = "miss"
             miss_reason = "empty_cache"
             if self._entries:
                 if saw_fingerprint_reject == len(self._entries):

--- a/dflash_mlx/cache/prefix_l2.py
+++ b/dflash_mlx/cache/prefix_l2.py
@@ -334,6 +334,15 @@ class _WritePayload:
     nbytes: int
     epoch: int
 
+@dataclass(frozen=True)
+class _WriteJob:
+    """Holds pre-eval'd arrays ready for disk write. Created on the request thread."""
+    arrays_mlx: dict
+    meta: dict
+    final_path: Path
+    nbytes: int
+    epoch: int
+
 class DFlashPrefixL2Cache:
 
     def __init__(
@@ -350,7 +359,7 @@ class DFlashPrefixL2Cache:
         self._lock = threading.Lock()
 
         self._writer_slots = threading.Semaphore(self._max_in_flight)
-        self._write_queue: Queue[Optional[_WritePayload]] = Queue()
+        self._write_queue: Queue[Optional[_WriteJob]] = Queue()
         self._epoch = 0
 
         self._tracked_disk_bytes = 0
@@ -501,23 +510,20 @@ class DFlashPrefixL2Cache:
                 self._stats["write_drops_queue_full"] += 1
             return False
         try:
-            payload = self._prepare_payload(snapshot)
-        except OSError as e:
-            if e.errno in (errno.ENOSPC, errno.EDQUOT):
-                _LOG.warning("L2 write skipped (disk full): %s", e)
-                with self._lock:
-                    self._stats["write_errors"] += 1
-            else:
-                _LOG.warning("L2 materialize failed: %s", e)
-                with self._lock:
-                    self._stats["materialize_errors"] += 1
-            self._writer_slots.release()
-            return False
+            arrays_mlx, meta = _serialize(snapshot)
+            _eval_arrays(arrays_mlx)
         except Exception:
             self._writer_slots.release()
             raise
-
-        self._write_queue.put(payload)
+        with self._lock:
+            epoch = self._epoch
+        self._write_queue.put(_WriteJob(
+            arrays_mlx=arrays_mlx,
+            meta=meta,
+            final_path=final_path,
+            nbytes=int(snapshot.nbytes),
+            epoch=epoch,
+        ))
         return True
 
     def stats(self) -> dict[str, Any]:
@@ -553,48 +559,59 @@ class DFlashPrefixL2Cache:
     def _writer_loop(self) -> None:
         while True:
             try:
-                payload = self._write_queue.get(timeout=0.5)
+                job = self._write_queue.get(timeout=0.5)
             except Empty:
                 if self._stop.is_set():
                     break
                 continue
-            if payload is None:
+            if job is None:
                 break
             try:
-                self._write_payload(payload)
-            except Exception as e:
-                _LOG.warning("L2 write failed: %s", e)
                 with self._lock:
-                    self._stats["write_errors"] += 1
+                    if job.epoch != self._epoch:
+                        self._stats["write_drops_epoch_invalidated"] += 1
+                        continue
+                try:
+                    payload = self._write_job_to_disk(job)
+                except OSError as e:
+                    if e.errno in (errno.ENOSPC, errno.EDQUOT):
+                        _LOG.warning("L2 write skipped (disk full): %s", e)
+                        with self._lock:
+                            self._stats["write_errors"] += 1
+                    else:
+                        _LOG.warning("L2 materialize failed: %s", e)
+                        with self._lock:
+                            self._stats["materialize_errors"] += 1
+                    continue
+                try:
+                    self._write_payload(payload)
+                except Exception as e:
+                    _LOG.warning("L2 write failed: %s", e)
+                    with self._lock:
+                        self._stats["write_errors"] += 1
             finally:
-
-                payload = None
+                job = None
                 self._writer_slots.release()
 
-    def _prepare_payload(self, snapshot: DFlashPrefixSnapshot) -> _WritePayload:
-        arrays_mlx, meta = _serialize(snapshot)
-        _eval_arrays(arrays_mlx)
-        final_path = self._final_path_for(snapshot)
-        with self._lock:
-            epoch = self._epoch
-        if final_path.exists():
+    def _write_job_to_disk(self, job: _WriteJob) -> _WritePayload:
+        """Write pre-eval'd arrays to a temp file. Called from the writer thread."""
+        if job.final_path.exists():
             return _WritePayload(
                 tmp_path=None,
-                final_path=final_path,
-                nbytes=int(snapshot.nbytes),
-                epoch=int(epoch),
+                final_path=job.final_path,
+                nbytes=job.nbytes,
+                epoch=job.epoch,
             )
-
-        final_path.parent.mkdir(parents=True, exist_ok=True)
+        job.final_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_name = tempfile.mkstemp(
-            prefix=f".{final_path.stem}.",
+            prefix=f".{job.final_path.stem}.",
             suffix=L2_TMP_SUFFIX,
-            dir=str(final_path.parent),
+            dir=str(job.final_path.parent),
         )
         os.close(tmp_fd)
         tmp_path = Path(tmp_name)
         try:
-            mx.save_safetensors(str(tmp_path), arrays_mlx, metadata=meta)
+            mx.save_safetensors(str(tmp_path), job.arrays_mlx, metadata=job.meta)
         except Exception:
             try:
                 tmp_path.unlink()
@@ -603,9 +620,9 @@ class DFlashPrefixL2Cache:
             raise
         return _WritePayload(
             tmp_path=tmp_path,
-            final_path=final_path,
-            nbytes=int(snapshot.nbytes),
-            epoch=int(epoch),
+            final_path=job.final_path,
+            nbytes=job.nbytes,
+            epoch=job.epoch,
         )
 
     def _write_payload(self, payload: _WritePayload) -> None:

--- a/dflash_mlx/cache/snapshot.py
+++ b/dflash_mlx/cache/snapshot.py
@@ -7,13 +7,103 @@ from __future__ import annotations
 from collections.abc import Sequence
 import time
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 import mlx.core as mx
 
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 
 FAState = tuple[mx.array, mx.array, int] | tuple[mx.array, mx.array, int, int]
+
+@dataclass(frozen=True)
+class TargetHiddenChunks:
+    """Sparse target-hidden spans with their logical sequence length."""
+
+    total_len: int
+    chunks: tuple[mx.array, ...]
+    spans: tuple[tuple[int, int], ...]
+
+    def __post_init__(self) -> None:
+        if not self.chunks:
+            raise ValueError("TargetHiddenChunks requires at least one chunk")
+        if len(self.chunks) != len(self.spans):
+            raise ValueError("TargetHiddenChunks chunks/spans length mismatch")
+        previous_end = 0
+        for chunk, (start, end) in zip(self.chunks, self.spans):
+            if start < 0 or end < start or end > int(self.total_len):
+                raise ValueError(f"Invalid target-hidden span ({start}, {end})")
+            if start < previous_end:
+                raise ValueError("Target-hidden spans must be ordered and non-overlapping")
+            if int(chunk.shape[1]) != end - start:
+                raise ValueError(
+                    f"Target-hidden chunk length {int(chunk.shape[1])} "
+                    f"!= span length {end - start}"
+                )
+            previous_end = end
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        ref = self.chunks[0]
+        return (int(ref.shape[0]), int(self.total_len), int(ref.shape[-1]))
+
+    @property
+    def nbytes(self) -> int:
+        return sum(int(chunk.nbytes) for chunk in self.chunks)
+
+    @property
+    def dtype(self) -> Any:
+        return self.chunks[0].dtype
+
+    def astype(self, dtype: Any) -> "TargetHiddenChunks":
+        if all(chunk.dtype == dtype for chunk in self.chunks):
+            return self
+        return TargetHiddenChunks(
+            total_len=int(self.total_len),
+            chunks=tuple(chunk.astype(dtype) for chunk in self.chunks),
+            spans=self.spans,
+        )
+
+    def slice(self, start: int, end: int) -> mx.array:
+        start = max(0, int(start))
+        end = min(int(self.total_len), int(end))
+        if end < start:
+            raise ValueError(f"Invalid target-hidden slice ({start}, {end})")
+        pieces: list[mx.array] = []
+        cursor = start
+        for chunk, (chunk_start, chunk_end) in zip(self.chunks, self.spans):
+            if chunk_end <= cursor:
+                continue
+            if chunk_start > cursor:
+                break
+            copy_end = min(end, chunk_end)
+            if copy_end > cursor:
+                offset = cursor - chunk_start
+                pieces.append(chunk[:, offset : offset + copy_end - cursor, :])
+                cursor = copy_end
+            if cursor >= end:
+                break
+        if cursor != end:
+            raise ValueError(
+                f"Target-hidden spans do not cover requested slice ({start}, {end})"
+            )
+        if not pieces:
+            ref = self.chunks[0]
+            return mx.zeros(
+                (int(ref.shape[0]), 0, int(ref.shape[-1])),
+                dtype=ref.dtype,
+            )
+        return pieces[0] if len(pieces) == 1 else mx.concatenate(pieces, axis=1)
+
+    def materialize(self) -> mx.array:
+        ref = self.chunks[0]
+        result = mx.zeros(
+            (int(ref.shape[0]), int(self.total_len), int(ref.shape[-1])),
+            dtype=ref.dtype,
+        )
+        for chunk, (start, end) in zip(self.chunks, self.spans):
+            result[:, start:end, :] = chunk
+        mx.eval(result)
+        return result
 
 @dataclass
 class DFlashPrefixSnapshot:

--- a/dflash_mlx/cache/snapshot_service.py
+++ b/dflash_mlx/cache/snapshot_service.py
@@ -12,6 +12,7 @@ import mlx.core as mx
 from dflash_mlx.cache.codecs import PrefixSnapshotBuilder
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 from dflash_mlx.cache.manager import RuntimeCacheManager, RuntimeCacheManagerClosed
+from dflash_mlx.cache.snapshot import TargetHiddenChunks
 
 
 @dataclass(frozen=True)
@@ -86,7 +87,7 @@ class SnapshotService:
         *,
         token_ids: list[int],
         target_cache: list[Any],
-        target_hidden: mx.array | None,
+        target_hidden: mx.array | TargetHiddenChunks | None,
         last_logits: mx.array | None,
         kind: Literal["prefill", "generation"],
         require_logits: bool,

--- a/dflash_mlx/cache/store.py
+++ b/dflash_mlx/cache/store.py
@@ -34,6 +34,11 @@ class PrefixSnapshotStore:
             "l2_prefill_tokens_saved": 0,
         }
         self._trace_config: TraceConfig | None = None
+        # Updated on every lookup to reflect the source of the last hit.
+        # L1 path: propagated from self._l1.last_hit_kind.
+        # L2 path: set directly in _record_l2_hit().
+        # Readable by RuntimeCacheManager while holding _state_lock.
+        self._last_hit_kind: str = "miss"
 
     def set_trace_config(self, trace_config: TraceConfig | None) -> None:
         self._trace_config = trace_config
@@ -114,10 +119,12 @@ class PrefixSnapshotStore:
             else:
                 self._stats["l2_prefix_hits"] += 1
             self._stats["l2_prefill_tokens_saved"] += int(l2_len)
+        self._last_hit_kind = "l2_exact" if exact else "l2_prefix"
         record_cache_event(
             self._trace_config,
             op="lookup",
             result="l2_hit",
+            hit_kind=self._last_hit_kind,
             request_id=request_id,
             req_tokens=len(req_tuple),
             matched_len=int(l2_len),
@@ -135,10 +142,14 @@ class PrefixSnapshotStore:
         request_id: int | None = None,
     ) -> tuple[int, DFlashPrefixSnapshot | None]:
         if request_id is None and record:
-            return self._l1.lookup(req_tuple, key)
-        if request_id is None:
-            return self._l1.lookup(req_tuple, key, record=record)
-        return self._l1.lookup(req_tuple, key, record=record, request_id=request_id)
+            result = self._l1.lookup(req_tuple, key)
+        elif request_id is None:
+            result = self._l1.lookup(req_tuple, key, record=record)
+        else:
+            result = self._l1.lookup(req_tuple, key, record=record, request_id=request_id)
+        if record:
+            self._last_hit_kind = self._l1.last_hit_kind
+        return result
 
     def insert(self, snapshot: DFlashPrefixSnapshot) -> bool:
         inserted_l2_admitted = False

--- a/dflash_mlx/draft_backend.py
+++ b/dflash_mlx/draft_backend.py
@@ -241,6 +241,12 @@ def _draft_compute_dtype(draft_model: DFlashDraftModel) -> Any | None:
 
 
 def _astype_if_needed(value: mx.array, dtype: Any | None) -> mx.array:
-    if dtype is None or value.dtype == dtype:
+    if dtype is None:
+        return value
+    from dflash_mlx.cache.snapshot import TargetHiddenChunks
+
+    if isinstance(value, TargetHiddenChunks):
+        return value.astype(dtype)
+    if value.dtype == dtype:
         return value
     return value.astype(dtype)

--- a/dflash_mlx/engine/events.py
+++ b/dflash_mlx/engine/events.py
@@ -180,6 +180,7 @@ class SummaryEvent:
     copyspec_hits: int = 0
     copyspec_tokens: int = 0
     adaptive_metrics: dict[str, Any] | None = None
+    hit_kind: str = "miss"
 
     def to_payload(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -225,6 +226,7 @@ class SummaryEvent:
             ),
         }
         payload.update({key: value for key, value in optional.items() if value is not None})
+        payload["hit_kind"] = self.hit_kind
         if self.fallback_ar:
             payload["fallback_ar"] = True
             payload["fallback_reason"] = self.fallback_reason

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -17,6 +17,7 @@ from dflash_mlx.cache.codecs import hydrate_target_cache
 from dflash_mlx.cache.snapshot_service import SnapshotPublication, SnapshotService
 from dflash_mlx.cache.snapshot import (
     DFlashPrefixSnapshot,
+    TargetHiddenChunks,
     validate_prefix_snapshot as _validate_prefix_snapshot,
 )
 from dflash_mlx.draft_backend import DraftBackend
@@ -2474,7 +2475,7 @@ def _publish_snapshot_event(
     *,
     token_ids: list[int],
     target_cache: Any,
-    target_hidden: Optional[mx.array],
+    target_hidden: Optional[mx.array | TargetHiddenChunks],
     last_logits: Optional[mx.array],
     snapshot_service: Optional[SnapshotService],
     kind: Literal["prefill", "generation"],

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -96,6 +96,7 @@ class _SessionRequest:
     stable_prefix_len: Optional[int] = None
     prefix_cache_active: bool = False
     publish_generation_snapshot: bool = True
+    prefix_hit_kind: str = "miss"
     prompt_array: mx.array = field(init=False, repr=False)
     prompt_len: int = field(init=False)
     stop_token_array: Optional[mx.array] = field(init=False, repr=False)
@@ -114,6 +115,7 @@ class _SessionRequest:
         stable_prefix_len: Optional[int],
         prefix_cache_active: bool,
         publish_generation_snapshot: bool = True,
+        prefix_hit_kind: str = "miss",
     ) -> "_SessionRequest":
         return cls(
             prompt_tokens=tuple(int(token) for token in prompt_tokens),
@@ -130,6 +132,7 @@ class _SessionRequest:
             stable_prefix_len=stable_prefix_len,
             prefix_cache_active=bool(prefix_cache_active),
             publish_generation_snapshot=bool(publish_generation_snapshot),
+            prefix_hit_kind=str(prefix_hit_kind),
         )
 
     def __post_init__(self) -> None:
@@ -2427,6 +2430,7 @@ class SpeculativeSession:
                 copyspec_hits=int(decode.copyspec_hits),
                 copyspec_tokens=int(decode.copyspec_tokens),
                 adaptive_metrics=decode.adaptive_totals or None,
+                hit_kind=request.prefix_hit_kind,
             )
             yield summary
         finally:
@@ -2533,6 +2537,7 @@ def stream_dflash_generate_impl(
     stable_prefix_len: Optional[int] = None,
     prefix_cache_active: bool = False,
     publish_generation_snapshot: bool = True,
+    prefix_hit_kind: str = "miss",
     runtime_context: Any,
 ) -> Iterator[EngineEvent]:
     target_capabilities = target_ops.capabilities_for(target_model)
@@ -2588,6 +2593,7 @@ def stream_dflash_generate_impl(
         stable_prefix_len=stable_prefix_len,
         prefix_cache_active=prefix_cache_active,
         publish_generation_snapshot=publish_generation_snapshot,
+        prefix_hit_kind=prefix_hit_kind,
     )
 
     session = SpeculativeSession.open(

--- a/dflash_mlx/engine/target_features.py
+++ b/dflash_mlx/engine/target_features.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 
 import mlx.core as mx
 
+from dflash_mlx.cache.snapshot import TargetHiddenChunks
 from dflash_mlx.engine.prefill import init_target_hidden_from_snapshot
 
 
@@ -16,15 +17,15 @@ from dflash_mlx.engine.prefill import init_target_hidden_from_snapshot
 class TargetFeatureStore:
     prompt_len: int
     project_context: Callable[[mx.array], mx.array] | None = None
-    _current_hidden: mx.array | None = None
-    _prefill_hidden_for_snapshot: mx.array | None = None
+    _current_hidden: mx.array | TargetHiddenChunks | None = None
+    _prefill_hidden_for_snapshot: mx.array | TargetHiddenChunks | None = None
     _generation_chunks: list[mx.array] = field(default_factory=list)
 
     @property
-    def current_hidden(self) -> mx.array | None:
+    def current_hidden(self) -> mx.array | TargetHiddenChunks | None:
         return self._current_hidden
 
-    def require_current_hidden(self) -> mx.array:
+    def require_current_hidden(self) -> mx.array | TargetHiddenChunks:
         if self._current_hidden is None:
             raise RuntimeError("target hidden features are unavailable")
         return self._current_hidden
@@ -38,12 +39,19 @@ class TargetFeatureStore:
         prefix_snapshot: Any,
         *,
         snap_prefix_len: int,
-    ) -> mx.array:
-        self._current_hidden = init_target_hidden_from_snapshot(
-            prefix_snapshot,
-            snap_prefix_len=int(snap_prefix_len),
-            prompt_len=int(self.prompt_len),
-        )
+    ) -> mx.array | TargetHiddenChunks:
+        if int(snap_prefix_len) == int(self.prompt_len):
+            self._current_hidden = TargetHiddenChunks(
+                total_len=int(snap_prefix_len),
+                chunks=tuple(prefix_snapshot.target_hidden_chunks),
+                spans=tuple(prefix_snapshot.target_hidden_chunk_spans),
+            )
+        else:
+            self._current_hidden = init_target_hidden_from_snapshot(
+                prefix_snapshot,
+                snap_prefix_len=int(snap_prefix_len),
+                prompt_len=int(self.prompt_len),
+            )
         return self._current_hidden
 
     def write_prompt_slice(
@@ -59,6 +67,8 @@ class TargetFeatureStore:
                 (features.shape[0], int(self.prompt_len), features.shape[-1]),
                 dtype=features.dtype,
             )
+        elif isinstance(self._current_hidden, TargetHiddenChunks):
+            self._current_hidden = self._current_hidden.materialize()
         self._current_hidden[:, int(start):int(end), :] = features
         mx.eval(self._current_hidden)
         return self._current_hidden
@@ -66,6 +76,8 @@ class TargetFeatureStore:
     def prefix_view(self, boundary: int) -> mx.array | None:
         if self._current_hidden is None:
             return None
+        if isinstance(self._current_hidden, TargetHiddenChunks):
+            return self._current_hidden.slice(0, int(boundary))
         return self._current_hidden[:, :int(boundary), :]
 
     def freeze_prefill_for_snapshot(self, *, enabled: bool) -> None:
@@ -82,7 +94,7 @@ class TargetFeatureStore:
         if collect_snapshot:
             self._generation_chunks.append(committed_hidden)
 
-    def generation_snapshot_hidden(self) -> mx.array | None:
+    def generation_snapshot_hidden(self) -> mx.array | TargetHiddenChunks | None:
         if self._prefill_hidden_for_snapshot is None or not self._generation_chunks:
             return None
         gen_hidden = (
@@ -90,6 +102,20 @@ class TargetFeatureStore:
             if len(self._generation_chunks) == 1
             else mx.concatenate(self._generation_chunks, axis=1)
         )
+        if isinstance(self._prefill_hidden_for_snapshot, TargetHiddenChunks):
+            prefill = self._prefill_hidden_for_snapshot
+            generated_len = int(gen_hidden.shape[1])
+            return TargetHiddenChunks(
+                total_len=int(prefill.total_len) + generated_len,
+                chunks=(*prefill.chunks, gen_hidden),
+                spans=(
+                    *prefill.spans,
+                    (
+                        int(prefill.total_len),
+                        int(prefill.total_len) + generated_len,
+                    ),
+                ),
+            )
         hidden = mx.concatenate([self._prefill_hidden_for_snapshot, gen_hidden], axis=1)
         mx.eval(hidden)
         return hidden

--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -353,14 +353,28 @@ class DFlashAttention(nn.Module):
 
     def _context_segments_for_cache(
         self,
-        target_hidden: mx.array,
+        target_hidden: Any,
         cache: Any,
     ) -> tuple[mx.array, list[tuple[int, int]]]:
+        from dflash_mlx.cache.snapshot import TargetHiddenChunks
+
+        is_chunks = isinstance(target_hidden, TargetHiddenChunks)
+        total_len = int(target_hidden.shape[1])
         if not isinstance(cache, ContextOnlyDraftKVCache):
-            return target_hidden, [(0, int(target_hidden.shape[1]))]
-        spans = cache.context_spans_to_append(int(target_hidden.shape[1]))
+            if is_chunks:
+                return target_hidden.slice(0, total_len), [(0, total_len)]
+            return target_hidden, [(0, total_len)]
+        spans = cache.context_spans_to_append(total_len)
         if not spans:
+            if is_chunks:
+                return target_hidden.slice(0, 0), []
             return target_hidden[:, :0, :], []
+        if is_chunks:
+            pieces = [target_hidden.slice(start, end) for start, end in spans]
+            return (
+                pieces[0] if len(pieces) == 1 else mx.concatenate(pieces, axis=1),
+                spans,
+            )
         if len(spans) == 1:
             start, end = spans[0]
             return target_hidden[:, start:end, :], spans

--- a/dflash_mlx/runtime/__init__.py
+++ b/dflash_mlx/runtime/__init__.py
@@ -60,6 +60,7 @@ def stream_dflash_generate(
     stable_prefix_len: int | None = None,
     prefix_cache_active: bool = False,
     publish_generation_snapshot: bool = True,
+    prefix_hit_kind: str = "miss",
     runtime_context: Any = None,
 ) -> Iterator[EngineEvent]:
     if runtime_context is None:
@@ -95,5 +96,6 @@ def stream_dflash_generate(
             stable_prefix_len=stable_prefix_len,
             prefix_cache_active=prefix_cache_active,
             publish_generation_snapshot=publish_generation_snapshot,
+            prefix_hit_kind=prefix_hit_kind,
             runtime_context=runtime_context,
         )

--- a/dflash_mlx/runtime/config.py
+++ b/dflash_mlx/runtime/config.py
@@ -71,6 +71,7 @@ class EffectiveRuntimeConfig:
     target_fa_window: int
     dflash_max_ctx: int
     verify_mode: str
+    prefix_cache_l2_frontier_stride: int
 
 DEFAULT_RUNTIME_CONFIG = EffectiveRuntimeConfig(
     prefill_step_size=2048,
@@ -88,6 +89,7 @@ DEFAULT_RUNTIME_CONFIG = EffectiveRuntimeConfig(
     target_fa_window=0,
     dflash_max_ctx=0,
     verify_mode="adaptive",
+    prefix_cache_l2_frontier_stride=0,
 )
 
 @dataclass(frozen=True)
@@ -239,6 +241,18 @@ RUNTIME_CONFIG_FIELDS: tuple[RuntimeConfigFieldSpec, ...] = (
             "Accepts raw bytes or suffixes like 50GB."
         ),
         metavar="BYTES",
+    ),
+    RuntimeConfigFieldSpec(
+        field="prefix_cache_l2_frontier_stride",
+        flags=("--prefix-cache-l2-frontier-stride",),
+        env="DFLASH_PREFIX_CACHE_L2_FRONTIER_STRIDE",
+        value_type=int,
+        help=(
+            "Token stride at which L2 frontier snapshots are written during cold "
+            "prefill. 0 = auto (default: 8192, rounded up to a prefill-step "
+            "multiple). Values below 8192 are raised to the disk-pressure floor."
+        ),
+        metavar="INT",
     ),
     RuntimeConfigFieldSpec(
         field="prefix_cache",
@@ -394,6 +408,7 @@ def runtime_config_from_defaults(
     target_fa_window: int = 0,
     dflash_max_ctx: int = 0,
     verify_mode: str | None = None,
+    prefix_cache_l2_frontier_stride: int | None = None,
 ) -> EffectiveRuntimeConfig:
     defaults = DEFAULT_RUNTIME_CONFIG
     return validate_runtime_config(
@@ -455,6 +470,11 @@ def runtime_config_from_defaults(
             target_fa_window=int(target_fa_window),
             dflash_max_ctx=int(dflash_max_ctx),
             verify_mode=defaults.verify_mode if verify_mode is None else str(verify_mode),
+            prefix_cache_l2_frontier_stride=(
+                defaults.prefix_cache_l2_frontier_stride
+                if prefix_cache_l2_frontier_stride is None
+                else int(prefix_cache_l2_frontier_stride)
+            ),
         )
     )
 
@@ -532,6 +552,11 @@ def resolve_runtime_config(args: Any) -> EffectiveRuntimeConfig:
             0,
         ),
         verify_mode=_resolve_verify_mode(getattr(args, "verify_mode", None), defaults.verify_mode),
+        prefix_cache_l2_frontier_stride=_resolve_int(
+            getattr(args, "prefix_cache_l2_frontier_stride", None),
+            _runtime_env("prefix_cache_l2_frontier_stride"),
+            defaults.prefix_cache_l2_frontier_stride,
+        ),
     )
 
 def runtime_config_sources(args: Any, cfg: EffectiveRuntimeConfig) -> dict[str, str]:
@@ -571,6 +596,11 @@ def validate_runtime_config(cfg: EffectiveRuntimeConfig) -> EffectiveRuntimeConf
         raise ValueError("--target-fa-window / target_fa_window must be >= 0")
     if cfg.dflash_max_ctx < 0:
         raise ValueError("--dflash-max-ctx / dflash_max_ctx must be >= 0")
+    if cfg.prefix_cache_l2_frontier_stride < 0:
+        raise ValueError(
+            "--prefix-cache-l2-frontier-stride / "
+            "prefix_cache_l2_frontier_stride must be >= 0"
+        )
     if cfg.verify_mode not in ("dflash", "adaptive", "ddtree", "off"):
         raise ValueError(
             "--verify-mode / verify_mode must be dflash, adaptive, ddtree, or off"

--- a/dflash_mlx/server/prefix_cache_flow.py
+++ b/dflash_mlx/server/prefix_cache_flow.py
@@ -83,6 +83,7 @@ class PrefixCacheFlow:
     snapshot: Optional[DFlashPrefixSnapshot] = None
     lookup_ms: float = 0.0
     hit_tokens: int = 0
+    hit_kind: str = "miss"
     snapshot_service: Optional[SnapshotService] = None
 
     @property
@@ -149,7 +150,8 @@ class PrefixCacheFlow:
         if lookup.matched_tokens > 0:
             sys.stderr.write(
                 f"{time.strftime('%Y-%m-%d %H:%M:%S')} [dflash] prefix cache hit "
-                f"{hit_tokens}/{len(prompt)} tokens (stable prefix {stable_prefix_len})\n"
+                f"{hit_tokens}/{len(prompt)} tokens "
+                f"({lookup.hit_kind}, stable prefix {stable_prefix_len})\n"
             )
             sys.stderr.flush()
         try:
@@ -164,6 +166,7 @@ class PrefixCacheFlow:
             snapshot=lookup.snapshot,
             lookup_ms=lookup.elapsed_ms,
             hit_tokens=hit_tokens,
+            hit_kind=lookup.hit_kind,
             snapshot_service=(
                 SnapshotService.from_request(
                     cache_manager=cache_manager,

--- a/dflash_mlx/server/runtime.py
+++ b/dflash_mlx/server/runtime.py
@@ -170,6 +170,7 @@ class ServerRuntime:
             stable_prefix_len=prefix_flow.stable_prefix_len,
             prefix_cache_active=prefix_flow.cache_active,
             publish_generation_snapshot=prefix_flow.publish_generation_snapshot,
+            prefix_hit_kind=prefix_flow.hit_kind,
             runtime_context=runtime_context,
         )
         loop_result = consume_dflash_events(

--- a/tests/test_prefix_cache_hit_kind.py
+++ b/tests/test_prefix_cache_hit_kind.py
@@ -1,0 +1,153 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+"""Tests for hit_kind classification in PrefixCacheLookupResult.
+
+Design: hit_kind is exposed only through the public RuntimeCacheManager.lookup()
+API (which returns PrefixCacheLookupResult).  Internal _l1.lookup() and
+_store.lookup() keep their existing 2-tuple signatures — they do not return
+hit_kind.  The classification is side-effected into _last_hit_kind state that
+the manager reads after the lookup under _state_lock.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from dflash_mlx.cache.codecs import build_snapshot
+from dflash_mlx.cache.fingerprints import DFlashPrefixKey
+from dflash_mlx.cache.manager import HitKind, PrefixCacheLookupResult, RuntimeCacheManager
+from dflash_mlx.cache.prefix_l1 import DFlashPrefixCache
+from dflash_mlx.cache.store import PrefixSnapshotStore
+from mlx_lm.models.cache import KVCache
+
+
+def _make_key() -> DFlashPrefixKey:
+    return DFlashPrefixKey(
+        target_model_id="test/target-v1",
+        draft_model_id="test/draft-v1",
+        capture_layer_ids=(10, 20),
+        draft_sink_size=16,
+        draft_window_size=2048,
+        template_hash="a" * 64,
+        prompt_policy_hash="b" * 64,
+    )
+
+
+def _make_snapshot(
+    token_ids: list[int],
+    key: DFlashPrefixKey,
+    *,
+    kind: str = "prefill",
+    with_logits: bool = True,
+    hidden_dim: int = 8,
+    vocab: int = 32,
+):
+    n = max(1, len(token_ids))
+    kv = KVCache()
+    kv.keys = mx.zeros((1, 2, n, hidden_dim), dtype=mx.float32)
+    kv.values = mx.zeros((1, 2, n, hidden_dim), dtype=mx.float32)
+    kv.offset = n
+    mx.eval(kv.keys, kv.values)
+    target_hidden = mx.zeros((1, n, hidden_dim), dtype=mx.float32)
+    last_logits = mx.zeros((1, vocab), dtype=mx.float32) if with_logits else None
+    snap = build_snapshot(
+        token_ids=token_ids,
+        target_cache=[kv],
+        target_hidden=target_hidden,
+        last_logits=last_logits,
+        key=key,
+        kind=kind,
+    )
+    return snap
+
+
+def _make_manager(max_entries: int = 8) -> RuntimeCacheManager:
+    l1 = DFlashPrefixCache(max_entries=max_entries, max_bytes=8 * 1024**3)
+    store = PrefixSnapshotStore(l1=l1)
+    return RuntimeCacheManager(store)
+
+
+class TestHitKindTypeSystem:
+    """The HitKind Literal covers all possible values."""
+
+    def test_hit_kind_literal_values(self):
+        assert set(HitKind.__args__) == {
+            "miss", "l1_exact", "l1_prefix", "l2_exact", "l2_prefix"
+        }
+
+    def test_result_is_dataclass_not_tuple(self):
+        mgr = _make_manager()
+        result = mgr.lookup([1, 2, 3], _make_key())
+        assert isinstance(result, PrefixCacheLookupResult)
+        # Must NOT be unpackable as a tuple (keeps old 2-tuple callers safe).
+        with pytest.raises((TypeError, ValueError)):
+            _, _ = result  # type: ignore[misc]
+
+    def test_default_hit_kind_is_miss(self):
+        result = PrefixCacheLookupResult(matched_tokens=0, snapshot=None, elapsed_ms=0.0)
+        assert result.hit_kind == "miss"
+
+
+class TestHitKindL1:
+    """hit_kind classification with L1-only cache."""
+
+    def test_cold_miss(self):
+        mgr = _make_manager()
+        result = mgr.lookup([1, 2, 3], _make_key())
+        assert result.hit_kind == "miss"
+        assert result.matched_tokens == 0
+
+    def test_prefix_hit(self):
+        mgr = _make_manager()
+        key = _make_key()
+        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
+        mgr._store._l1.insert(snap)
+        result = mgr.lookup([1, 2, 3, 4, 5], key)
+        assert result.hit_kind == "l1_prefix"
+        assert result.matched_tokens == 3
+
+    def test_exact_hit(self):
+        mgr = _make_manager()
+        key = _make_key()
+        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
+        mgr._store._l1.insert(snap)
+        result = mgr.lookup([1, 2, 3], key)
+        assert result.hit_kind == "l1_exact"
+        assert result.matched_tokens == 3
+
+    def test_sequential_lookups_are_independent(self):
+        mgr = _make_manager()
+        key = _make_key()
+        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
+        mgr._store._l1.insert(snap)
+
+        assert mgr.lookup([1, 2, 3], key).hit_kind == "l1_exact"
+        assert mgr.lookup([9, 9, 9], key).hit_kind == "miss"
+        assert mgr.lookup([1, 2, 3, 4, 5], key).hit_kind == "l1_prefix"
+
+    def test_probe_does_not_overwrite_last_hit_kind(self):
+        """Internal record=False probes must not change _last_hit_kind."""
+        mgr = _make_manager()
+        key = _make_key()
+        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
+        mgr._store._l1.insert(snap)
+
+        # Establish a recorded hit.
+        mgr.lookup([1, 2, 3], key)
+        assert mgr._store._l1._last_hit_kind == "l1_exact"
+
+        # Probe (record=False) must not overwrite state.
+        mgr._store._l1.lookup([1, 2, 3], key, record=False)
+        assert mgr._store._l1._last_hit_kind == "l1_exact"
+
+    def test_generation_snapshot_without_logits_reports_prefix_not_exact(self):
+        """Generation snapshot without last_logits can only serve as a prefix hit."""
+        mgr = _make_manager()
+        key = _make_key()
+        snap = _make_snapshot([1, 2, 3], key, kind="generation", with_logits=False)
+        mgr._store._l1.insert(snap)
+        result = mgr.lookup([1, 2, 3], key)
+        # Without logits the snapshot is not usable for exact-match serving.
+        assert result.hit_kind in ("miss", "l1_prefix")
+        assert result.matched_tokens in (0, 3)

--- a/tests/test_prefix_cache_hit_kind.py
+++ b/tests/test_prefix_cache_hit_kind.py
@@ -19,6 +19,7 @@ from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 from dflash_mlx.cache.manager import HitKind, PrefixCacheLookupResult, RuntimeCacheManager
 from dflash_mlx.cache.prefix_l1 import DFlashPrefixCache
 from dflash_mlx.cache.store import PrefixSnapshotStore
+from dflash_mlx.engine.events import SummaryEvent
 from mlx_lm.models.cache import KVCache
 
 
@@ -151,3 +152,61 @@ class TestHitKindL1:
         # Without logits the snapshot is not usable for exact-match serving.
         assert result.hit_kind in ("miss", "l1_prefix")
         assert result.matched_tokens in (0, 3)
+
+
+def _make_summary_event(hit_kind: str = "miss") -> SummaryEvent:
+    return SummaryEvent(
+        elapsed_us=100.0,
+        prompt_token_count=10,
+        generated_token_ids=(1, 2, 3),
+        generation_tokens=3,
+        accepted_from_draft=2,
+        acceptance_ratio=0.67,
+        cycles_completed=1,
+        phase_timings_us={},
+        hit_kind=hit_kind,
+    )
+
+
+class TestSummaryEventHitKind:
+    """SummaryEvent.to_payload() always includes hit_kind."""
+
+    def test_default_hit_kind_is_miss(self):
+        event = SummaryEvent(
+            elapsed_us=0.0,
+            prompt_token_count=0,
+            generated_token_ids=(),
+            generation_tokens=0,
+            accepted_from_draft=0,
+            acceptance_ratio=0.0,
+            cycles_completed=0,
+            phase_timings_us={},
+        )
+        assert event.hit_kind == "miss"
+        assert event.to_payload()["hit_kind"] == "miss"
+
+    def test_hit_kind_always_present_in_payload(self):
+        event = _make_summary_event("l1_exact")
+        payload = event.to_payload()
+        assert "hit_kind" in payload
+        assert payload["hit_kind"] == "l1_exact"
+
+    def test_all_hit_kind_values_roundtrip_through_payload(self):
+        for kind in HitKind.__args__:
+            payload = _make_summary_event(kind).to_payload()
+            assert payload["hit_kind"] == kind, f"hit_kind={kind!r} did not survive to_payload()"
+
+    def test_lookup_result_hit_kind_propagates_to_summary_event_payload(self):
+        """The value from PrefixCacheLookupResult must match what ends up in SummaryEvent payload.
+        This documents the contract that spec_epoch.py must honour when forwarding hit_kind."""
+        mgr = _make_manager()
+        key = _make_key()
+        snap = _make_snapshot([1, 2, 3], key)
+        mgr._store._l1.insert(snap)
+
+        result = mgr.lookup([1, 2, 3], key)
+        assert result.hit_kind == "l1_exact"
+
+        # Simulate spec_epoch forwarding: SummaryEvent.hit_kind = request.prefix_hit_kind.
+        summary_payload = _make_summary_event(result.hit_kind).to_payload()
+        assert summary_payload["hit_kind"] == "l1_exact"

--- a/tests/test_prefix_cache_integration.py
+++ b/tests/test_prefix_cache_integration.py
@@ -1116,6 +1116,28 @@ class TestContextConfigExposedCorrectly:
         assert manager is not None
         assert manager.frontier_stride() == 10000
 
+    def test_l2_frontier_stride_honors_larger_configured_value(
+        self, monkeypatch, tmp_path
+    ):
+        import dflash_mlx.cache.manager as cache_manager_mod
+
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        context = _runtime_context(
+            prefix_cache=True,
+            prefix_cache_l2=True,
+            prefix_cache_l2_dir=str(tmp_path),
+            prefill_step_size=2048,
+            prefix_cache_l2_frontier_stride=32000,
+        )
+        manager = cache_manager_mod.get_runtime_cache_manager(
+            context,
+            cache_identity=("configured-frontier",),
+        )
+
+        assert manager is not None
+        assert manager.frontier_stride() == 32768
+
     def test_frontier_stride_disabled_without_l2(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 

--- a/tests/test_prefix_l2.py
+++ b/tests/test_prefix_l2.py
@@ -248,7 +248,10 @@ class TestL2Lifecycle:
         assert "l2" not in stats
 
     def test_evict_promotes_to_l2_disk(self, tmp_path):
-        l2 = DFlashPrefixL2Cache(cache_dir=tmp_path, max_bytes=10**9)
+        # max_in_flight=2: lazy publishing means the writer thread holds the slot
+        # for the disk-write duration; allow 2 concurrent writes so both inserts
+        # can pipeline without the second dropping on semaphore contention.
+        l2 = DFlashPrefixL2Cache(cache_dir=tmp_path, max_bytes=10**9, max_in_flight=2)
         try:
             cache = _store(max_entries=1, max_bytes=10**9, l2=l2)
             key = _make_key()
@@ -968,7 +971,9 @@ class TestEpochInvalidation:
 
             l2.clear()
 
-            payload = l2._write_queue.get_nowait()
+            job = l2._write_queue.get_nowait()
+            # _write_payload checks epoch; simulate what the writer thread does
+            payload = l2._write_job_to_disk(job)
             l2._write_payload(payload)
 
             assert _all_snapshot_files(tmp_path) == []
@@ -1173,7 +1178,9 @@ class TestStatsHotPath:
             l2.shutdown()
 
 class TestAsyncWriterSafety:
-    def test_async_writer_does_not_call_mx_save_safetensors(self, tmp_path, monkeypatch):
+    def test_insert_async_does_not_call_mx_save_safetensors(self, tmp_path, monkeypatch):
+        """insert_async must not call mx.save_safetensors on the caller thread.
+        The disk write is deferred to the writer thread via _WriteJob."""
         import mlx.core as _mx
 
         l2 = DFlashPrefixL2Cache(cache_dir=tmp_path, max_bytes=10**9)
@@ -1195,10 +1202,15 @@ class TestAsyncWriterSafety:
             key = _make_key()
             l2.insert_async(_make_synthetic_snapshot([1, 2, 3], key))
             assert l2._write_queue.qsize() == 1
-            assert calls["n"] == 1
-            assert "dflash-l2-writer" not in threads
+            # save_safetensors must NOT have been called on the request thread
+            assert calls["n"] == 0, (
+                f"insert_async called mx.save_safetensors {calls['n']} times — "
+                "disk write should be deferred to the writer thread"
+            )
 
-            payload = l2._write_queue.get_nowait()
+            # Now simulate the writer thread processing the job
+            job = l2._write_queue.get_nowait()
+            payload = l2._write_job_to_disk(job)
             l2._write_payload(payload)
             assert calls["n"] == 1
             assert len(_all_snapshot_files(tmp_path)) == 1

--- a/tests/test_server_request_loop.py
+++ b/tests/test_server_request_loop.py
@@ -376,6 +376,7 @@ def test_server_runtime_routes_tool_chat_generation_snapshot_policy(monkeypatch)
     )
     prefix_flow = SimpleNamespace(
         hit_tokens=4,
+        hit_kind="l1_exact",
         lookup_ms=0.25,
         snapshot=object(),
         snapshot_service=object(),

--- a/tests/test_target_hidden_chunks.py
+++ b/tests/test_target_hidden_chunks.py
@@ -1,0 +1,129 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mlx.core as mx
+import numpy as np
+
+from dflash_mlx.cache.codecs import PrefixSnapshotBuilder
+from dflash_mlx.cache.fingerprints import DFlashPrefixKey
+from dflash_mlx.cache.snapshot import TargetHiddenChunks
+from dflash_mlx.engine.target_features import TargetFeatureStore
+from dflash_mlx.model import ContextOnlyDraftKVCache, DFlashAttention
+
+
+def _key() -> DFlashPrefixKey:
+    return DFlashPrefixKey(
+        target_model_id="target",
+        draft_model_id="draft",
+        capture_layer_ids=(1,),
+        draft_sink_size=2,
+        draft_window_size=4,
+        template_hash="template",
+        prompt_policy_hash="policy",
+        target_fa_window=0,
+    )
+
+
+def _snapshot(prompt_len: int = 12):
+    sink = mx.ones((1, 2, 3), dtype=mx.float32)
+    tail = mx.ones((1, 4, 3), dtype=mx.float32) * 2
+    return SimpleNamespace(
+        target_hidden_chunks=(sink, tail),
+        target_hidden_chunk_spans=((0, 2), (prompt_len - 4, prompt_len)),
+    )
+
+
+def test_exact_hit_generation_snapshot_stays_chunked_without_materialize():
+    prompt_len = 12
+    store = TargetFeatureStore(prompt_len=prompt_len)
+    hidden = store.hydrate_from_snapshot(
+        _snapshot(prompt_len),
+        snap_prefix_len=prompt_len,
+    )
+    assert isinstance(hidden, TargetHiddenChunks)
+
+    with patch.object(
+        TargetHiddenChunks,
+        "materialize",
+        side_effect=AssertionError("exact-hit path materialized target hidden"),
+    ):
+        store.freeze_prefill_for_snapshot(enabled=True)
+        generated = mx.ones((1, 3, 3), dtype=mx.float32) * 3
+        store.commit_generation(generated, collect_snapshot=True)
+        snapshot_hidden = store.generation_snapshot_hidden()
+        assert isinstance(snapshot_hidden, TargetHiddenChunks)
+
+        built = PrefixSnapshotBuilder(
+            key=_key(),
+            draft_sink_size=2,
+            draft_window_size=4,
+        ).build(
+            token_ids=list(range(prompt_len + 3)),
+            target_cache=[],
+            target_hidden=snapshot_hidden,
+            last_logits=None,
+            kind="generation",
+        )
+
+    assert built.target_hidden_chunk_spans == ((0, 2), (prompt_len - 1, prompt_len + 3))
+    np.testing.assert_array_equal(
+        np.array(built.target_hidden_chunks[0]),
+        np.ones((1, 2, 3), dtype=np.float32),
+    )
+    expected_tail = np.concatenate(
+        [
+            np.full((1, 1, 3), 2, dtype=np.float32),
+            np.full((1, 3, 3), 3, dtype=np.float32),
+        ],
+        axis=1,
+    )
+    np.testing.assert_array_equal(
+        np.array(built.target_hidden_chunks[1]),
+        expected_tail,
+    )
+
+
+def test_chunked_context_feeds_sink_and_tail_without_materialize():
+    prompt_len = 12
+    hidden = TargetHiddenChunks(
+        total_len=prompt_len,
+        chunks=(
+            mx.ones((1, 2, 3), dtype=mx.float32),
+            mx.ones((1, 4, 3), dtype=mx.float32) * 2,
+        ),
+        spans=((0, 2), (8, 12)),
+    )
+    cache = ContextOnlyDraftKVCache(sink_size=2, window_size=4)
+
+    with patch.object(
+        TargetHiddenChunks,
+        "materialize",
+        side_effect=AssertionError("draft context materialized target hidden"),
+    ):
+        selected, spans = DFlashAttention._context_segments_for_cache(
+            None,
+            hidden,
+            cache,
+        )
+
+    assert spans == [(0, 2), (8, 12)]
+    assert selected.shape == (1, 6, 3)
+    np.testing.assert_array_equal(
+        np.array(selected[:, :2, :]),
+        np.ones((1, 2, 3), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        np.array(selected[:, 2:, :]),
+        np.full((1, 4, 3), 2, dtype=np.float32),
+    )
+
+
+def test_partial_hit_keeps_existing_dense_restore_behavior():
+    store = TargetFeatureStore(prompt_len=14)
+    restored = store.hydrate_from_snapshot(_snapshot(12), snap_prefix_len=12)
+    assert isinstance(restored, mx.array)
+    assert restored.shape == (1, 14, 3)


### PR DESCRIPTION
## Summary

- Classify prefix-cache lookups as cold, L1 prefix/exact, or L2 prefix/exact while preserving the existing tuple-compatible APIs.
- Preserve compact target hidden-state chunks through snapshot serialization and restore, avoiding reconstruction of a dense hidden-state tensor.
- Move safetensors encoding and filesystem work to the L2 writer thread while keeping MLX evaluation on the owning request thread.
- Honor the configured L2 frontier stride so long-context prefills do not persist every intermediate frontier.
- Propagate the cache hit kind through summary events for callers and metrics.

This is complementary to #34: that PR adds request-level lookup diagnostics; this PR changes the snapshot representation, persistence path, and long-context reuse performance.

## Validation

### Automated tests

```text
1102 passed, 8 skipped, 2 warnings in 44.92s
```

Command: `.venv/bin/python -m pytest -q`

### Real-model validation

Target: `bearzi/gemma-4-31b-it-oQ6`
Draft: `z-lab/gemma-4-31B-it-DFlash`
Thinking: disabled

| Prompt tokens | Cold TTFT | L1 exact TTFT | L2 exact TTFT | Restored / computed |
| ---: | ---: | ---: | ---: | ---: |
| 8,192 | 140.82 s | 0.67 s | 6.52 s | 8,188 / 4 |
| 32,768 | 523.58 s | 0.82 s | 8.17 s | 32,764 / 4 |
| 65,536 | 1182.06 s | 1.17 s | 8.17 s | 65,532 / 4 |

Additional controls:

- Target-only decode: 9.4 tok/s.
- DFlash decode: 29.2 tok/s at 93.8% draft acceptance.
- Peak DFlash memory at 64K: 46.54 GB; observed process peak was about 49.3 GB on a 64 GB M1 MAX Apple Silicon system.
- The fixed 64K run persisted only the 32K midpoint and final 64K snapshot, rather than every 8K frontier.

## Design notes

- The writer queue receives already evaluated arrays because MLX stream ownership prevents moving `mx.eval()` safely to the background writer.
- Snapshot token and byte budgets remain explicit controls; a 64K prefill snapshot measured about 6.91 GB.
- Exact restores intentionally compute the final four prompt tokens required by the generation path.

## Disclosure

This PR was vibe-coded with AI assistance and supervised, reviewed, and validated by me.
