### PR TITLE
Support concurrent multi-model hosts: cache-manager registry + fail-loud target hooks

### DIFF
--- a/dflash_mlx/cache/manager.py
+++ b/dflash_mlx/cache/manager.py
@@ -18,8 +18,16 @@ from dflash_mlx.cache.prefix_l2 import DFlashPrefixL2Cache
 from dflash_mlx.cache.snapshot import DFlashPrefixSnapshot
 from dflash_mlx.cache.store import PrefixSnapshotStore
 
-_DFLASH_RUNTIME_CACHE_MANAGER: Optional["RuntimeCacheManager"] = None
-_DFLASH_RUNTIME_CACHE_CONFIG_KEY: Optional[tuple[Any, ...]] = None
+# Live cache managers keyed by per-model cache_identity (config_key[0]), so a
+# host serving several models in one process keeps each model's prefix cache
+# alive instead of retiring it when another model loads. The stored config_key
+# distinguishes a same-model reconfiguration (replace the entry) from a
+# different-model load (keep both). The standalone server loads one model, so
+# the registry holds a single entry; embedders may host several at once.
+_DFLASH_RUNTIME_CACHE_REGISTRY: "dict[Any, tuple[tuple[Any, ...], RuntimeCacheManager]]" = {}
+# Identity of the most recently resolved manager — backs the keyless
+# current_runtime_cache_manager() used by the single-model metrics endpoint.
+_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY: Any = None
 _DFLASH_RUNTIME_CACHE_LOCK = threading.Lock()
 _MIN_L2_FRONTIER_STRIDE = 8192
 
@@ -222,30 +230,31 @@ def get_runtime_cache_manager(
     *,
     cache_identity: Any = None,
 ) -> Optional[RuntimeCacheManager]:
-    global _DFLASH_RUNTIME_CACHE_CONFIG_KEY, _DFLASH_RUNTIME_CACHE_MANAGER
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
     if runtime_context is None:
         return None
     if _runtime_cache_disabled(runtime_context):
-        _clear_runtime_cache_manager()
+        _clear_runtime_cache_identity(cache_identity)
         return None
     config_key = _prefix_cache_config_key(runtime_context, cache_identity=cache_identity)
+    identity = config_key[0]
     trace_config = runtime_context.diagnostics.trace
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
-        if (
-            manager is not None
-            and _DFLASH_RUNTIME_CACHE_CONFIG_KEY == config_key
-            and not manager._is_retired()
-        ):
-            manager.set_trace_config(trace_config)
-            return manager
-        if manager is not None:
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
+        if entry is not None:
+            existing_key, manager = entry
+            if existing_key == config_key and not manager._is_retired():
+                manager.set_trace_config(trace_config)
+                _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = identity
+                return manager
+            # Same model, reconfigured (or retired): retire the old entry and
+            # rebuild. A shutdown failure here leaves the retired entry in place
+            # and propagates, mirroring the single-slot contract.
             _shutdown_manager(manager)
-            _DFLASH_RUNTIME_CACHE_MANAGER = None
-            _DFLASH_RUNTIME_CACHE_CONFIG_KEY = None
+            del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
         manager = RuntimeCacheManager(_make_prefix_store(runtime_context))
-        _DFLASH_RUNTIME_CACHE_MANAGER = manager
-        _DFLASH_RUNTIME_CACHE_CONFIG_KEY = config_key
+        _DFLASH_RUNTIME_CACHE_REGISTRY[identity] = (config_key, manager)
+        _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = identity
         return manager
 
 
@@ -254,45 +263,85 @@ def sync_runtime_cache_manager(
     *,
     cache_identity: Any = None,
 ) -> Optional[RuntimeCacheManager]:
-    global _DFLASH_RUNTIME_CACHE_CONFIG_KEY, _DFLASH_RUNTIME_CACHE_MANAGER
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
     if runtime_context is None:
         return None
     if _runtime_cache_disabled(runtime_context):
-        _clear_runtime_cache_manager()
+        _clear_runtime_cache_identity(cache_identity)
         return None
     config_key = _prefix_cache_config_key(runtime_context, cache_identity=cache_identity)
+    identity = config_key[0]
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
-        if manager is None:
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
+        if entry is None:
             return None
-        if _DFLASH_RUNTIME_CACHE_CONFIG_KEY != config_key or manager._is_retired():
+        existing_key, manager = entry
+        if existing_key != config_key or manager._is_retired():
             _shutdown_manager(manager)
-            _DFLASH_RUNTIME_CACHE_MANAGER = None
-            _DFLASH_RUNTIME_CACHE_CONFIG_KEY = None
+            del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+            if _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY == identity:
+                _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
             return None
         manager.set_trace_config(runtime_context.diagnostics.trace)
