### PR TITLE
fix: accept nested block_size/rope_theta in z-lab Jun 2026 draft configs

### DIFF
--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -283,6 +283,16 @@ class DFlashDraftModelArgs:
                 data["sliding_window"] = _GEMMA4_DEFAULT_SLIDING_WINDOW
         data["layer_types"] = layer_types
         data["dflash_config"] = dict(data.get("dflash_config") or {})
+        if "block_size" not in data:
+            nested_block_size = data["dflash_config"].get("block_size")
+            if nested_block_size is not None:
+                data["block_size"] = nested_block_size
+        if "rope_theta" not in data:
+            rope_parameters = data.get("rope_parameters") or {}
+            if isinstance(rope_parameters, dict) and "rope_theta" in rope_parameters:
+                data["rope_theta"] = rope_parameters["rope_theta"]
+            elif isinstance(data.get("rope_scaling"), dict) and "rope_theta" in data["rope_scaling"]:
+                data["rope_theta"] = data["rope_scaling"]["rope_theta"]
         return cls(
             **{key: value for key, value in data.items() if key in cls.__annotations__}
         )

--- a/tests/test_draft_config_schema.py
+++ b/tests/test_draft_config_schema.py
@@ -1,0 +1,162 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Regression tests for DFlashDraftModelArgs.from_dict schema tolerance.
+
+z-lab iterated the DFlash draft config.json layout multiple times. This test
+pins from_dict behavior across every known schema variant so consumers do not
+silently break when HuggingFace publishes a new revision.
+
+Covered schemas:
+    * legacy (HF revisions through ~May 2026): block_size and rope_theta top-level.
+    * nested-dflash-config (z-lab HF revision c69b185, Jun 18 2026):
+      block_size moved into dflash_config; rope_theta into rope_parameters.
+    * rope-scaling-fallback: rope_theta nested inside rope_scaling (defensive).
+"""
+
+import pytest
+
+from dflash_mlx.model import DFlashDraftModelArgs
+
+
+def _base_legacy_schema() -> dict:
+    return {
+        "model_type": "dflash_qwen3",
+        "hidden_size": 2048,
+        "num_hidden_layers": 8,
+        "intermediate_size": 6144,
+        "num_attention_heads": 32,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 248320,
+        "num_key_value_heads": 4,
+        "max_position_embeddings": 4096,
+        "rope_theta": 10_000_000.0,
+        "head_dim": 128,
+        "tie_word_embeddings": False,
+        "num_target_layers": 41,
+        "block_size": 16,
+        "dflash_config": {
+            "mask_token_id": 248070,
+            "target_layer_ids": [1, 10, 19, 28, 37],
+        },
+        "layer_types": ("full_attention",) * 8,
+    }
+
+
+def _base_nested_schema() -> dict:
+    """z-lab HF revision c69b185 / f181eece (Jun 18-19 2026).
+
+    block_size moved into dflash_config; rope_theta into a new rope_parameters
+    dict; layer topology switched to mostly-sliding; layer count 8 -> 6;
+    num_key_value_heads 4 -> 8; target_layer_ids 5 -> 8 anchors.
+    """
+    return {
+        "model_type": "dflash_qwen3",
+        "hidden_size": 2048,
+        "num_hidden_layers": 6,
+        "intermediate_size": 6144,
+        "num_attention_heads": 32,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 248320,
+        "num_key_value_heads": 8,
+        "max_position_embeddings": 4096,
+        "head_dim": 128,
+        "tie_word_embeddings": False,
+        "num_target_layers": 41,
+        "sliding_window": 4096,
+        "dflash_config": {
+            "block_size": 16,
+            "mask_token_id": 248077,
+            "target_layer_ids": [1, 6, 11, 16, 22, 27, 32, 37],
+        },
+        "rope_parameters": {
+            "rope_theta": 10_000_000.0,
+            "rope_type": "default",
+        },
+        "layer_types": (
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "schema_factory,expected_layers,expected_kv_heads,expected_anchor_count",
+    [
+        ("legacy", 8, 4, 5),
+        ("nested", 6, 8, 8),
+    ],
+)
+def test_from_dict_resolves_block_size_and_rope_theta_across_schemas(
+    schema_factory: str,
+    expected_layers: int,
+    expected_kv_heads: int,
+    expected_anchor_count: int,
+):
+    factory = _base_legacy_schema if schema_factory == "legacy" else _base_nested_schema
+    data = factory()
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.block_size == 16, f"[{schema_factory}] block_size must resolve to 16"
+    assert args.rope_theta == 10_000_000.0, f"[{schema_factory}] rope_theta must resolve to 1e7"
+    assert args.num_hidden_layers == expected_layers
+    assert args.num_key_value_heads == expected_kv_heads
+    assert tuple(args.layer_types)[0:1] in (("full_attention",), ("sliding_attention",))
+
+
+def test_from_dict_unwraps_block_size_from_dflash_config_when_top_level_absent():
+    data = _base_nested_schema()
+    data.pop("block_size", None)
+    data.pop("rope_theta", None)
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.block_size == 16
+    assert args.rope_theta == 10_000_000.0
+
+
+def test_from_dict_unwraps_rope_theta_from_rope_scaling_as_fallback():
+    data = _base_legacy_schema()
+    data.pop("rope_theta", None)
+    data["rope_scaling"] = {"rope_theta": 10_000_000.0, "rope_type": "default"}
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.rope_theta == 10_000_000.0
+
+
+def test_from_dict_preserves_top_level_block_size_and_rope_theta_when_present():
+    data = _base_legacy_schema()
+    data["block_size"] = 16
+    data["rope_theta"] = 10_000_000.0
+    data["dflash_config"]["block_size"] = 99
+    data["rope_parameters"] = {"rope_theta": 1.0}
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.block_size == 16
+    assert args.rope_theta == 10_000_000.0
+
+
+def test_nested_schema_constructs_into_a_model():
+    """The Jun 2026 nested schema must round-trip into a real DFlashDraftModel.
+
+    Guards against regressions in the model class (fc width, anchor count,
+    sliding-window setup) that could be introduced by future refactors.
+    """
+    from dflash_mlx.model import DFlashDraftModel
+
+    args = DFlashDraftModelArgs.from_dict(_base_nested_schema())
+    model = DFlashDraftModel(args)
+
+    assert len(model.layers) == 6
+    assert model.block_size == 16
+    assert model.mask_token_id == 248077
+    assert len(model.target_layer_ids) == 8
+    assert model.fc.weight.shape == (2048, 8 * 2048)


### PR DESCRIPTION
## Problem

`DFlashDraftModelArgs.from_dict` raises against the current `main` of every z-lab Qwen3.6 DFlash draft on HuggingFace:

```
TypeError: DFlashDraftModelArgs.__init__() missing 2 required positional arguments: 'rope_theta' and 'block_size'
```

## Root cause

z-lab relocated two required fields in `z-lab/Qwen3.6-35B-A3B-DFlash` HF revision `c69b185` (published Jun 19 2026, current `main` is `f181eece`):

| Field | Legacy location (through ~May 2026) | Current location |
| --- | --- | --- |
| `block_size` | top-level | `dflash_config.block_size` |
| `rope_theta` | top-level | `rope_parameters.rope_theta` |

`from_dict` only read these at top level, so the constructor signature is unsatisfied.

The architecture itself also changed in the same revision (`num_hidden_layers` 8 → 6, `num_key_value_heads` 4 → 8, `layer_types` mostly `sliding_attention`, `target_layer_ids` 5 → 8 anchors, weight blob 2.98 GB → 948 MB), but `DFlashDraftModel` already handles all of those correctly — only `from_dict` was the blocker.

## Impact

Every consumer of `dflash-mlx` that resolves `z-lab/Qwen3.6-*-DFlash` against HF `main` is currently broken. Users in adjacent projects have hit the same class of failure repeatedly as z-lab iterates the draft config schema:

- `jundot/omlx#827` (Apr 17) — schema-drift break against the predecessor revision.
- `jundot/omlx` discussion #803 (Apr 16) — same error class (`DFlashDraftModelArgs.__init__() missing 12 required positional arguments: ..., 'rope_theta', ..., 'block_size'`).
- `jundot/omlx#1292` (May 18) — related skew caused by `dflash-mlx` version drift.
- `waybarrios/vllm-mlx#502` — user pinned to the older HF revision `42d3b34d` specifically to dodge this break.

## Fix

Guarded unwrap in `DFlashDraftModelArgs.from_dict`:

```python
if "block_size" not in data:
    nested_block_size = data["dflash_config"].get("block_size")
    if nested_block_size is not None:
        data["block_size"] = nested_block_size
if "rope_theta" not in data:
    rope_parameters = data.get("rope_parameters") or {}
    if isinstance(rope_parameters, dict) and "rope_theta" in rope_parameters:
        data["rope_theta"] = rope_parameters["rope_theta"]
    elif isinstance(data.get("rope_scaling"), dict) and "rope_theta" in data["rope_scaling"]:
        data["rope_theta"] = data["rope_scaling"]["rope_theta"]
```

**No model-class changes** — `DFlashDraftModel` already correctly handles the new topology via `dflash_config.target_layer_ids` (line 687), `dflash_config.mask_token_id` (line 696), and the sliding-attention path (line 304).

**Backward compatible by construction** — every unwrap is gated on the top-level key being absent, so older HF revisions (e.g. `31977fb`, `9178e0f`, `42d3b34d`) keep working unchanged.

The `rope_scaling` fallback is defensive and currently unused by any published z-lab revision; it exists to absorb a future schema shuffle without another patch.

## Verification

- **Regression test added** (`tests/test_draft_config_schema.py`, 6 cases, all pass) — parametrized over the legacy and nested schemas, plus targeted tests for each unwrap branch and a round-trip test that constructs a real `DFlashDraftModel` from the nested config and asserts the resulting `fc.weight` shape, layer count, target anchor count, and `mask_token_id`.
- **Smoke load** — `DFlashDraftModelArgs.from_dict` then `DFlashDraftModel(args)` against the actual `config.json` from `z-lab/Qwen3.6-35B-A3B-DFlash@f181eece`: succeeds, no `TypeError`, all values match the checkpoint (6 layers, `fc.weight.shape == (2048, 16384)`, `target_layer_ids == [1, 6, 11, 16, 22, 27, 32, 37]`).
- **Backward-compat smoke** — same construction against `z-lab/Qwen3.6-35B-A3B-DFlash@42d3b34d` (the predecessor revision): also succeeds, values match the old checkpoint (8 layers, `fc.weight.shape == (2048, 10240)`, 5 anchors).
- **End-to-end server** — patched `dflash-mlx 0.1.10` serving `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` with draft `z-lab/Qwen3.6-35B-A3B-DFlash@main` (i.e. the broken revision): server starts cleanly, serves `/v1/chat/completions` requests, DFlash speculates end-to-end. Sample request (`"What is 2+2?"`, `max_tokens=8`, `temperature=0`): correct answer, `mode_used: dflash`, `cycles: 1`, `acceptance_rate: 0.667`, `tokens_per_cycle: 3.0`. No AR fallback.

Run the new tests locally with:

```bash
pytest tests/test_draft_config_schema.py -v
```

## Notes

- This is the third z-lab draft config schema reshuffle in roughly two months (`31977fb` → `9178e0f` → `c69b185`). The unwrap approach is deliberately permissive to absorb future drift without requiring another fix PR each time z-lab moves a field.
- Issue creation on this repo is restricted to collaborators, which is why this PR has no linked issue. Happy to open one if the maintainers prefer to track it that way.
