### PR TITLE
feat: add --copyspec-mode with an auto self-gating mode for prompt-lookup drafting

### DIFF
--- a/dflash_mlx/benchmark.py
+++ b/dflash_mlx/benchmark.py
@@ -92,6 +92,7 @@ CONTROLLED_FLAG_NAMES = (
     "draft_window_size",
     "verify_len_cap",
     "verify_mode",
+    "copyspec_mode",
     "only_dflash",
     "out",
 )
@@ -512,6 +513,7 @@ def _build_config(
     draft_window_size: int,
     verify_len_cap: int,
     verify_mode: str,
+    copyspec_mode: str,
     only_dflash: bool,
 ) -> dict[str, Any]:
     return {
@@ -532,6 +534,7 @@ def _build_config(
         "draft_window_size": int(draft_window_size),
         "verify_len_cap": int(verify_len_cap),
         "verify_mode": str(verify_mode),
+        "copyspec_mode": str(copyspec_mode),
         "only_dflash": bool(only_dflash),
         "prompt": prompt,
         "prompt_tokens": int(prompt_tokens),
@@ -547,6 +550,7 @@ def _offline_runtime_values(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
 ) -> dict[str, Any]:
     cfg = build_offline_runtime_config(
         prefill_step_size=prefill_step_size,
@@ -555,6 +559,7 @@ def _offline_runtime_values(
         draft_window_size=draft_window_size,
         verify_len_cap=verify_len_cap,
         verify_mode=verify_mode,
+        copyspec_mode=copyspec_mode,
     )
     return {
         "prefill_step_size": int(cfg.prefill_step_size),
@@ -563,6 +568,7 @@ def _offline_runtime_values(
         "draft_window_size": int(cfg.draft_window_size),
         "verify_len_cap": int(cfg.verify_len_cap),
         "verify_mode": str(cfg.verify_mode),
+        "copyspec_mode": str(cfg.copyspec_mode),
     }
 
 def _build_single_case_report(
@@ -586,6 +592,7 @@ def _build_single_case_report(
     draft_window_size: int,
     verify_len_cap: int,
     verify_mode: str,
+    copyspec_mode: str,
     only_dflash: bool,
 ) -> dict[str, Any]:
     run_entries = [_format_run_entry(run) for run in runs]
@@ -653,6 +660,7 @@ def _build_single_case_report(
             draft_window_size=draft_window_size,
             verify_len_cap=verify_len_cap,
             verify_mode=verify_mode,
+            copyspec_mode=copyspec_mode,
             only_dflash=only_dflash,
         ),
         "runs": run_entries,
@@ -1017,6 +1025,7 @@ def _run_once_sequential(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
     expected_answer: str | None = None,
     cooldown: int = 0,
     only_dflash: bool = False,
@@ -1073,6 +1082,7 @@ def _run_once_sequential(
             draft_window_size=draft_window_size,
             verify_len_cap=verify_len_cap,
             verify_mode=verify_mode,
+            copyspec_mode=copyspec_mode,
         )
         bundle = load_runtime_bundle(
             model_ref=target_model_ref,
@@ -1190,6 +1200,7 @@ def benchmark_once(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
     cooldown: int = 10,
     expected_answer: str | None = None,
     only_dflash: bool = False,
@@ -1201,6 +1212,7 @@ def benchmark_once(
         draft_window_size=draft_window_size,
         verify_len_cap=verify_len_cap,
         verify_mode=verify_mode,
+        copyspec_mode=copyspec_mode,
     )
     thermal_pressure = _get_thermal_pressure()
     _warn_if_throttled(thermal_pressure)
@@ -1258,6 +1270,7 @@ def benchmark_repeated(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
     cooldown: int = 10,
     expected_answer: str | None = None,
     only_dflash: bool = False,
@@ -1269,6 +1282,7 @@ def benchmark_repeated(
         draft_window_size=draft_window_size,
         verify_len_cap=verify_len_cap,
         verify_mode=verify_mode,
+        copyspec_mode=copyspec_mode,
     )
     target_meta: dict[str, Any] | None = None
     draft_meta: dict[str, Any] | None = None
@@ -1349,6 +1363,7 @@ def benchmark_suite(
         "draft_window_size": args.draft_window_size,
         "verify_len_cap": args.verify_len_cap,
         "verify_mode": args.verify_mode,
+        "copyspec_mode": args.copyspec_mode,
         "cooldown": args.cooldown,
         "only_dflash": bool(args.only_dflash),
     }
@@ -1567,6 +1582,7 @@ def _controlled_flag_values(
         "draft_window_size": int(args.draft_window_size),
         "verify_len_cap": int(args.verify_len_cap),
         "verify_mode": str(args.verify_mode),
+        "copyspec_mode": str(args.copyspec_mode),
         "only_dflash": bool(args.only_dflash),
         "out": str(output_path),
     }
@@ -1603,6 +1619,7 @@ def _explicit_flag_values(
         "--draft-window-size": "draft_window_size",
         "--verify-len-cap": "verify_len_cap",
         "--verify-mode": "verify_mode",
+        "--copyspec-mode": "copyspec_mode",
         "--only-dflash": "only_dflash",
         "--out": "out",
     }

--- a/dflash_mlx/engine/copyspec.py
+++ b/dflash_mlx/engine/copyspec.py
@@ -113,6 +113,168 @@ class CopySpecIndex:
         return positions
 
 
+COPYSPEC_PROBE_OFF_CYCLES = 24
+COPYSPEC_PROBE_ON_MIN_COPY = 6
+COPYSPEC_PROBE_ON_MAX_CYCLES = 48
+COPYSPEC_LATCH_CYCLES = 200
+COPYSPEC_MARGIN = 1.0
+
+
+class CopySpecAutoGate:
+    """Windowed A/B latch that decides per-cycle whether copyspec should draft.
+
+    Four-phase state machine:
+      measure_off  → gather a baseline (copyspec disabled)
+      measure_on   → probe with copyspec enabled
+      engaged      → copyspec is winning; stay on for latch_cycles
+      dormant      → copyspec is losing; stay off for latch_cycles
+    """
+
+    def __init__(
+        self,
+        *,
+        probe_off_cycles: int = COPYSPEC_PROBE_OFF_CYCLES,
+        probe_on_min_copy: int = COPYSPEC_PROBE_ON_MIN_COPY,
+        probe_on_max_cycles: int = COPYSPEC_PROBE_ON_MAX_CYCLES,
+        latch_cycles: int = COPYSPEC_LATCH_CYCLES,
+        margin: float = COPYSPEC_MARGIN,
+    ) -> None:
+        if probe_off_cycles < 1:
+            raise ValueError("probe_off_cycles must be >= 1")
+        if probe_on_min_copy < 1:
+            raise ValueError("probe_on_min_copy must be >= 1")
+        if probe_on_max_cycles < 1:
+            raise ValueError("probe_on_max_cycles must be >= 1")
+        if latch_cycles < 1:
+            raise ValueError("latch_cycles must be >= 1")
+        if margin <= 0:
+            raise ValueError("margin must be > 0")
+
+        self._probe_off_cycles = probe_off_cycles
+        self._probe_on_min_copy = probe_on_min_copy
+        self._probe_on_max_cycles = probe_on_max_cycles
+        self._latch_cycles = latch_cycles
+        self._margin = margin
+
+        # Phase
+        self.phase: str = "measure_off"
+
+        # Window accumulators
+        self._win_commits: int = 0
+        self._win_cost_ns: int = 0
+        self._win_cycles: int = 0
+        self._win_copy_blocks: int = 0
+
+        # State
+        self._off_rate: float | None = None
+        self._latch_remaining: int = 0
+        self._pending_reset: bool = False
+
+        # Metrics
+        self._engaged_cycles: int = 0
+        self._dormant_cycles: int = 0
+        self._probes: int = 0
+        self._engages: int = 0
+        self._disengages: int = 0
+
+    def engage_copy(self) -> bool:
+        """Return True iff copyspec should draft this cycle."""
+        return self.phase in ("measure_on", "engaged")
+
+    def record_cycle(
+        self,
+        *,
+        source: str,
+        commit_count: int,
+        cycle_cost_ns: int | None,
+    ) -> None:
+        """Called once per cycle that ran a real draft (block_len > 1)."""
+        # Accumulate
+        self._win_commits += commit_count
+        if isinstance(cycle_cost_ns, int) and cycle_cost_ns > 0:
+            self._win_cost_ns += cycle_cost_ns
+        self._win_cycles += 1
+        if source == "copy":
+            self._win_copy_blocks += 1
+
+        # Advance phase machine
+        if self.phase == "measure_off":
+            if self._win_cycles >= self._probe_off_cycles:
+                self._off_rate = self._win_rate()
+                self._reset_window()
+                self.phase = "measure_on"
+                self._probes += 1
+
+        elif self.phase == "measure_on":
+            ended = (
+                self._win_copy_blocks >= self._probe_on_min_copy
+                or self._win_cycles >= self._probe_on_max_cycles
+            )
+            if ended:
+                on_rate = self._win_rate()
+                copy_seen = self._win_copy_blocks
+                self._reset_window()
+                if (
+                    copy_seen == 0
+                    or self._off_rate is None
+                    or on_rate < self._off_rate * self._margin
+                ):
+                    self.phase = "dormant"
+                    self._latch_remaining = self._latch_cycles
+                    self._pending_reset = True
+                    self._disengages += 1
+                else:
+                    self.phase = "engaged"
+                    self._latch_remaining = self._latch_cycles
+                    self._engages += 1
+
+        elif self.phase == "engaged":
+            self._engaged_cycles += 1
+            self._latch_remaining -= 1
+            if self._latch_remaining <= 0:
+                self._pending_reset = True
+                self.phase = "measure_off"
+                self._reset_window()
+
+        elif self.phase == "dormant":
+            self._dormant_cycles += 1
+            self._latch_remaining -= 1
+            if self._latch_remaining <= 0:
+                self.phase = "measure_off"
+                self._reset_window()
+
+    def take_reset(self) -> bool:
+        """Return True if the adaptive policy should be reset, then clear the flag."""
+        result = self._pending_reset
+        self._pending_reset = False
+        return result
+
+    def _win_rate(self) -> float:
+        """Realized throughput for the current window."""
+        if self._win_cost_ns > 0:
+            return self._win_commits / (self._win_cost_ns / 1e9)
+        if self._win_cycles > 0:
+            return self._win_commits / self._win_cycles
+        return 0.0
+
+    def _reset_window(self) -> None:
+        self._win_commits = 0
+        self._win_cost_ns = 0
+        self._win_cycles = 0
+        self._win_copy_blocks = 0
+
+    def metrics(self) -> dict:
+        return {
+            "state": self.phase,
+            "off_rate": self._off_rate,
+            "engaged_cycles": int(self._engaged_cycles),
+            "dormant_cycles": int(self._dormant_cycles),
+            "probes": int(self._probes),
+            "engages": int(self._engages),
+            "disengages": int(self._disengages),
+        }
+
+
 def _hash_tokens(tokens: Sequence[int]) -> int:
     value = _FNV_OFFSET_BASIS
     for token in tokens:

--- a/dflash_mlx/engine/copyspec.py
+++ b/dflash_mlx/engine/copyspec.py
@@ -118,6 +118,7 @@ COPYSPEC_PROBE_ON_MIN_COPY = 6
 COPYSPEC_PROBE_ON_MAX_CYCLES = 48
 COPYSPEC_LATCH_CYCLES = 200
 COPYSPEC_MARGIN = 1.0
+COPYSPEC_BACKOFF_CAP = 4  # max dormant-period doublings (latch_cycles * 2^cap)
 
 
 class CopySpecAutoGate:
@@ -138,6 +139,7 @@ class CopySpecAutoGate:
         probe_on_max_cycles: int = COPYSPEC_PROBE_ON_MAX_CYCLES,
         latch_cycles: int = COPYSPEC_LATCH_CYCLES,
         margin: float = COPYSPEC_MARGIN,
+        backoff_cap: int = COPYSPEC_BACKOFF_CAP,
     ) -> None:
         if probe_off_cycles < 1:
             raise ValueError("probe_off_cycles must be >= 1")
@@ -149,12 +151,15 @@ class CopySpecAutoGate:
             raise ValueError("latch_cycles must be >= 1")
         if margin <= 0:
             raise ValueError("margin must be > 0")
+        if backoff_cap < 0:
+            raise ValueError("backoff_cap must be >= 0")
 
         self._probe_off_cycles = probe_off_cycles
         self._probe_on_min_copy = probe_on_min_copy
         self._probe_on_max_cycles = probe_on_max_cycles
         self._latch_cycles = latch_cycles
         self._margin = margin
+        self._backoff_cap = backoff_cap
 
         # Phase
         self.phase: str = "measure_off"
@@ -169,6 +174,11 @@ class CopySpecAutoGate:
         self._off_rate: float | None = None
         self._latch_remaining: int = 0
         self._pending_reset: bool = False
+        # Consecutive disengages → exponentially longer dormant periods, so a
+        # workload where copyspec never wins stops paying repeated probe cost
+        # (each probe engages copyspec briefly and is wasted there). Reset to
+        # 0 on any engage, so a workload that turns copy-heavy stays responsive.
+        self._consecutive_losses: int = 0
 
         # Metrics
         self._engaged_cycles: int = 0
@@ -220,12 +230,16 @@ class CopySpecAutoGate:
                     or on_rate < self._off_rate * self._margin
                 ):
                     self.phase = "dormant"
-                    self._latch_remaining = self._latch_cycles
+                    self._latch_remaining = self._latch_cycles * (
+                        2 ** min(self._consecutive_losses, self._backoff_cap)
+                    )
+                    self._consecutive_losses += 1
                     self._pending_reset = True
                     self._disengages += 1
                 else:
                     self.phase = "engaged"
                     self._latch_remaining = self._latch_cycles
+                    self._consecutive_losses = 0
                     self._engages += 1
 
         elif self.phase == "engaged":

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -22,7 +22,7 @@ from dflash_mlx.cache.snapshot import (
 )
 from dflash_mlx.draft_backend import DraftBackend
 from dflash_mlx.engine.acceptance import match_acceptance_length as _match_acceptance_length
-from dflash_mlx.engine.copyspec import CopySpecIndex
+from dflash_mlx.engine.copyspec import CopySpecAutoGate, CopySpecIndex
 from dflash_mlx.engine.ddtree import (
     build_flat_ddtree,
     build_flat_tree_inputs,
@@ -1603,7 +1603,9 @@ class SpeculativeSession:
             if best.source == "copyspec":
                 copyspec_hits_total += 1
                 copyspec_tokens_total += copyspec_tokens_cycle or max(0, int(block_len) - 1)
-                if self.copyspec_mode == "conservative" and acceptance_len == 0:
+                # ddtree path has no adaptive policy / auto-gate: treat auto
+                # as the safe conservative one-strike here.
+                if self.copyspec_mode in ("conservative", "auto") and acceptance_len == 0:
                     state.copyspec_disabled = True
             if profile_cycles:
                 acceptance_cycle_ns = time.perf_counter_ns() - acceptance_start_ns
@@ -1847,6 +1849,14 @@ class SpeculativeSession:
             verify_len_cap=cycle_config.verify_len_cap,
             prompt_len=request.prompt_len,
         )
+        # copyspec_mode=auto: a self-gating policy that periodically A/B-probes
+        # copyspec-on vs -off throughput, latches on/off, and signals an
+        # adaptive-policy reset on disengage (so copyspec perturbation is
+        # wiped). Only the linear/adaptive path runs it (the ddtree path maps
+        # auto -> conservative one-strike).
+        copyspec_auto_gate = (
+            CopySpecAutoGate() if self.copyspec_mode == "auto" else None
+        )
         block_token_buffer = mx.full(
             (effective_block_tokens,),
             int(draft_model.mask_token_id),
@@ -1878,6 +1888,8 @@ class SpeculativeSession:
                 forbidden_tokens=forbidden_copy_tokens,
             )
             if candidate is None:
+                return None
+            if copyspec_auto_gate is not None and not copyspec_auto_gate.engage_copy():
                 return None
             draft_backend.advance_context(
                 draft_model=draft_model,
@@ -2133,7 +2145,7 @@ class SpeculativeSession:
                 if self.copyspec_mode == "conservative" and acceptance_len == 0:
                     state.copyspec_disabled = True
             staged_first_next = posterior[acceptance_len : acceptance_len + 1]
-            if adaptive_block_policy is not None:
+            if adaptive_block_policy is not None or copyspec_auto_gate is not None:
                 cycle_wall_ns = time.perf_counter_ns() - cycle_start_ns
                 cycle_pause_ns = max(0, yield_pause.pause_ns - cycle_pause_start_ns)
                 adaptive_cycle_cost_ns = max(0, cycle_wall_ns - cycle_pause_ns)
@@ -2146,11 +2158,30 @@ class SpeculativeSession:
                         + commit_cycle_ns
                         + replay_cycle_ns
                     )
-                adaptive_block_policy.record(
-                    block_len=block_len,
-                    acceptance_len=acceptance_len,
-                    cycle_cost_ns=adaptive_cycle_cost_ns,
-                )
+                if copyspec_auto_gate is not None and block_len > 1:
+                    copyspec_auto_gate.record_cycle(
+                        source=("copy" if draft_source == "copyspec" else "dflash"),
+                        commit_count=commit_count,
+                        cycle_cost_ns=adaptive_cycle_cost_ns,
+                    )
+                    # On disengage the gate asks for a clean adaptive policy so
+                    # copyspec's perturbation does not drag the rest of the run.
+                    if (
+                        copyspec_auto_gate.take_reset()
+                        and adaptive_block_policy is not None
+                    ):
+                        adaptive_block_policy = _AdaptiveBlockPolicy.from_runtime(
+                            runtime_config=runtime_config,
+                            effective_block_tokens=effective_block_tokens,
+                            verify_len_cap=cycle_config.verify_len_cap,
+                            prompt_len=request.prompt_len,
+                        )
+                if adaptive_block_policy is not None:
+                    adaptive_block_policy.record(
+                        block_len=block_len,
+                        acceptance_len=acceptance_len,
+                        cycle_cost_ns=adaptive_cycle_cost_ns,
+                    )
             committed_ids = [int(token_id) for token_id in committed_segment.tolist()]
             self.copyspec_index.append_committed(committed_ids)
             if not profile_cycles:

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -540,6 +540,7 @@ class SpeculativeSession:
     clear_cache_boundaries: bool
     target_fa_window: int
     copyspec_index: CopySpecIndex
+    copyspec_mode: str
 
     @classmethod
     def open(
@@ -625,6 +626,7 @@ class SpeculativeSession:
             clear_cache_boundaries=bool(runtime_config.clear_cache_boundaries),
             target_fa_window=target_fa_window,
             copyspec_index=CopySpecIndex(prompt_tokens),
+            copyspec_mode=str(getattr(runtime_config, "copyspec_mode", "conservative")),
         )
 
     def clear_cache_boundary(self) -> None:
@@ -1093,7 +1095,7 @@ class SpeculativeSession:
             block_len: int,
             draft_context: mx.array,
         ) -> mx.array | None:
-            if state.copyspec_disabled:
+            if self.copyspec_mode == "off" or state.copyspec_disabled:
                 return None
             candidate = self.copyspec_index.draft_after(
                 int(staged_first.item()),
@@ -1601,7 +1603,7 @@ class SpeculativeSession:
             if best.source == "copyspec":
                 copyspec_hits_total += 1
                 copyspec_tokens_total += copyspec_tokens_cycle or max(0, int(block_len) - 1)
-                if acceptance_len == 0:
+                if self.copyspec_mode == "conservative" and acceptance_len == 0:
                     state.copyspec_disabled = True
             if profile_cycles:
                 acceptance_cycle_ns = time.perf_counter_ns() - acceptance_start_ns
@@ -1868,7 +1870,7 @@ class SpeculativeSession:
             block_len: int,
             draft_context: mx.array,
         ) -> mx.array | None:
-            if state.copyspec_disabled:
+            if self.copyspec_mode == "off" or state.copyspec_disabled:
                 return None
             candidate = self.copyspec_index.draft_after(
                 int(staged_first.item()),
@@ -2128,7 +2130,7 @@ class SpeculativeSession:
             if draft_source == "copyspec":
                 state.copyspec_hits += 1
                 state.copyspec_tokens += copyspec_tokens or max(0, int(block_len) - 1)
-                if acceptance_len == 0:
+                if self.copyspec_mode == "conservative" and acceptance_len == 0:
                     state.copyspec_disabled = True
             staged_first_next = posterior[acceptance_len : acceptance_len + 1]
             if adaptive_block_policy is not None:

--- a/dflash_mlx/generate.py
+++ b/dflash_mlx/generate.py
@@ -56,6 +56,7 @@ def run_generate(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
     draft_quant: Optional[str] = None,
 ) -> int:
     runtime_context = build_offline_runtime_context(
@@ -66,6 +67,7 @@ def run_generate(
         draft_window_size=draft_window_size,
         verify_len_cap=verify_len_cap,
         verify_mode=verify_mode,
+        copyspec_mode=copyspec_mode,
     )
     bundle = load_runtime_bundle(
         model_ref=model_ref,
@@ -111,14 +113,23 @@ def run_generate(
     if summary is None:
         return 1
 
+    sys.stderr.write(f"\n{format_generation_summary(summary)}\n")
+    sys.stderr.flush()
+    return 0
+
+
+def format_generation_summary(summary: SummaryEvent) -> str:
     tps = generation_tps_from_summary(summary)
     acceptance_pct = float(summary.acceptance_ratio) * 100.0
     token_count = int(summary.generation_tokens)
-    sys.stderr.write(
-        f"\n{token_count} tokens | {tps:.1f} tok/s | {acceptance_pct:.1f}% acceptance\n"
-    )
-    sys.stderr.flush()
-    return 0
+    line = f"{token_count} tokens | {tps:.1f} tok/s | {acceptance_pct:.1f}% acceptance"
+    copyspec_hits = int(summary.copyspec_hits)
+    if copyspec_hits > 0:
+        line += (
+            f" | copyspec {copyspec_hits} blocks"
+            f" / {int(summary.copyspec_tokens)} tokens"
+        )
+    return line
 
 def main(argv: Sequence[str] | None = None, *, prog: str | None = None) -> None:
     apply_metal_limits()

--- a/dflash_mlx/runtime/config.py
+++ b/dflash_mlx/runtime/config.py
@@ -71,6 +71,7 @@ class EffectiveRuntimeConfig:
     target_fa_window: int
     dflash_max_ctx: int
     verify_mode: str
+    copyspec_mode: str
     quantize_kv_cache: bool
     prefix_cache_l2_frontier_stride: int
 
@@ -90,6 +91,7 @@ DEFAULT_RUNTIME_CONFIG = EffectiveRuntimeConfig(
     target_fa_window=0,
     dflash_max_ctx=0,
     verify_mode="adaptive",
+    copyspec_mode="conservative",
     quantize_kv_cache=False,
     prefix_cache_l2_frontier_stride=0,
 )
@@ -208,6 +210,18 @@ RUNTIME_CONFIG_FIELDS: tuple[RuntimeConfigFieldSpec, ...] = (
         env="DFLASH_VERIFY_MODE",
         choices=("dflash", "adaptive", "ddtree", "off"),
         help="Verify path mode. Default adaptive shortens low-acceptance blocks; use off only for debug/parity.",
+        surfaces=(SURFACE_SERVE_DOCTOR, SURFACE_GENERATE, SURFACE_BENCHMARK),
+    ),
+    RuntimeConfigFieldSpec(
+        field="copyspec_mode",
+        flags=("--copyspec-mode",),
+        env="DFLASH_COPYSPEC_MODE",
+        choices=("conservative", "aggressive", "off"),
+        help=(
+            "Prompt-lookup (copyspec) drafting. Default conservative disables copyspec after one missed copy block. "
+            "'aggressive' keeps it on (best for copy-heavy workloads on large MoE targets; can regress non-copy "
+            "prompts). 'off' disables it."
+        ),
         surfaces=(SURFACE_SERVE_DOCTOR, SURFACE_GENERATE, SURFACE_BENCHMARK),
     ),
     RuntimeConfigFieldSpec(
@@ -383,6 +397,7 @@ def runtime_config_field_defaults(
 
 _GENERATE_RUNTIME_FIELD_ORDER = (
     "verify_mode",
+    "copyspec_mode",
     "prefill_step_size",
     "target_fa_window",
     "quantize_kv_cache",
@@ -393,6 +408,7 @@ _GENERATE_RUNTIME_FIELD_ORDER = (
 
 _BENCHMARK_RUNTIME_FIELD_ORDER = (
     "verify_mode",
+    "copyspec_mode",
     "prefill_step_size",
     "target_fa_window",
     "quantize_kv_cache",
@@ -428,6 +444,7 @@ def runtime_config_from_defaults(
     target_fa_window: int = 0,
     dflash_max_ctx: int = 0,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
     quantize_kv_cache: bool | None = None,
     prefix_cache_l2_frontier_stride: int | None = None,
 ) -> EffectiveRuntimeConfig:
@@ -491,6 +508,7 @@ def runtime_config_from_defaults(
             target_fa_window=int(target_fa_window),
             dflash_max_ctx=int(dflash_max_ctx),
             verify_mode=defaults.verify_mode if verify_mode is None else str(verify_mode),
+            copyspec_mode=defaults.copyspec_mode if copyspec_mode is None else str(copyspec_mode),
             quantize_kv_cache=(
                 defaults.quantize_kv_cache
                 if quantize_kv_cache is None
@@ -583,6 +601,7 @@ def resolve_runtime_config(args: Any) -> EffectiveRuntimeConfig:
             0,
         ),
         verify_mode=_resolve_verify_mode(getattr(args, "verify_mode", None), defaults.verify_mode),
+        copyspec_mode=_resolve_copyspec_mode(getattr(args, "copyspec_mode", None), defaults.copyspec_mode),
         prefix_cache_l2_frontier_stride=_resolve_int(
             getattr(args, "prefix_cache_l2_frontier_stride", None),
             _runtime_env("prefix_cache_l2_frontier_stride"),
@@ -641,6 +660,10 @@ def validate_runtime_config(cfg: EffectiveRuntimeConfig) -> EffectiveRuntimeConf
     if cfg.verify_mode not in ("dflash", "adaptive", "ddtree", "off"):
         raise ValueError(
             "--verify-mode / verify_mode must be dflash, adaptive, ddtree, or off"
+        )
+    if cfg.copyspec_mode not in ("conservative", "aggressive", "off"):
+        raise ValueError(
+            "--copyspec-mode / copyspec_mode must be conservative, aggressive, or off"
         )
     if not cfg.prefix_cache and cfg.prefix_cache_l2:
         return replace(cfg, prefix_cache_l2=False)
@@ -702,6 +725,14 @@ def _resolve_verify_mode(cli_value: str | None, default: str) -> str:
     if cli_value is not None:
         return str(cli_value)
     raw = os.environ.get(_runtime_env("verify_mode"), "").strip()
+    if raw:
+        return raw
+    return default
+
+def _resolve_copyspec_mode(cli_value: str | None, default: str) -> str:
+    if cli_value is not None:
+        return str(cli_value)
+    raw = os.environ.get(_runtime_env("copyspec_mode"), "").strip()
     if raw:
         return raw
     return default

--- a/dflash_mlx/runtime/config.py
+++ b/dflash_mlx/runtime/config.py
@@ -216,11 +216,12 @@ RUNTIME_CONFIG_FIELDS: tuple[RuntimeConfigFieldSpec, ...] = (
         field="copyspec_mode",
         flags=("--copyspec-mode",),
         env="DFLASH_COPYSPEC_MODE",
-        choices=("conservative", "aggressive", "off"),
+        choices=("conservative", "aggressive", "off", "auto"),
         help=(
-            "Prompt-lookup (copyspec) drafting. Default conservative disables copyspec after one missed copy block. "
-            "'aggressive' keeps it on (best for copy-heavy workloads on large MoE targets; can regress non-copy "
-            "prompts). 'off' disables it."
+            "Prompt-lookup (copyspec) drafting. 'conservative' disables copyspec after one missed copy block. "
+            "'aggressive' keeps it on (copy-heavy workloads on large MoE targets; can regress non-copy prompts). "
+            "'off' disables it. 'auto' self-gates: periodically A/B-probes copyspec on vs off and latches to "
+            "whichever is faster, resetting adaptive state on disengage (safe across workloads)."
         ),
         surfaces=(SURFACE_SERVE_DOCTOR, SURFACE_GENERATE, SURFACE_BENCHMARK),
     ),
@@ -661,9 +662,9 @@ def validate_runtime_config(cfg: EffectiveRuntimeConfig) -> EffectiveRuntimeConf
         raise ValueError(
             "--verify-mode / verify_mode must be dflash, adaptive, ddtree, or off"
         )
-    if cfg.copyspec_mode not in ("conservative", "aggressive", "off"):
+    if cfg.copyspec_mode not in ("conservative", "aggressive", "off", "auto"):
         raise ValueError(
-            "--copyspec-mode / copyspec_mode must be conservative, aggressive, or off"
+            "--copyspec-mode / copyspec_mode must be conservative, aggressive, off, or auto"
         )
     if not cfg.prefix_cache and cfg.prefix_cache_l2:
         return replace(cfg, prefix_cache_l2=False)

--- a/dflash_mlx/runtime/config.py
+++ b/dflash_mlx/runtime/config.py
@@ -216,12 +216,12 @@ RUNTIME_CONFIG_FIELDS: tuple[RuntimeConfigFieldSpec, ...] = (
         field="copyspec_mode",
         flags=("--copyspec-mode",),
         env="DFLASH_COPYSPEC_MODE",
-        choices=("conservative", "aggressive", "off", "auto"),
+        choices=("conservative", "off", "auto"),
         help=(
-            "Prompt-lookup (copyspec) drafting. 'conservative' disables copyspec after one missed copy block. "
-            "'aggressive' keeps it on (copy-heavy workloads on large MoE targets; can regress non-copy prompts). "
-            "'off' disables it. 'auto' self-gates: periodically A/B-probes copyspec on vs off and latches to "
-            "whichever is faster, resetting adaptive state on disengage (safe across workloads)."
+            "Prompt-lookup (copyspec) drafting. Default 'conservative' disables copyspec after one missed "
+            "copy block. 'auto' self-gates: periodically A/B-probes copyspec on vs off and latches to whichever "
+            "is faster, resetting adaptive state on disengage (a clear win on strong-copyspec targets like large "
+            "MoE; self-disables where copyspec doesn't pay off). 'off' disables copyspec entirely."
         ),
         surfaces=(SURFACE_SERVE_DOCTOR, SURFACE_GENERATE, SURFACE_BENCHMARK),
     ),
@@ -662,9 +662,9 @@ def validate_runtime_config(cfg: EffectiveRuntimeConfig) -> EffectiveRuntimeConf
         raise ValueError(
             "--verify-mode / verify_mode must be dflash, adaptive, ddtree, or off"
         )
-    if cfg.copyspec_mode not in ("conservative", "aggressive", "off", "auto"):
+    if cfg.copyspec_mode not in ("conservative", "off", "auto"):
         raise ValueError(
-            "--copyspec-mode / copyspec_mode must be conservative, aggressive, off, or auto"
+            "--copyspec-mode / copyspec_mode must be conservative, off, or auto"
         )
     if not cfg.prefix_cache and cfg.prefix_cache_l2:
         return replace(cfg, prefix_cache_l2=False)

--- a/dflash_mlx/runtime/context.py
+++ b/dflash_mlx/runtime/context.py
@@ -49,6 +49,7 @@ def build_offline_runtime_config(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
 ) -> EffectiveRuntimeConfig:
     runtime_config = _runtime_config_from_defaults(
         prefix_cache=False,
@@ -60,6 +61,7 @@ def build_offline_runtime_config(
         draft_window_size=draft_window_size,
         verify_len_cap=verify_len_cap,
         verify_mode=verify_mode,
+        copyspec_mode=copyspec_mode,
     )
     return validate_runtime_config(runtime_config)
 
@@ -72,6 +74,7 @@ def build_offline_runtime_context(
     draft_window_size: int | None = None,
     verify_len_cap: int | None = None,
     verify_mode: str | None = None,
+    copyspec_mode: str | None = None,
 ) -> RuntimeContext:
     runtime_config = build_offline_runtime_config(
         target_fa_window=target_fa_window,
@@ -81,6 +84,7 @@ def build_offline_runtime_context(
         draft_window_size=draft_window_size,
         verify_len_cap=verify_len_cap,
         verify_mode=verify_mode,
+        copyspec_mode=copyspec_mode,
     )
     return build_runtime_context(runtime_config)
 

--- a/tests/test_copyspec.py
+++ b/tests/test_copyspec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from dflash_mlx.engine.copyspec import CopySpecIndex
+from dflash_mlx.engine.copyspec import CopySpecIndex, CopySpecAutoGate
 
 
 def test_copyspec_draft_after_returns_full_prompt_copy() -> None:
@@ -47,3 +47,330 @@ def test_copyspec_skips_forbidden_tokens() -> None:
 def test_copyspec_rejects_invalid_window_size() -> None:
     with pytest.raises(ValueError, match="window_size"):
         CopySpecIndex([1, 2, 3], window_size=0)
+
+
+# ────────────────────────────────────────────────────────────────
+# CopySpecAutoGate tests
+# ────────────────────────────────────────────────────────────────
+
+def _make_gate(**kwargs) -> CopySpecAutoGate:
+    """Tiny helper: gate with small windows so tests run in <10 cycles."""
+    defaults = dict(
+        probe_off_cycles=4,
+        probe_on_min_copy=2,
+        probe_on_max_cycles=8,
+        latch_cycles=6,
+        margin=1.0,
+    )
+    defaults.update(kwargs)
+    return CopySpecAutoGate(**defaults)
+
+
+def _dflash(gate: CopySpecAutoGate, *, commits: int = 4, cost_ns: int | None = 500_000) -> None:
+    """Feed one dflash cycle into the gate."""
+    gate.record_cycle(source="dflash", commit_count=commits, cycle_cost_ns=cost_ns)
+
+
+def _copy(gate: CopySpecAutoGate, *, commits: int = 4, cost_ns: int | None = 500_000) -> None:
+    """Feed one copy cycle into the gate."""
+    gate.record_cycle(source="copy", commit_count=commits, cycle_cost_ns=cost_ns)
+
+
+# 1. Initial state ────────────────────────────────────────────────
+
+def test_starts_in_measure_off() -> None:
+    gate = _make_gate()
+    assert gate.phase == "measure_off"
+
+
+def test_engage_copy_false_in_measure_off() -> None:
+    gate = _make_gate()
+    assert gate.engage_copy() is False
+
+
+# 2. measure_off → measure_on transition ──────────────────────────
+
+def test_after_probe_off_cycles_transitions_to_measure_on() -> None:
+    gate = _make_gate(probe_off_cycles=4)
+    for _ in range(4):
+        _dflash(gate)
+    assert gate.phase == "measure_on"
+    assert gate.engage_copy() is True
+
+
+def test_off_rate_captured_after_measure_off() -> None:
+    gate = _make_gate(probe_off_cycles=4)
+    # 4 cycles × 8 commits each, cost 500_000 ns each → rate = 32 / (4×500_000/1e9)
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=8, cycle_cost_ns=500_000)
+    expected = 32 / (4 * 500_000 / 1e9)  # 16_000_000.0
+    assert gate._off_rate == pytest.approx(expected)
+
+
+def test_off_rate_not_set_before_measure_off_ends() -> None:
+    gate = _make_gate(probe_off_cycles=4)
+    _dflash(gate)
+    assert gate._off_rate is None
+
+
+# 3. measure_on → engaged (copy wins) ────────────────────────────
+
+def test_copy_wins_transitions_to_engaged() -> None:
+    """Copy cycles with tiny cost (high tps) beat the dflash off-rate."""
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
+    # Off phase: 4 cycles, 4 commits, 1_000_000 ns each → off_rate = 16/(4e-3) = 4_000.0 tps
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
+    assert gate.phase == "measure_on"
+    # On phase: 2 copy cycles, 4 commits, 50_000 ns each → on_rate = 8/(100_000/1e9) = 80_000 tps
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.phase == "engaged"
+    assert gate.engage_copy() is True
+
+
+def test_copy_wins_no_reset_pending() -> None:
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    assert gate._pending_reset is False
+    assert gate.take_reset() is False
+
+
+def test_copy_wins_engages_counter() -> None:
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.metrics()["engages"] == 1
+
+
+# 4. measure_on → dormant (copy loses) ───────────────────────────
+
+def test_copy_loses_transitions_to_dormant() -> None:
+    """Copy cycles with huge cost (low tps) lose to the dflash off-rate."""
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
+    # Off: 4 commits × 50_000 ns → off_rate = 16/(4×50_000/1e9) = 80_000 tps (fast baseline)
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.phase == "measure_on"
+    # On: 2 copy cycles × 4 commits × 1_000_000 ns → on_rate = 8/(2e-3) = 4_000 tps (slow)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
+    assert gate.phase == "dormant"
+    assert gate.engage_copy() is False
+
+
+def test_copy_loses_take_reset_true_once() -> None:
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
+    assert gate.take_reset() is True
+    assert gate.take_reset() is False  # consumed
+
+
+def test_copy_loses_disengages_counter() -> None:
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
+    assert gate.metrics()["disengages"] == 1
+
+
+# 5. measure_on max_cycles with zero copy blocks → dormant + reset ─
+
+def test_measure_on_max_cycles_no_copy_goes_dormant() -> None:
+    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, probe_on_max_cycles=5)
+    for _ in range(4):
+        _dflash(gate)
+    assert gate.phase == "measure_on"
+    # 5 dflash cycles (no copy) to hit max_cycles
+    for _ in range(5):
+        _dflash(gate)
+    assert gate.phase == "dormant"
+    assert gate.take_reset() is True
+
+
+# 6. Engaged latch expiry → measure_off + reset ───────────────────
+
+def test_engaged_latch_expiry_returns_to_measure_off_with_reset() -> None:
+    gate = _make_gate(
+        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=3, margin=1.0
+    )
+    # Drive to engaged
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.phase == "engaged"
+    # Expire latch (3 cycles)
+    for _ in range(3):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.phase == "measure_off"
+    assert gate.take_reset() is True
+
+
+def test_engaged_cycles_counter_increments() -> None:
+    gate = _make_gate(
+        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=3, margin=1.0
+    )
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    # 2 more engaged cycles (latch=3, not yet expired)
+    gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.metrics()["engaged_cycles"] == 2
+
+
+# 7. Dormant latch expiry → measure_off, NO reset ─────────────────
+
+def test_dormant_latch_expiry_returns_to_measure_off_no_reset() -> None:
+    gate = _make_gate(
+        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=3, margin=1.0
+    )
+    # Drive to dormant
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
+    assert gate.phase == "dormant"
+    # Consume the reset from entering dormant
+    gate.take_reset()
+    # Expire latch
+    for _ in range(3):
+        _dflash(gate)
+    assert gate.phase == "measure_off"
+    assert gate.take_reset() is False
+
+
+def test_dormant_cycles_counter_increments() -> None:
+    gate = _make_gate(
+        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=5, margin=1.0
+    )
+    for _ in range(4):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
+    assert gate.phase == "dormant"
+    for _ in range(2):
+        _dflash(gate)
+    assert gate.metrics()["dormant_cycles"] == 2
+
+
+# 8. _win_rate: tps vs tpc fallback ──────────────────────────────
+
+def test_win_rate_uses_tps_when_cost_present() -> None:
+    gate = _make_gate(probe_off_cycles=100)  # won't transition during test
+    gate.record_cycle(source="dflash", commit_count=16, cycle_cost_ns=1_000_000)
+    # 16 commits / (1_000_000 / 1e9 seconds) = 16_000.0 tps
+    assert gate._win_rate() == pytest.approx(16_000.0)
+
+
+def test_win_rate_falls_back_to_tpc_when_no_cost() -> None:
+    gate = _make_gate(probe_off_cycles=100)
+    gate.record_cycle(source="dflash", commit_count=8, cycle_cost_ns=None)
+    gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=None)
+    # 12 commits / 2 cycles = 6.0 tpc
+    assert gate._win_rate() == pytest.approx(6.0)
+
+
+def test_win_rate_returns_zero_when_empty() -> None:
+    gate = _make_gate()
+    assert gate._win_rate() == 0.0
+
+
+# 9. Full lifecycle: measure_off → measure_on(win) → engaged → (latch) → measure_off
+
+def test_full_lifecycle_phase_sequence_and_reset_signals() -> None:
+    gate = _make_gate(
+        probe_off_cycles=3,
+        probe_on_min_copy=2,
+        probe_on_max_cycles=8,
+        latch_cycles=4,
+        margin=1.0,
+    )
+    phases = [gate.phase]
+
+    # measure_off: 3 dflash cycles
+    for _ in range(3):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=2_000_000)
+    phases.append(gate.phase)  # should be measure_on
+    assert gate.take_reset() is False  # no reset on transition to measure_on
+
+    # measure_on: 2 copy cycles (fast → win)
+    for _ in range(2):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    phases.append(gate.phase)  # should be engaged
+    assert gate.take_reset() is False  # no reset on engage
+
+    # engaged: run latch_cycles to expire
+    for _ in range(4):
+        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
+    phases.append(gate.phase)  # should be measure_off
+    assert gate.take_reset() is True  # reset when re-baselining
+
+    assert phases == ["measure_off", "measure_on", "engaged", "measure_off"]
+
+
+# 10. __init__ validation ──────────────────────────────────────────
+
+@pytest.mark.parametrize("bad_kwargs,match", [
+    ({"probe_off_cycles": 0}, "probe_off_cycles"),
+    ({"probe_on_min_copy": 0}, "probe_on_min_copy"),
+    ({"probe_on_max_cycles": 0}, "probe_on_max_cycles"),
+    ({"latch_cycles": 0}, "latch_cycles"),
+    ({"margin": 0.0}, "margin"),
+    ({"margin": -1.0}, "margin"),
+])
+def test_init_validation(bad_kwargs: dict, match: str) -> None:
+    valid = dict(
+        probe_off_cycles=4,
+        probe_on_min_copy=2,
+        probe_on_max_cycles=8,
+        latch_cycles=6,
+        margin=1.0,
+    )
+    valid.update(bad_kwargs)
+    with pytest.raises(ValueError, match=match):
+        CopySpecAutoGate(**valid)
+
+
+# 11. metrics() shape ─────────────────────────────────────────────
+
+def test_metrics_returns_expected_keys() -> None:
+    gate = _make_gate()
+    m = gate.metrics()
+    assert set(m.keys()) == {
+        "state", "off_rate", "engaged_cycles",
+        "dormant_cycles", "probes", "engages", "disengages",
+    }
+    assert m["state"] == "measure_off"
+    assert m["off_rate"] is None
+    assert m["engaged_cycles"] == 0
+
+
+# 12. probes counter ──────────────────────────────────────────────
+
+def test_probes_counter_increments_each_measure_on_entry() -> None:
+    gate = _make_gate(probe_off_cycles=2, probe_on_min_copy=1, latch_cycles=2, margin=1.0)
+    # First probe cycle: off → on → dormant → off
+    for _ in range(2):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.metrics()["probes"] == 1
+    # Drain measure_on with 1 copy that loses (high cost)
+    gate.record_cycle(source="copy", commit_count=1, cycle_cost_ns=5_000_000)
+    # wait latch to expire
+    for _ in range(2):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    # Re-baseline complete → second probe
+    for _ in range(2):
+        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
+    assert gate.metrics()["probes"] == 2

--- a/tests/test_generate_cli.py
+++ b/tests/test_generate_cli.py
@@ -100,6 +100,7 @@ def test_generate_cli_passes_verify_mode(monkeypatch):
             "draft_window_size": 512,
             "verify_len_cap": 8,
             "verify_mode": "off",
+            "copyspec_mode": "conservative",
             "draft_quant": "w4",
         }
     ]

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from dflash_mlx.engine.events import SummaryEvent
+from dflash_mlx.generate import format_generation_summary
+
+
+def _summary(**overrides: Any) -> SummaryEvent:
+    defaults: dict[str, Any] = dict(
+        elapsed_us=2_000_000.0,
+        prompt_token_count=10,
+        generated_token_ids=(),
+        generation_tokens=100,
+        accepted_from_draft=75,
+        acceptance_ratio=0.75,
+        cycles_completed=25,
+        phase_timings_us={"prefill": 1_000_000.0},
+    )
+    defaults.update(overrides)
+    return SummaryEvent(**defaults)
+
+
+def test_summary_line_without_copyspec() -> None:
+    line = format_generation_summary(_summary())
+
+    assert line == "100 tokens | 100.0 tok/s | 75.0% acceptance"
+
+
+def test_summary_line_includes_copyspec_when_active() -> None:
+    line = format_generation_summary(
+        _summary(copyspec_hits=4, copyspec_tokens=60)
+    )
+
+    assert line == (
+        "100 tokens | 100.0 tok/s | 75.0% acceptance"
+        " | copyspec 4 blocks / 60 tokens"
+    )

--- a/tests/test_runtime_verify_config.py
+++ b/tests/test_runtime_verify_config.py
@@ -296,6 +296,7 @@ def test_offline_runtime_arguments_project_from_shared_runtime_schema():
         "draft_window_size": 512,
         "verify_len_cap": 0,
         "verify_mode": "ddtree",
+        "copyspec_mode": "conservative",
     }
 
 
@@ -410,3 +411,37 @@ def test_speculative_cycle_config_threads_verify_cap_after_block_clamp():
 
     assert cycle.effective_block_tokens == 12
     assert cycle.verify_len_cap == 4
+
+
+def test_copyspec_mode_default_is_conservative():
+    cfg = runtime_config_from_defaults()
+
+    assert cfg.copyspec_mode == "conservative"
+
+
+def test_copyspec_mode_accepts_valid_choices():
+    for mode in ("conservative", "aggressive", "off"):
+        cfg = runtime_config_from_defaults(copyspec_mode=mode)
+        assert cfg.copyspec_mode == mode
+
+
+def test_copyspec_mode_rejects_invalid_value():
+    with pytest.raises(ValueError, match="copyspec_mode must be conservative"):
+        runtime_config_from_defaults(copyspec_mode="always")
+
+
+def test_offline_runtime_arguments_accept_copyspec_mode():
+    parser = argparse.ArgumentParser()
+    add_offline_runtime_arguments(parser, BENCHMARK_RUNTIME_FIELDS)
+
+    args = parser.parse_args(["--copyspec-mode", "aggressive"])
+
+    assert offline_runtime_kwargs(args, BENCHMARK_RUNTIME_FIELDS)["copyspec_mode"] == "aggressive"
+
+
+def test_offline_runtime_arguments_reject_invalid_copyspec_mode():
+    parser = argparse.ArgumentParser()
+    add_offline_runtime_arguments(parser, BENCHMARK_RUNTIME_FIELDS)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--copyspec-mode", "always"])

--- a/tests/test_runtime_verify_config.py
+++ b/tests/test_runtime_verify_config.py
@@ -420,7 +420,7 @@ def test_copyspec_mode_default_is_conservative():
 
 
 def test_copyspec_mode_accepts_valid_choices():
-    for mode in ("conservative", "aggressive", "off"):
+    for mode in ("conservative", "auto", "off"):
         cfg = runtime_config_from_defaults(copyspec_mode=mode)
         assert cfg.copyspec_mode == mode
 
@@ -434,9 +434,9 @@ def test_offline_runtime_arguments_accept_copyspec_mode():
     parser = argparse.ArgumentParser()
     add_offline_runtime_arguments(parser, BENCHMARK_RUNTIME_FIELDS)
 
-    args = parser.parse_args(["--copyspec-mode", "aggressive"])
+    args = parser.parse_args(["--copyspec-mode", "auto"])
 
-    assert offline_runtime_kwargs(args, BENCHMARK_RUNTIME_FIELDS)["copyspec_mode"] == "aggressive"
+    assert offline_runtime_kwargs(args, BENCHMARK_RUNTIME_FIELDS)["copyspec_mode"] == "auto"
 
 
 def test_offline_runtime_arguments_reject_invalid_copyspec_mode():


### PR DESCRIPTION
## Add `--copyspec-mode` with opt-in `auto` self-gating

Follow-up to #35 / the #36 revert. This adds:

- `--copyspec-mode conservative` as the default, preserving the current one-strike behavior.
- `--copyspec-mode auto` as an opt-in self-gating mode for workloads where prompt-copy drafting is likely to pay off.
- `--copyspec-mode off` for diagnostics and parity.

The important release behavior is that the default remains `conservative`; users do not get `auto` unless they ask for it.

## What `auto` does

`auto` periodically measures baseline DFlash throughput with copyspec off, probes copyspec on, latches to the faster path, resets adaptive block state when disengaging, and uses exponential re-probe backoff when copy blocks do not pay off.

This is useful on strong-copyspec targets where avoiding expensive draft passes can outweigh the probing cost. It should not be described as a universal default for dense targets.

## Maintainer validation

Validated on Apple M5 Max with 120s cooldown between serialized runs.

### Qwen3.6-35B-A3B-4bit + DFlash drafter

- edit3072: base `230.75 tok/s`, conservative `230.88`, auto `277.34` (`+20.19%`), off `224.62`
- fresh3072: base `184.79 tok/s`, conservative `185.02`, auto `199.60` (`+8.01%`), off `182.51`

### Qwen3.6-27B-4bit + DFlash drafter

- edit3072: base `115.59 tok/s`, conservative `118.51`, auto `115.78` (`+0.17%`), off `119.23`
- fresh3072 repeat: base `76.84 tok/s`, conservative `77.38`, auto `73.07` (`-4.91%`), off `81.03`
- README/math1024: base `117.39 tok/s`, conservative `118.82`, auto `112.98` (`-3.75%`), off `110.17`

## Test validation

- Targeted PR tests: `71 passed`
- Copyspec runtime tests: `3 passed`
- Full suite: `1150 passed, 6 skipped`
- `dflash doctor --json`: ok

## Release note

`auto` is a strong opt-in for Qwen3.6-35B-A3B / copy-heavy workloads. Keep `conservative` as the default and do not recommend `auto` broadly for Qwen3.6-27B dense.

Refs #35.