+        _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = identity
         return manager
 
 
 def current_runtime_cache_manager() -> Optional[RuntimeCacheManager]:
+    """Return the most recently resolved manager (single-model metrics view).
+
+    With several models registered this is the last one get/sync'd. Per-request
+    code must use the manager carried on its ``PrefixCacheFlow`` instead, which
+    is always the right model regardless of interleaving.
+    """
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
-        if manager is None or manager._is_retired():
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY)
+        if entry is None:
+            return None
+        _, manager = entry
+        if manager._is_retired():
             return None
         return manager
 
 
-def shutdown_runtime_cache_manager() -> None:
-    _clear_runtime_cache_manager(raise_on_error=False)
+def shutdown_runtime_cache_manager(
+    runtime_context: Optional[Any] = None,
+    *,
+    cache_identity: Any = None,
+) -> None:
+    """Retire cache managers.
+
+    No args retires *all* registered managers (process/server teardown). Passing
+    a ``runtime_context`` and/or ``cache_identity`` retires just that model's
+    manager, leaving any others serving (oMLX per-engine unload).
+    """
+    if runtime_context is None and cache_identity is None:
+        _clear_all_runtime_cache_managers(raise_on_error=False)
+        return
+    _clear_runtime_cache_identity(cache_identity, raise_on_error=False)
 
 
-def _clear_runtime_cache_manager(*, raise_on_error: bool = True) -> None:
-    global _DFLASH_RUNTIME_CACHE_CONFIG_KEY, _DFLASH_RUNTIME_CACHE_MANAGER
+def _clear_runtime_cache_identity(identity: Any, *, raise_on_error: bool = True) -> None:
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
+        if entry is None:
+            return
+        _, manager = entry
         if _shutdown_manager(manager, raise_on_error=raise_on_error):
