### PR TITLE
fix: prefer Qwen language_model wrapper

### DIFF
--- a/dflash_mlx/engine/target_qwen_gdn.py
+++ b/dflash_mlx/engine/target_qwen_gdn.py
@@ -756,10 +756,11 @@ class QwenGdnTargetOps:
         return hasattr(inner, "layers") and hasattr(inner, "embed_tokens")
 
     def text_wrapper(self, target_model: Any) -> Any:
+        language_model = getattr(target_model, "language_model", None)
+        if language_model is not None and hasattr(language_model, "model"):
+            return language_model
         if hasattr(target_model, "model"):
             return target_model
-        if hasattr(target_model, "language_model"):
-            return target_model.language_model
         raise AttributeError(f"Unsupported target model wrapper: {type(target_model)!r}")
 
     def text_model(self, target_model: Any) -> Any:

--- a/tests/test_target_ops.py
+++ b/tests/test_target_ops.py
@@ -53,6 +53,16 @@ class _FakeTarget:
             embed_tokens=_FakeEmbed(),
         )
 
+class _WrongOuterEmbed:
+    def as_linear(self, hidden: mx.array) -> mx.array:
+        del hidden
+        return mx.array([[[1.0, 0.0]]])
+
+class _RealQwenLmHead:
+    def __call__(self, hidden: mx.array) -> mx.array:
+        del hidden
+        return mx.array([[[0.0, 1.0]]])
+
 def _fake_qwen_full_attention(*, q_heads: int = 4, kv_heads: int = 1, head_dim: int = 256):
     class _Proj:
         def __init__(self, out_dim: int) -> None:
@@ -260,6 +270,31 @@ def test_resolver_rejects_empty_model_type_even_with_qwen_like_shape():
         assert "model_type=unknown" in str(exc)
     else:
         raise AssertionError("empty model_type must not resolve to Qwen ops")
+
+def test_qwen_text_wrapper_prefers_language_model_over_outer_model():
+    real_text_wrapper = SimpleNamespace(
+        args=SimpleNamespace(tie_word_embeddings=False),
+        model=SimpleNamespace(layers=[_FakeFaLayer()], embed_tokens=_FakeEmbed()),
+        lm_head=_RealQwenLmHead(),
+    )
+    outer_wrapper = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[_FakeFaLayer()],
+            embed_tokens=_WrongOuterEmbed(),
+        ),
+        language_model=real_text_wrapper,
+    )
+
+    ops = QwenGdnTargetOps()
+    hidden = mx.zeros((1, 1, 1))
+    logits = ops.logits_from_hidden(outer_wrapper, hidden)
+    expected = real_text_wrapper.lm_head(hidden)
+    mx.eval(logits, expected)
+
+    assert ops.text_wrapper(outer_wrapper) is real_text_wrapper
+    assert int(mx.argmax(logits[:, -1, :], axis=-1).item()) == int(
+        mx.argmax(expected[:, -1, :], axis=-1).item()
+    )
 
 def test_capabilities_for_distinguishes_hybrid_and_pure_attention():
     ops = QwenGdnTargetOps()


### PR DESCRIPTION
## Summary

- Prefer `target_model.language_model` when the outer Qwen wrapper also exposes `.model`.
- Keep the direct Qwen text-model path unchanged when no valid language wrapper is present.
- Add a regression test for untied Qwen logits, where selecting the outer wrapper projects through the wrong `embed_tokens.as_linear` path instead of the real `lm_head`.

## Context

This is the dflash-mlx-side guard for the wrapper shape seen in jundot/omlx#1707. Pure `mlx_lm 0.31.3` Qwen text models on this machine expose only `.model`, so the direct CLI path does not naturally trigger the bug here. The backend was still fragile: any integration that passes an outer wrapper with both `.model` and `.language_model` can silently compute verifier logits from the wrong head.

## Validation

- Repro against published `v0.1.9`: `/tmp/dflash-qwen-wrapper-repro/test_qwen_text_wrapper_bug.py` fails.
- Same repro against this branch: passes.
- `PYTHONPATH=$PWD /Users/bastienbouge/Documents/dev/dflash-mlx/.venv/bin/python -m pytest tests/test_target_ops.py tests/test_target_qwen_tree.py tests/test_target_fa_window.py tests/test_engine_rollback.py tests/test_dflash_swa_mask.py -q` -> `67 passed`.
- `PYTHONPATH=$PWD /Users/bastienbouge/Documents/dev/dflash-mlx/.venv/bin/python -m pytest tests/ -q` -> `1151 passed, 6 skipped`.
- `git diff --check` -> pass.
