### PR TITLE
fix: support gemma4_unified targets and transformers 5.x drafter rope config

### DIFF
--- a/dflash_mlx/engine/target_gemma4.py
+++ b/dflash_mlx/engine/target_gemma4.py
@@ -306,7 +306,17 @@ class Gemma4TargetOps:
 
     def supports_model(self, target_model: Any) -> bool:
         model_type = self.model_type(target_model)
-        if model_type not in ("gemma4", "gemma4_text"):
+        # gemma4_unified checkpoints load through mlx-lm's MODEL_REMAPPING
+        # (gemma4_unified -> gemma4), so the resulting module IS the gemma4
+        # text stack this backend already drives; only args.model_type keeps
+        # the unified name. gemma4_unified_text covers a directly loaded
+        # unified text tower resolving via the language_model/config paths.
+        if model_type not in (
+            "gemma4",
+            "gemma4_text",
+            "gemma4_unified",
+            "gemma4_unified_text",
+        ):
             return False
         try:
             inner = self.text_model(target_model)

--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -264,6 +264,18 @@ class DFlashDraftModelArgs:
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> "DFlashDraftModelArgs":
         data = dict(params)
+        # transformers >= 5.x nests rope fields under rope_parameters
+        # (e.g. the z-lab gemma4 drafters); hoist them so the required
+        # top-level rope_theta is satisfied for both conventions.
+        rope_params = data.get("rope_parameters")
+        if isinstance(rope_params, dict):
+            if "rope_theta" not in data and "rope_theta" in rope_params:
+                data["rope_theta"] = rope_params["rope_theta"]
+            if (
+                "rope_scaling" not in data
+                and rope_params.get("rope_type", "default") != "default"
+            ):
+                data["rope_scaling"] = rope_params
         layer_types = tuple(data.get("layer_types") or ())
         model_type = str(data.get("model_type", ""))
         if (

--- a/tests/test_gemma4_draft.py
+++ b/tests/test_gemma4_draft.py
@@ -731,3 +731,60 @@ def test_draft_args_reject_sliding_attention_without_positive_window():
         assert "sliding_attention draft layers require a positive sliding_window" in str(exc)
     else:
         raise AssertionError("sliding attention without positive window must be rejected")
+
+
+def test_gemma4_unified_target_supports_model():
+    # Current mlx-community Gemma 4 exports declare gemma4_unified; mlx-lm's
+    # MODEL_REMAPPING loads them through the gemma4 module, so the wrapper
+    # this backend receives is structurally identical and only the
+    # args.model_type string differs.
+    target_model = SimpleNamespace(
+        args=SimpleNamespace(
+            model_type="gemma4_unified",
+            layer_types=("sliding_attention", "full_attention"),
+            num_kv_shared_layers=0,
+        ),
+        model=SimpleNamespace(layers=[object()], embed_tokens=object()),
+    )
+    assert Gemma4TargetOps().supports_model(target_model)
+
+
+def test_draft_args_hoist_rope_theta_from_rope_parameters():
+    # transformers >= 5.x drafter exports (z-lab gemma4 drafters) nest rope
+    # fields under rope_parameters with no top-level rope_theta.
+    base = {
+        "model_type": "qwen3",
+        "hidden_size": 32,
+        "num_hidden_layers": 2,
+        "intermediate_size": 64,
+        "num_attention_heads": 4,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 128,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 4096,
+        "head_dim": 8,
+        "tie_word_embeddings": True,
+        "num_target_layers": 8,
+        "block_size": 16,
+        "layer_types": ["full_attention", "full_attention"],
+    }
+    args = DFlashDraftModelArgs.from_dict(
+        {**base, "rope_parameters": {"rope_theta": 1_000_000, "rope_type": "default"}}
+    )
+    assert args.rope_theta == 1_000_000
+    assert args.rope_scaling is None
+
+    yarn = {"rope_theta": 1_000_000, "rope_type": "yarn", "factor": 4.0}
+    args = DFlashDraftModelArgs.from_dict({**base, "rope_parameters": yarn})
+    assert args.rope_theta == 1_000_000
+    assert args.rope_scaling == yarn
+
+    # explicit top-level values always win over the nested form
+    args = DFlashDraftModelArgs.from_dict(
+        {
+            **base,
+            "rope_theta": 10_000.0,
+            "rope_parameters": {"rope_theta": 1_000_000, "rope_type": "default"},
+        }
+    )
+    assert args.rope_theta == 10_000.0


### PR DESCRIPTION
## Summary

Current mlx-community and lmstudio Gemma 4 MLX exports declare `model_type: gemma4_unified` (with `text_config.model_type: gemma4_unified_text`). DFlash rejects all of them; reported downstream as jundot/omlx#2153. Two separate blockers:

1. `Gemma4TargetOps.supports_model` only accepts `gemma4` and `gemma4_text`. mlx-lm loads unified checkpoints through its existing gemma4 module (`MODEL_REMAPPING` maps `gemma4_unified` to `gemma4`, and sanitize drops the vision and audio towers), so the wrapper this backend receives is structurally identical to the old exports. Only the `args.model_type` string differs. The gate now accepts `gemma4_unified` and `gemma4_unified_text`.

2. The matching z-lab drafters (`z-lab/gemma4-12B-it-DFlash` and friends) are transformers 5.10 exports: rope settings are nested under `rope_parameters` and there is no top-level `rope_theta`, which `DFlashDraftModelArgs.__init__` requires. `from_dict` now hoists `rope_theta` out of `rope_parameters`, and passes a non-default `rope_type` dict through as `rope_scaling`. Explicit top-level values still win.

## Testing

- [x] Two new tests in `tests/test_gemma4_draft.py`: a `gemma4_unified` target passes `supports_model`; the `rope_parameters` hoist covers the default, yarn, and top-level-wins cases.
- [x] `tests/test_gemma4_draft.py`: 30 passed.
- [x] Full suite: 1259 passed, 1 failed. The failure (`test_verify_kernel_contract...m16_gate_up-16-5120-17408`) fails identically on unmodified `9ca0028` on this M4 Pro, so it is pre-existing and unrelated.
- [x] Live, through omlx: `mlx-community/gemma-4-12B-it-4bit` + `z-lab/gemma4-12B-it-DFlash`, 400 token greedy generation. `acceptance=65.2%, cycles=139`, no AR fallback, coherent output, wall clock 31.5 to 36.6 tok/s over the non-speculative baseline. The uplift is modest because a 12B 4-bit target is cheap per token; acceptance matches what the old-format exports get.