-            _DFLASH_RUNTIME_CACHE_MANAGER = None
-            _DFLASH_RUNTIME_CACHE_CONFIG_KEY = None
+            del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+            if _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY == identity:
+                _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
+
+
+def _clear_all_runtime_cache_managers(*, raise_on_error: bool = True) -> None:
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
+    with _DFLASH_RUNTIME_CACHE_LOCK:
+        for identity in list(_DFLASH_RUNTIME_CACHE_REGISTRY.keys()):
+            _, manager = _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+            if _shutdown_manager(manager, raise_on_error=raise_on_error):
+                del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+        _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
 
 
 def _prefix_cache_config_key(

--- a/dflash_mlx/engine/_hook_guard.py
+++ b/dflash_mlx/engine/_hook_guard.py
@@ -1,0 +1,40 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Guard for class-level target hooks shared across backends.
+
+Target backends install speculative hooks by replacing ``cls.__call__`` on a
+model's attention class and tagging the class with a marker so a second install
+is a no-op. The marker is keyed by the class *object*, which is safe only while
+each attention class resolves to exactly one target backend. Should two model
+families that resolve to different backends ever share an attention class, a
+bare boolean marker would let whichever backend installed first silently run
+its attention for the other model. This guard makes that case fail loudly.
+"""
+from __future__ import annotations
+
+
+class DFlashHookConflict(RuntimeError):
+    """Two target backends tried to patch the same attention class."""
+
+
+def claim_class_hook(cls: type, attr: str, owner: str) -> bool:
+    """Claim the class-level hook slot ``attr`` on ``cls`` for ``owner``.
+
+    Returns ``True`` when the slot is free (the caller should install and then
+    set ``cls.attr = owner``) and ``False`` when ``owner`` already installed it
+    (the caller should no-op). Raises :class:`DFlashHookConflict` when a
+    *different* backend already owns the slot.
+    """
+    existing = getattr(cls, attr, None)
+    if existing is None:
+        return True
+    if existing == owner:
+        return False
+    raise DFlashHookConflict(
+        f"{cls.__module__}.{cls.__qualname__} is already patched by DFlash target "
+        f"backend {existing!r}; backend {owner!r} cannot reuse the same attention "
+        f"class. Two model families that share an attention class must resolve to "
+        f"the same target backend."
+    )

--- a/dflash_mlx/engine/target_gemma4.py
+++ b/dflash_mlx/engine/target_gemma4.py
@@ -16,6 +16,7 @@ from dflash_mlx.engine.gqa_sdpa import (
     per_head_gqa_sdpa,
     repeat_gqa_mask,
 )
+from dflash_mlx.engine._hook_guard import claim_class_hook
 from dflash_mlx.engine.sparse_rope import SPARSE_POSITIONS_ATTR
 from dflash_mlx.engine.target_ops import TargetCapabilities
 
@@ -216,7 +217,7 @@ def _gemma4_full_gqa_sdpa(
 
 def _install_full_attention_gqa_hook(attn: Any) -> None:
     cls = type(attn)
-    if getattr(cls, "_dflash_full_attention_gqa_installed", False):
+    if not claim_class_hook(cls, "_dflash_full_attention_gqa_installed", "gemma4"):
         return
 
     original_call = cls.__call__
@@ -279,7 +280,7 @@ def _install_full_attention_gqa_hook(attn: Any) -> None:
         return self.o_proj(output), (keys, values), offset
 
     cls.__call__ = attention_call
-    cls._dflash_full_attention_gqa_installed = True
+    cls._dflash_full_attention_gqa_installed = "gemma4"
 
 
 class Gemma4TargetOps:

--- a/dflash_mlx/engine/target_qwen_gdn.py
+++ b/dflash_mlx/engine/target_qwen_gdn.py
@@ -17,6 +17,7 @@ from mlx_lm.models.base import (
     scaled_dot_product_attention,
 )
 
+from dflash_mlx.engine._hook_guard import claim_class_hook
 from dflash_mlx.engine.gqa_sdpa import (
     async_per_head_gqa_sdpa,
     grouped_gqa_sdpa,
@@ -543,7 +544,7 @@ def _commit_recurrent_tree_path(
 
 def _install_speculative_linear_cache_hook(linear_attn: Any) -> None:
     cls = type(linear_attn)
-    if getattr(cls, "_dflash_speculative_call_installed", False):
+    if not claim_class_hook(cls, "_dflash_speculative_call_installed", "qwen_gdn"):
         return
 
     original_call = cls.__call__
@@ -651,11 +652,11 @@ def _install_speculative_linear_cache_hook(linear_attn: Any) -> None:
         return out
 
     cls.__call__ = speculative_call
-    cls._dflash_speculative_call_installed = True
+    cls._dflash_speculative_call_installed = "qwen_gdn"
 
 def _install_full_attention_gqa_hook(attn: Any) -> None:
     cls = type(attn)
-    if getattr(cls, "_dflash_full_attention_gqa_installed", False):
+    if not claim_class_hook(cls, "_dflash_full_attention_gqa_installed", "qwen_gdn"):
         return
 
     original_call = cls.__call__
@@ -725,7 +726,7 @@ def _install_full_attention_gqa_hook(attn: Any) -> None:
         return self.o_proj(gated_output)
 
     cls.__call__ = attention_call
-    cls._dflash_full_attention_gqa_installed = True
+    cls._dflash_full_attention_gqa_installed = "qwen_gdn"
 
 class QwenGdnTargetOps:
     backend_name = "qwen_gdn"

--- a/dflash_mlx/server/request_loop.py
+++ b/dflash_mlx/server/request_loop.py
@@ -24,7 +24,6 @@ from dflash_mlx.engine.events import (
     SummaryEvent,
     TokenEvent,
 )
-from dflash_mlx.cache.manager import current_runtime_cache_manager
 from dflash_mlx.observability.memory import process_memory_snapshot
 from dflash_mlx.server.prefix_cache_flow import PrefixCacheFlow
 from dflash_mlx.server.metrics import record_cycle_diagnostic, update_live_request
@@ -118,7 +117,11 @@ def consume_dflash_events(
                 fields=memory_start,
             )
 
-    cache_manager = current_runtime_cache_manager()
+    # Use the manager resolved for THIS request rather than the process-wide
+    # "current" one: with several models registered, the global current can
+    # point at a different model when requests interleave. prefix_flow carries
+    # the right model's manager (or None when the cache is off for it).
+    cache_manager = prefix_flow.cache_manager if prefix_flow is not None else None
     if cache_manager is not None:
         cache_manager.begin_request()
     try:

--- a/tests/test_cache_manager_registry.py
+++ b/tests/test_cache_manager_registry.py
@@ -1,0 +1,115 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Registry semantics for the runtime cache manager.
+
+Two DFlash models loaded in one process (e.g. an embedding host's engine
+pool) must each keep their own prefix-cache manager alive concurrently.
+Previously a single process-global slot meant loading the second model
+retired the first's cache. These tests pin the registry contract:
+
+  * distinct cache identities coexist (neither retired),
+  * the same identity + same config returns the same manager,
+  * the same identity reconfigured replaces (and retires) the old one,
+  * shutdown can target one identity or clear all.
+"""
+from __future__ import annotations
+
+import pytest
+
+import dflash_mlx.cache.manager as cm
+from dflash_mlx.runtime.config import runtime_config_from_defaults
+from dflash_mlx.runtime.context import build_runtime_context
+
+
+def _ctx(**overrides):
+    values = dict(
+        prefix_cache=True,
+        prefix_cache_l2=False,
+        prefix_cache_l2_dir="/tmp/dflash-prefix-l2-registry-test",
+    )
+    values.update(overrides)
+    return build_runtime_context(runtime_config_from_defaults(**values))
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    # Start and end each test with an empty registry so order can't leak state.
+    cm.shutdown_runtime_cache_manager()
+    yield
+    cm.shutdown_runtime_cache_manager()
+
+
+def test_distinct_identities_coexist():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+
+    assert mgr_a is not None and mgr_b is not None
+    assert mgr_a is not mgr_b
+    # The crux of #1892: loading B must NOT retire A.
+    assert mgr_a.active
+    assert mgr_b.active
+
+
+def test_same_identity_same_config_returns_same_manager():
+    ctx = _ctx()
+    first = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    second = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    assert first is second
+
+
+def test_same_identity_reconfig_replaces_and_retires_old():
+    first = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache_max_entries=2), cache_identity="model-A"
+    )
+    second = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache_max_entries=7), cache_identity="model-A"
+    )
+    assert first is not second
+    assert not first.active  # reconfigured -> old retired
+    assert second.active
+    assert second.stats()["max_entries"] == 7
+
+
+def test_reconfig_of_one_identity_leaves_other_untouched():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    # Reconfigure only A.
+    mgr_a2 = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache_max_entries=9), cache_identity="model-A"
+    )
+    assert mgr_a2 is not mgr_a
+    assert not mgr_a.active
+    assert mgr_a2.active
+    assert mgr_b.active  # B is unaffected
+
+
+def test_sync_resolves_per_identity():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-A") is mgr_a
+    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-B") is mgr_b
+
+
+def test_keyed_shutdown_only_retires_that_identity():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    cm.shutdown_runtime_cache_manager(ctx, cache_identity="model-A")
+    assert not mgr_a.active
+    assert mgr_b.active  # B survives A's unload
+    # A's slot is gone; B is still resolvable.
+    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-B") is mgr_b
+
+
+def test_shutdown_all_retires_everything():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    cm.shutdown_runtime_cache_manager()  # no args == teardown all
+    assert not mgr_a.active
+    assert not mgr_b.active

