### PR TITLE
fix(prefix_l2): skip empty target-hidden chunks in serialization

### DIFF
--- a/dflash_mlx/cache/prefix_l2.py
+++ b/dflash_mlx/cache/prefix_l2.py
@@ -236,10 +236,24 @@ def _serialize(snapshot: DFlashPrefixSnapshot) -> tuple[dict[str, mx.array], dic
             gdn_array_present.append(mask)
 
     chunk_spans: list[list[int]] = []
-    for c, chunk in enumerate(snapshot.target_hidden_chunks):
-        arrays[f"target_hidden_{c}"] = chunk
-    for span in snapshot.target_hidden_chunk_spans:
+    array_idx = 0
+    for chunk, span in zip(
+        snapshot.target_hidden_chunks, snapshot.target_hidden_chunk_spans
+    ):
+        # Skip zero-length chunks (e.g. an empty sink slice when
+        # draft_sink_size == 0). mx.save_safetensors refuses to serialize
+        # empty arrays, which crashed the L2 writer thread and prevented
+        # any snapshot from persisting. Spans are kept in lockstep with the
+        # arrays so _deserialize (which keys off len(chunk_spans_raw))
+        # rebuilds the same set.
+        if chunk is None or 0 in chunk.shape:
+            continue
+        # Name arrays positionally (0..k) — _deserialize reads
+        # target_hidden_{c} for c in range(len(chunk_spans)), so a skipped
+        # chunk must not leave a hole in the sequence.
+        arrays[f"target_hidden_{array_idx}"] = chunk
         chunk_spans.append([int(span[0]), int(span[1])])
+        array_idx += 1
 
     has_last_logits = snapshot.last_logits is not None
     if has_last_logits:

--- a/tests/test_prefix_l2.py
+++ b/tests/test_prefix_l2.py
@@ -35,7 +35,9 @@ from dflash_mlx.diagnostics import TraceConfig
 from dflash_mlx.engine.prefill import snapshot_covers_prefix
 from tests.test_prefix_cache import (
     _make_full_hidden_snapshot,
+    _make_gdn_cache_populated,
     _make_key,
+    _make_kv_cache_populated,
     _make_rotating_cache_populated,
     _make_synthetic_snapshot,
     _make_trimmed_snapshot,
@@ -1564,3 +1566,44 @@ class TestEvictionLruOnHit:
             assert path.stat().st_mtime_ns == 10**9
         finally:
             l2.shutdown()
+
+
+def test_serialize_skips_empty_target_hidden_chunk_when_sink_is_zero():
+    """Regression: draft_sink_size=0 produces an empty sink chunk that
+    mx.save_safetensors refuses to serialize, crashing the L2 writer thread
+    and preventing any snapshot from persisting (issue #54)."""
+    from dflash_mlx.cache.codecs import build_snapshot
+
+    key = _make_key()
+    n = 128  # > sink(0) + window, forcing the sink/tail split
+    snap = build_snapshot(
+        token_ids=list(range(n)),
+        target_cache=[
+            _make_kv_cache_populated(n_tokens=n),
+            _make_gdn_cache_populated(),
+        ],
+        target_hidden=mx.zeros((1, n, 8), dtype=mx.float32),
+        last_logits=mx.zeros((1, 32), dtype=mx.float32),
+        key=key,
+        kind="prefill",
+        draft_sink_size=0,   # reproduces the empty-sink crash
+        draft_window_size=16,
+    )
+
+    arrays, meta_dict = _serialize(snap)
+    meta = json.loads(meta_dict["dflash_meta"])
+    spans = meta["target_hidden_chunk_spans"]
+
+    # No empty arrays in the serialized payload; spans stay in lockstep.
+    assert spans, "expected at least one chunk span"
+    for c in range(len(spans)):
+        arr = arrays[f"target_hidden_{c}"]
+        assert 0 not in arr.shape, f"empty chunk serialized: target_hidden_{c}"
+
+    # Round-trip: deserialize must reconstruct the same (non-empty) chunks.
+    restored = _deserialize(arrays, meta)
+    assert len(restored.target_hidden_chunks) == len(spans)
+    for chunk, span in zip(restored.target_hidden_chunks, spans):
+        assert 0 not in chunk.shape
+        assert span[1] > span[0]
+


### PR DESCRIPTION
Fixes #54

**Problem:** With `draft_sink_size=0` (oMLX's default), `_build_target_hidden_chunks` produces an empty sink chunk `target_hidden[:, 0:0, :]` (shape `(1, 0, 8)`). `_serialize` wrote it unconditionally, and `mx.save_safetensors` refuses to serialize empty arrays:

```
ValueError: [save_safetensors] Cannot serialize an empty array ('target_hidden_0')
```

The exception killed the `dflash-l2-writer` thread on every snapshot, so **nothing ever persisted to the L2 (SSD) cache** (`l2_writes=0`, `l2_bytes=0`), and the crash/retry overhead degraded request latency.

**Fix:** In `_serialize`, skip zero-length chunks and keep `chunk_spans` in lockstep. Arrays are named positionally (`target_hidden_0..k`) so `_deserialize` — which reads `target_hidden_{c}` for `c in range(len(chunk_spans_raw))` — reconstructs the same non-empty set.

**Test:** Added `test_serialize_skips_empty_target_hidden_chunk_when_sink_is_zero`, which builds a snapshot with `draft_sink_size=0`, asserts no empty chunk is serialized, and verifies the serialize/deserialize round-trip preserves only non-empty chunks.
- Without the fix: fails with `empty chunk serialized: target_hidden_0`, shape `(1, 0, 8)` (verified).
- With the fix: passes. Full `test_prefix_l2.py` suite: **70 passed**.

**Env:** oMLX 0.6.2-dflash2, dflash_mlx 0.1.10+omlx.5, Qwen3.8-27B-4bit + incoai/Qwen3.8-27B-DFlash2, Apple M5 Max.