### PR TITLE
[codex] align DFlash server profiling with benchmark mode

### DIFF
--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -264,6 +264,12 @@ class DFlashDraftModelArgs:
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "DFlashDraftModelArgs":
         data = dict(params)
+        rope_parameters = data.get("rope_parameters") or {}
+        if "rope_theta" not in data and isinstance(rope_parameters, dict):
+            data["rope_theta"] = rope_parameters.get("rope_theta")
+        dflash_config = dict(data.get("dflash_config") or {})
+        if "block_size" not in data:
+            data["block_size"] = dflash_config.get("block_size")
         layer_types = tuple(data.get("layer_types") or ())
         model_type = str(data.get("model_type", ""))
         if (
@@ -282,7 +288,7 @@ class DFlashDraftModelArgs:
             ):
                 data["sliding_window"] = _GEMMA4_DEFAULT_SLIDING_WINDOW
         data["layer_types"] = layer_types
-        data["dflash_config"] = dict(data.get("dflash_config") or {})
+        data["dflash_config"] = dflash_config
         return cls(
             **{key: value for key, value in data.items() if key in cls.__annotations__}
         )

--- a/dflash_mlx/server/config.py
+++ b/dflash_mlx/server/config.py
@@ -159,6 +159,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Set chat-template arg enable_thinking=true.",
     )
     parser.add_argument(
+        "--no-eos",
+        action="store_true",
+        default=False,
+        help="Suppress EOS so generation reaches the requested max tokens.",
+    )
+    parser.add_argument(
         "--prompt-cache-size",
         type=int,
         default=10,

--- a/dflash_mlx/server/runtime.py
+++ b/dflash_mlx/server/runtime.py
@@ -132,8 +132,13 @@ class ServerRuntime:
         if args.seed is not None:
             mx.random.seed(args.seed)
 
-        stop_token_ids = get_stop_token_ids(tokenizer)
-        eos_token_ids = set(int(token_id) for token_id in tokenizer.eos_token_ids)
+        base_stop_token_ids = get_stop_token_ids(tokenizer)
+        no_eos = bool(getattr(self.model_provider.cli_args, "no_eos", False))
+        stop_token_ids = [] if no_eos else base_stop_token_ids
+        suppress_token_ids = base_stop_token_ids if no_eos else None
+        eos_token_ids = (
+            set() if no_eos else set(int(token_id) for token_id in tokenizer.eos_token_ids)
+        )
         request_start_ns = time.perf_counter_ns()
         prefix_flow = PrefixCacheFlow.for_request(
             model_provider=self.model_provider,
@@ -167,6 +172,7 @@ class ServerRuntime:
             use_chat_template=False,
             quantize_kv_cache=bool(runtime_context.runtime.quantize_kv_cache),
             stop_token_ids=stop_token_ids,
+            suppress_token_ids=suppress_token_ids,
             prompt_tokens_override=prepared.prompt,
             prefix_snapshot=prefix_flow.snapshot,
             snapshot_service=prefix_flow.snapshot_service,


### PR DESCRIPTION
## Summary
- allow the server path to load current DFlash draft configs where `rope_theta` and `block_size` live in nested config fields
- add a server `--no-eos` flag matching benchmark mode so profiling can force `max_tokens`
- pass EOS suppression into the DFlash generation stream when `--no-eos` is enabled

## Why
The OpenAI-compatible server path could not load the current `z-lab/Qwen3.6-35B-A3B-DFlash` config without a compatibility shim. After loading, server profiling still diverged from benchmark behavior because benchmark `--no-eos` suppressed EOS and reached the full token budget, while the server stopped early.

## Validation
- `python3 -m dflash_mlx.cli serve --help` shows `--no-eos`
- config constructor check loaded `rope_theta=10000000`, `block_size=16`, `sliding_window=4096`
- direct benchmark: 79.87 tok/s, 85.94% acceptance, 128 tokens
- warm server path with `--no-eos` and canonical tokenization: 104.3 tok/s warmup, 101.8 tok/s measured, 85.2% acceptance, 128 tokens