--- a/tests/test_prefix_cache_integration.py
+++ b/tests/test_prefix_cache_integration.py
@@ -189,7 +189,7 @@ class TestServeHelperShapes:
     def test_get_cache_disabled(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
         assert cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(prefix_cache=False)
         ) is None
@@ -197,8 +197,8 @@ class TestServeHelperShapes:
     def test_get_cache_enabled_returns_singleton(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(prefix_cache=True)
         first = cache_manager_mod.get_runtime_cache_manager(context)
         second = cache_manager_mod.get_runtime_cache_manager(context)
@@ -328,7 +328,7 @@ class TestContextConfigExposedCorrectly:
     def test_prefix_cache_config_affects_singleton(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
         assert cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(prefix_cache=False)
         ) is None
@@ -340,8 +340,8 @@ class TestContextConfigExposedCorrectly:
     def test_singleton_rebuilds_when_config_changes(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         first = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(prefix_cache=True, prefix_cache_max_entries=2)
         )
@@ -364,8 +364,8 @@ class TestContextConfigExposedCorrectly:
             shutdown_calls.append(self)
             return original_shutdown(self)
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
 
         first = cache_manager_mod.get_runtime_cache_manager(
@@ -394,29 +394,29 @@ class TestContextConfigExposedCorrectly:
             return _store(max_entries=2)
 
         old_manager = RuntimeCacheManager(_store(BrokenShutdownCache(max_entries=2)))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
 
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=True))
 
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         with pytest.raises(RuntimeError, match="shut down"):
             old_manager.stats()
         assert make_calls == []
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=True))
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         assert make_calls == []
 
     def test_retired_manager_handle_fails_after_clear(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(prefix_cache=True)
         manager = cache_manager_mod.get_runtime_cache_manager(context)
         assert manager is not None
@@ -438,7 +438,7 @@ class TestContextConfigExposedCorrectly:
         thread = threading.Thread(target=worker)
         thread.start()
         assert ready.wait(timeout=2.0)
-        cache_manager_mod._clear_runtime_cache_manager()
+        cache_manager_mod._clear_all_runtime_cache_managers()
         proceed.set()
         thread.join(timeout=2.0)
 
@@ -467,14 +467,14 @@ class TestContextConfigExposedCorrectly:
             return _store(max_entries=2)
 
         old_manager = RuntimeCacheManager(_store(BlockingShutdownCache(max_entries=2)))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
         context = _runtime_context(prefix_cache=True)
 
         def clear_worker() -> None:
             try:
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -522,12 +522,12 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingTraceCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def get_worker() -> None:
             try:
@@ -538,7 +538,7 @@ class TestContextConfigExposedCorrectly:
         def clear_worker() -> None:
             try:
                 clear_started.set()
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -579,12 +579,12 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingTraceCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def sync_worker() -> None:
             try:
@@ -595,7 +595,7 @@ class TestContextConfigExposedCorrectly:
         def clear_worker() -> None:
             try:
                 clear_started.set()
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -637,12 +637,12 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingLookupCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def lookup_worker() -> None:
             try:
@@ -653,7 +653,7 @@ class TestContextConfigExposedCorrectly:
         def clear_worker() -> None:
             try:
                 clear_started.set()
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -714,8 +714,8 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingInsertCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
 
         def insert_worker() -> None:
@@ -733,7 +733,7 @@ class TestContextConfigExposedCorrectly:
 
         def clear_worker() -> None:
             try:
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -785,12 +785,12 @@ class TestContextConfigExposedCorrectly:
                 return super().shutdown()
 
         old_manager = _manager(BlockingShutdownCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def clear_worker() -> None:
             try:
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -832,8 +832,8 @@ class TestContextConfigExposedCorrectly:
 
         old_cache = TrackedShutdownCache(max_entries=2)
         old_manager = _manager(old_cache)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(
             cache_manager_mod,
             "_make_prefix_store",
@@ -846,11 +846,46 @@ class TestContextConfigExposedCorrectly:
         assert cache_manager_mod.current_runtime_cache_manager() is None
         assert shutdown_calls == [old_cache]
 
-    def test_l2_rebuild_releases_old_lock_before_new_manager(self, monkeypatch, tmp_path):
+    def test_l2_same_identity_rebuild_releases_old_lock(self, monkeypatch, tmp_path):
+        # A same-identity reconfiguration rebuilds the manager: the old one is
+        # retired and releases its L2 disk lock before the new one opens, so the
+        # replacement reclaims a writable L2 on the same directory.
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
+        l2_dir = str(tmp_path / "l2")
+
+        def _ctx(max_entries):
+            return _runtime_context(
+                prefix_cache=True,
+                prefix_cache_l2=True,
+                prefix_cache_l2_dir=l2_dir,
+                prefix_cache_max_entries=max_entries,
+            )
+
+        try:
+            first = cache_manager_mod.get_runtime_cache_manager(_ctx(2), cache_identity="model-a")
+            assert first is not None
+            assert first.stats()["l2"]["writable"] is True
+
+            second = cache_manager_mod.get_runtime_cache_manager(_ctx(7), cache_identity="model-a")
+            assert second is not None
+            assert second is not first
+            assert not first.active  # rebuild retired the old manager...
+            assert second.stats()["l2"]["writable"] is True  # ...and freed the L2 lock
+        finally:
+            cache_manager_mod.shutdown_runtime_cache_manager()
+
+    def test_l2_concurrent_models_sharing_dir_make_second_read_only(self, monkeypatch, tmp_path):
+        # Two distinct models coexist in the registry. If they happen to share an
+        # L2 directory, only the first holds the writable lock; the second serves
+        # read-only L2 (graceful L1-only degradation, never corruption). Hosts
+        # that want writable L2 per model should give each a distinct L2 dir.
+        import dflash_mlx.cache.manager as cache_manager_mod
+
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(
             prefix_cache=True,
             prefix_cache_l2=True,
@@ -859,13 +894,11 @@ class TestContextConfigExposedCorrectly:
 
         try:
             first = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-a")
-            assert first is not None
-            assert first.stats()["l2"]["writable"] is True
-
             second = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-b")
-            assert second is not None
             assert second is not first
-            assert second.stats()["l2"]["writable"] is True
+            assert first.active and second.active  # both stay loaded
+            assert first.stats()["l2"]["writable"] is True
+            assert second.stats()["l2"]["writable"] is False
         finally:
             cache_manager_mod.shutdown_runtime_cache_manager()
 
@@ -879,8 +912,8 @@ class TestContextConfigExposedCorrectly:
             shutdown_calls.append(self)
             return original_shutdown(self)
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
 
         manager = cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=True))
@@ -901,20 +934,16 @@ class TestContextConfigExposedCorrectly:
         manager = _manager(BrokenShutdownCache(max_entries=2))
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_MANAGER",
-            manager,
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (("old",), manager)},
         )
-        monkeypatch.setattr(
-            cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            ("old",),
-        )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         cache_manager_mod.shutdown_runtime_cache_manager()
 
         assert "runtime cache manager shutdown failed: broken close" in capsys.readouterr().err
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is manager
         with pytest.raises(RuntimeError, match="shut down"):
             manager.stats()
 
@@ -926,14 +955,14 @@ class TestContextConfigExposedCorrectly:
                 raise RuntimeError("cannot close")
 
         old_manager = _manager(BrokenShutdownCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=False))
 
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         with pytest.raises(RuntimeError, match="shut down"):
             old_manager.stats()
 
@@ -954,19 +983,19 @@ class TestContextConfigExposedCorrectly:
         old_manager = _manager(BrokenShutdownCache(max_entries=2))
         with pytest.raises(RuntimeError, match="cannot close"):
             old_manager.shutdown()
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
 
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.sync_runtime_cache_manager(context)
 
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         assert make_calls == []
 
     def test_sync_clears_poisoned_manager_after_successful_retry(self, monkeypatch):
@@ -985,18 +1014,18 @@ class TestContextConfigExposedCorrectly:
         old_manager = _manager(FlakyShutdownCache(max_entries=2))
         with pytest.raises(RuntimeError, match="first close failed"):
             old_manager.shutdown()
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         assert cache_manager_mod.sync_runtime_cache_manager(context) is None
 
         assert len(shutdown_calls) == 2
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is None
+        assert None not in cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY
 
     def test_chat_template_stable_marker_returns_none_without_converter(self):
         from dflash_mlx.server.prefix_cache_manager import chat_template_stable_marker
@@ -1051,8 +1080,8 @@ class TestContextConfigExposedCorrectly:
     def test_budgets_propagate_to_cache(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1068,8 +1097,8 @@ class TestContextConfigExposedCorrectly:
     def test_l2_frontier_stride_has_disk_pressure_floor(self, monkeypatch, tmp_path):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1085,8 +1114,8 @@ class TestContextConfigExposedCorrectly:
     def test_l2_frontier_stride_never_splits_prefill_chunks(self, monkeypatch, tmp_path):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1102,8 +1131,8 @@ class TestContextConfigExposedCorrectly:
     def test_l2_frontier_stride_rounds_floor_to_chunk_multiple(self, monkeypatch, tmp_path):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1121,8 +1150,8 @@ class TestContextConfigExposedCorrectly:
     ):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(
             prefix_cache=True,
             prefix_cache_l2=True,
@@ -1141,8 +1170,8 @@ class TestContextConfigExposedCorrectly:
     def test_frontier_stride_disabled_without_l2(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1160,8 +1189,8 @@ class TestContextConfigExposedCorrectly:
         def raise_os_error(**_kwargs):
             raise OSError("l2 unavailable")
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "DFlashPrefixL2Cache", raise_os_error)
 
         manager = cache_manager_mod.get_runtime_cache_manager(
@@ -1178,8 +1207,8 @@ class TestContextConfigExposedCorrectly:
         def raise_type_error(**_kwargs):
             raise TypeError("bad l2 constructor")
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "DFlashPrefixL2Cache", raise_type_error)
 
         with pytest.raises(TypeError, match="bad l2 constructor"):
@@ -1239,8 +1268,8 @@ class TestContextConfigExposedCorrectly:
     def test_singleton_rebuilds_when_identity_changes(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(prefix_cache=True)
 
         first = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-a")

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -567,12 +567,15 @@ def test_metrics_startup_clears_stale_cache_when_runtime_disables_prefix_cache(m
         return original_shutdown(self)
 
     stale_cache = DFlashPrefixCache()
+    stale_identity = ("target-model", None, "draft-model")
     monkeypatch.setattr(
         cache_manager_mod,
-        "_DFLASH_RUNTIME_CACHE_MANAGER",
-        RuntimeCacheManager(PrefixSnapshotStore(l1=stale_cache)),
+        "_DFLASH_RUNTIME_CACHE_REGISTRY",
+        {stale_identity: (("old",), RuntimeCacheManager(PrefixSnapshotStore(l1=stale_cache)))},
     )
-    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+    monkeypatch.setattr(
+        cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", stale_identity
+    )
     monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
     monkeypatch.setattr(
         metrics_mod,
@@ -617,8 +620,8 @@ def test_metrics_startup_preserves_request_cache_identity(monkeypatch):
         ),
     )
     cache_identity = build_prefix_key(model_provider, draft_model, runtime_context)
-    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
     existing = cache_manager_mod.get_runtime_cache_manager(
         runtime_context,
         cache_identity=cache_identity,

--- a/tests/test_server_request_loop.py
+++ b/tests/test_server_request_loop.py
@@ -284,7 +284,9 @@ def test_consume_dflash_events_updates_live_cycle_metrics_before_summary(monkeyp
 
 
 def test_consume_dflash_events_ignores_snapshot_publication_metadata():
-    prefix_flow = SimpleNamespace(lookup_ms=0.1, hit_tokens=2, insert_ms=0.5)
+    prefix_flow = SimpleNamespace(
+        lookup_ms=0.1, hit_tokens=2, insert_ms=0.5, cache_manager=None
+    )
     rqueue = SimpleQueue()
     events = ClosableEvents(
         [
@@ -383,6 +385,7 @@ def test_server_runtime_routes_tool_chat_generation_snapshot_policy(monkeypatch)
         snapshot_service=object(),
         stable_prefix_len=3,
         cache_active=True,
+        cache_manager=None,
         publish_generation_snapshot=True,
         insert_ms=0.0,
         prefix_cache_memory_bytes=lambda: None,
@@ -487,6 +490,7 @@ def test_memory_waterfall_events_are_enriched_with_prefix_cache_memory():
         lookup_ms = 0.0
         hit_tokens = 0
         insert_ms = 0.0
+        cache_manager = None
 
         def prefix_cache_memory_bytes(self):
             return {

--- a/tests/test_target_fa_window.py
+++ b/tests/test_target_fa_window.py
@@ -207,14 +207,10 @@ def test_prefix_cache_flow_disabled_for_windowed_target(monkeypatch):
     preexisting_cache = DFlashPrefixCache()
     monkeypatch.setattr(
         cache_manager_mod,
-        "_DFLASH_RUNTIME_CACHE_MANAGER",
-        RuntimeCacheManager(PrefixSnapshotStore(l1=preexisting_cache)),
+        "_DFLASH_RUNTIME_CACHE_REGISTRY",
+        {None: (("old",), RuntimeCacheManager(PrefixSnapshotStore(l1=preexisting_cache)))},
     )
-    monkeypatch.setattr(
-        cache_manager_mod,
-        "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-        ("old",),
-    )
+    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
     monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
 
     flow = flow_mod.PrefixCacheFlow.for_request(

--- a/tests/test_target_hook_guard.py
+++ b/tests/test_target_hook_guard.py
@@ -1,0 +1,92 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Cross-backend safety for class-level target hooks.
+
+Target backends patch the attention class (``cls.__call__``) and tag it with a
+per-class marker so a second install is a no-op. The marker is keyed by class
+*object*, which is safe only while each attention class maps to exactly one
+target backend. If a future model routed to a different backend shared an
+attention class with an existing one, a bare boolean marker would let the
+first-installed backend's attention silently run for the second model. These
+tests pin the fail-loud contract: a different backend claiming an already
+patched class raises instead of silently skipping.
+"""
+from __future__ import annotations
+
+import mlx.nn as nn
+import pytest
+
+from dflash_mlx.engine._hook_guard import DFlashHookConflict, claim_class_hook
+
+
+def test_free_slot_is_claimable():
+    class A(nn.Module):
+        pass
+
+    assert claim_class_hook(A, "_marker", "gemma4") is True
+
+
+def test_same_owner_reclaim_is_noop():
+    class A(nn.Module):
+        pass
+
+    assert claim_class_hook(A, "_marker", "gemma4") is True
+    A._marker = "gemma4"  # installer sets the marker after patching
+    assert claim_class_hook(A, "_marker", "gemma4") is False
+
+
+def test_different_owner_raises():
+    class A(nn.Module):
+        pass
+
+    A._marker = "gemma4"
+    with pytest.raises(DFlashHookConflict, match="already patched"):
+        claim_class_hook(A, "_marker", "qwen_gdn")
+
+
+def test_installers_fail_loud_on_shared_attention_class():
+    # Real installers must wire the guard: a gemma4-claimed class cannot then be
+    # claimed by the qwen backend. (The claim runs before any attention math, so
+    # this needs no real weights.)
+    from dflash_mlx.engine.target_gemma4 import (
+        _install_full_attention_gqa_hook as gemma_install,
+    )
+    from dflash_mlx.engine.target_qwen_gdn import (
+        _install_full_attention_gqa_hook as qwen_install,
+    )
+
+    class SharedAttn(nn.Module):
+        def __call__(self, *args, **kwargs):  # patched by the installer
+            return None
+
+    inst = SharedAttn()
+    gemma_install(inst)  # claims the class for gemma4
+    # A second gemma install on the same class is a no-op.
+    gemma_install(inst)
+    with pytest.raises(DFlashHookConflict):
+        qwen_install(inst)  # different backend, same class -> loud failure
+
+
+def test_same_backend_two_models_sharing_attention_class_is_safe():
+    # Two different model architectures that resolve to the SAME backend may
+    # share an attention class (e.g. plain qwen3 and qwen3-next both use
+    # qwen3_next.Qwen3NextAttention). Installing the backend's hook for the
+    # second model on the already-patched class must be a silent no-op, not a
+    # conflict — the shared call is stateless and reads per-instance weights.
+    from dflash_mlx.engine.target_qwen_gdn import (
+        _install_full_attention_gqa_hook as qwen_install,
+    )
+
+    class SharedQwenAttn(nn.Module):
+        def __call__(self, *args, **kwargs):
+            return None
+
+    model_a_attn = SharedQwenAttn()
+    model_b_attn = SharedQwenAttn()  # distinct instance, same class
+    qwen_install(model_a_attn)  # model A claims qwen_gdn
+    qwen_install(model_b_attn)  # model B: same class + backend -> no-op, no raise
+    assert (
+        getattr(SharedQwenAttn, "_dflash_full_attention_gqa_installed") == "qwen_gdn"
+    )

--- a/tests/test_target_ops.py
+++ b/tests/test_target_ops.py
@@ -547,7 +547,7 @@ def test_gemma4_full_attention_gqa_hook_is_internal():
     full_attn = model.model.layers[1].self_attn
     assert not hasattr(sliding_attn, "_dflash_split_sdpa_enabled")
     assert not hasattr(full_attn, "_dflash_split_sdpa_enabled")
-    assert getattr(type(full_attn), "_dflash_full_attention_gqa_installed") is True
+    assert getattr(type(full_attn), "_dflash_full_attention_gqa_installed") == "gemma4"
 
 def test_gemma4_logits_use_tied_embedding_head():
     target = _FakeGemmaLogitTarget(tied=True)


### PR DESCRIPTION
Fixes #44.

dflash-mlx assumes one model per process. When embedded in a host that serves several models in one process, two process-global pieces of state limit it to one DFlash model at a time. This makes both safe for concurrent multi-model use, with **no behavior change for the single-model standalone server**.

## 1. Cache manager → registry keyed by model identity (`feat(cache)`)

`dflash_mlx/cache/manager.py` kept the runtime prefix-cache manager in a single process-global slot; loading a second model with a different `config_key` shut down and replaced the first model's manager, so a multi-model host lost the prefix cache of every model but the most recent.

- The manager is now a **registry keyed by `cache_identity`** (`config_key[0]`). Distinct models keep their managers alive concurrently; a same-model reconfiguration still replaces (and retires) its previous entry.
- `current_runtime_cache_manager()` tracks the most recently resolved identity (for the single-model metrics endpoint). The **request loop now uses the manager carried on its `PrefixCacheFlow`** instead of the global current — always the right model under interleaving.
- `shutdown_runtime_cache_manager()` with no args retires **all** managers (server teardown); passing a `cache_identity` retires just that model's manager.

## 2. Fail-loud target hooks (`fix(target)`)

`_install_full_attention_gqa_hook` patches `cls.__call__` and tagged the class with a **boolean** marker. The marker is keyed by class object, safe only while each attention class resolves to exactly one backend. The patched call is stateless (dispatches on the per-request `RecurrentRollbackCache._armed`, reads per-instance weights), so same-backend models are fine — but a future model resolving to a *different* backend that shared an attention class would silently run the first backend's attention.

- The marker now records the **owning backend name**; a different backend claiming an already-patched class raises `DFlashHookConflict` instead of silently skipping. Same-backend reinstalls stay a no-op. No behavior change for the current model set (gemma4 and qwen attention classes are distinct objects).

## Known limitation

Two coexisting models sharing an **L2 directory** contend for its writable lock; the second falls back to read-only L2 (graceful L1-only degradation, never corruption). Hosts wanting writable L2 per model should give each a distinct L2 dir (could be auto-namespaced by `cache_identity` later). Pinned by `test_l2_concurrent_models_sharing_dir_make_second_read_only`.

## Test plan

New tests:
- `tests/test_cache_manager_registry.py` — distinct identities coexist; same-identity reconfig replaces+retires; per-identity sync; keyed vs all shutdown.
- `tests/test_target_hook_guard.py` — free/same-owner/different-owner claim; installers fail loud on a shared class across backends; **same-backend two-model shared-class reuse is a safe no-op**.
- `test_l2_same_identity_rebuild_releases_old_lock` + `test_l2_concurrent_models_sharing_dir_make_second_read_only` — L2 lock semantics under the registry.

Existing single-slot tests updated to the registry (poisoning/locking/shutdown-failure semantics preserved; the request-loop now resolves the manager per-request via `PrefixCacheFlow`).

Full suite green against `main` (v0.1.10, `9ca0028`): `1269 passed, 17 skipped`. The only failure on my machine is the pre-existing hardware-dependent `test_verify_kernel_contract` deviation gate (fails identically on `main` with this branch stashed — unrelated).