### PR TITLE
Resolve post-v0.1.10 cache, config, L2, and DFlash2 inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ override that policy.
 | [mlx-community/Qwen3.5-35B-A3B-4bit](https://huggingface.co/mlx-community/Qwen3.5-35B-A3B-4bit) | [z-lab/Qwen3.5-35B-A3B-DFlash](https://huggingface.co/z-lab/Qwen3.5-35B-A3B-DFlash) |
 | [mlx-community/Qwen3.6-27B-4bit](https://huggingface.co/mlx-community/Qwen3.6-27B-4bit) | [z-lab/Qwen3.6-27B-DFlash](https://huggingface.co/z-lab/Qwen3.6-27B-DFlash) |
 | [mlx-community/Qwen3.6-35B-A3B-4bit](https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-4bit) | [z-lab/Qwen3.6-35B-A3B-DFlash](https://huggingface.co/z-lab/Qwen3.6-35B-A3B-DFlash) |
+| [mlx-community/Qwen3.8-27B-4bit](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit) | [z-lab/Qwen3.8-27B-DFlash2](https://huggingface.co/z-lab/Qwen3.8-27B-DFlash2) |
 | [Qwen/Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B) | [z-lab/Qwen3-4B-DFlash-b16](https://huggingface.co/z-lab/Qwen3-4B-DFlash-b16) |
 | [Qwen/Qwen3-8B](https://huggingface.co/Qwen/Qwen3-8B) | [z-lab/Qwen3-8B-DFlash-b16](https://huggingface.co/z-lab/Qwen3-8B-DFlash-b16) |
 | [mlx-community/gemma-4-31b-it-4bit](https://huggingface.co/mlx-community/gemma-4-31b-it-4bit) | [z-lab/gemma-4-31B-it-DFlash](https://huggingface.co/z-lab/gemma-4-31B-it-DFlash) |

--- a/dflash_mlx/cache/codecs.py
+++ b/dflash_mlx/cache/codecs.py
@@ -81,6 +81,7 @@ def _build_target_hidden_chunks(
     draft_window_size: int = 1024,
     allow_full_attention_context: bool = False,
     clone: bool = True,
+    cover_boundary: int = 0,
 ) -> tuple[tuple[mx.array, ...], tuple[tuple[int, int], ...], int]:
     grab = _clone_array if clone else (lambda a: a)
     total_len = int(target_hidden.shape[1])
@@ -99,14 +100,22 @@ def _build_target_hidden_chunks(
         full = grab(_target_hidden_slice(target_hidden, 0, total_len))
         assert full is not None
         return (full,), ((0, total_len),), total_len
+    tail_start = total_len - window
+    if cover_boundary > 0:
+        tail_start = min(tail_start, max(0, int(cover_boundary) - window))
+    if tail_start <= sink:
+        full = grab(_target_hidden_slice(target_hidden, 0, total_len))
+        assert full is not None
+        return (full,), ((0, total_len),), total_len
+    tail_chunk = grab(_target_hidden_slice(target_hidden, tail_start, total_len))
+    assert tail_chunk is not None
+    if sink == 0:
+        return (tail_chunk,), ((tail_start, total_len),), total_len
     sink_chunk = grab(_target_hidden_slice(target_hidden, 0, sink))
-    tail_chunk = grab(
-        _target_hidden_slice(target_hidden, total_len - window, total_len)
-    )
-    assert sink_chunk is not None and tail_chunk is not None
+    assert sink_chunk is not None
     return (
         (sink_chunk, tail_chunk),
-        ((0, sink), (total_len - window, total_len)),
+        ((0, sink), (tail_start, total_len)),
         total_len,
     )
 
@@ -125,8 +134,49 @@ def capture_gdn_sidecar(
         for entry in target_cache
     )
 
+
+def snapshot_covers_sidecar_context(
+    snapshot: DFlashPrefixSnapshot,
+    boundary: int,
+    *,
+    require_full_coverage: bool,
+) -> bool:
+    boundary = int(boundary)
+    if require_full_coverage:
+        return snapshot_covers_prefix(snapshot, boundary)
+
+    spans = tuple(snapshot.target_hidden_chunk_spans)
+    sink_end = min(boundary, max(0, int(snapshot.key.draft_sink_size)))
+    if sink_end > 0 and not _spans_cover_interval(spans, 0, sink_end):
+        return False
+    window = max(1, int(snapshot.key.draft_window_size))
+    tail_start = max(sink_end, boundary - window)
+    return _spans_cover_interval(spans, tail_start, boundary)
+
+
+def _spans_cover_interval(
+    spans: tuple[tuple[int, int], ...],
+    start: int,
+    end: int,
+) -> bool:
+    covered = int(start)
+    for span_start, span_end in spans:
+        span_start = int(span_start)
+        span_end = int(span_end)
+        if span_end <= covered:
+            continue
+        if span_start > covered:
+            return False
+        covered = max(covered, span_end)
+        if covered >= int(end):
+            return True
+    return covered >= int(end)
+
+
 def slice_snapshot_at_sidecar_boundary(
     snapshot: DFlashPrefixSnapshot,
+    *,
+    require_full_coverage: bool = False,
 ) -> DFlashPrefixSnapshot:
     boundary = int(snapshot.sidecar_boundary)
     if not 0 < boundary < snapshot.prefix_len:
@@ -135,9 +185,13 @@ def slice_snapshot_at_sidecar_boundary(
         )
     if snapshot.sidecar_gdn_states is None or snapshot.sidecar_last_logits is None:
         raise ValueError("Snapshot has a sidecar boundary but no sidecar states")
-    if not snapshot_covers_prefix(snapshot, boundary):
+    if not snapshot_covers_sidecar_context(
+        snapshot,
+        boundary,
+        require_full_coverage=require_full_coverage,
+    ):
         raise ValueError(
-            f"Snapshot feature spans do not cover sidecar boundary {boundary}"
+            f"Snapshot feature spans do not cover sidecar context at {boundary}"
         )
     fa: list[Optional[FAState]] = []
     for layer_idx, state in enumerate(snapshot.fa_states):
@@ -379,6 +433,7 @@ def build_snapshot(
         draft_window_size=draft_window_size,
         allow_full_attention_context=allow_full_attention_context,
         clone=not adopt_cache_arrays,
+        cover_boundary=sidecar_boundary,
     )
     cloned_logits = (
         last_logits

--- a/dflash_mlx/cache/manager.py
+++ b/dflash_mlx/cache/manager.py
@@ -237,7 +237,7 @@ def get_runtime_cache_manager(
         _clear_runtime_cache_identity(cache_identity)
         return None
     config_key = _prefix_cache_config_key(runtime_context, cache_identity=cache_identity)
-    identity = config_key[0]
+    identity = _runtime_cache_registry_identity(cache_identity)
     trace_config = runtime_context.diagnostics.trace
     with _DFLASH_RUNTIME_CACHE_LOCK:
         entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
@@ -270,7 +270,7 @@ def sync_runtime_cache_manager(
         _clear_runtime_cache_identity(cache_identity)
         return None
     config_key = _prefix_cache_config_key(runtime_context, cache_identity=cache_identity)
-    identity = config_key[0]
+    identity = _runtime_cache_registry_identity(cache_identity)
     with _DFLASH_RUNTIME_CACHE_LOCK:
         entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
         if entry is None:
@@ -312,17 +312,20 @@ def shutdown_runtime_cache_manager(
     """Retire cache managers.
 
     No args retires *all* registered managers (process/server teardown). Passing
-    a ``runtime_context`` and/or ``cache_identity`` retires just that model's
-    manager, leaving any others serving (oMLX per-engine unload).
+    ``cache_identity`` retires just that model's manager, leaving any others
+    serving (oMLX per-engine unload).
     """
     if runtime_context is None and cache_identity is None:
         _clear_all_runtime_cache_managers(raise_on_error=False)
         return
+    if cache_identity is None:
+        raise ValueError("scoped cache-manager shutdown requires cache_identity")
     _clear_runtime_cache_identity(cache_identity, raise_on_error=False)
 
 
 def _clear_runtime_cache_identity(identity: Any, *, raise_on_error: bool = True) -> None:
     global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
+    identity = _runtime_cache_registry_identity(identity)
     with _DFLASH_RUNTIME_CACHE_LOCK:
         entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
         if entry is None:
@@ -342,6 +345,15 @@ def _clear_all_runtime_cache_managers(*, raise_on_error: bool = True) -> None:
             if _shutdown_manager(manager, raise_on_error=raise_on_error):
                 del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
         _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
+
+
+def _runtime_cache_registry_identity(cache_identity: Any) -> Any:
+    if isinstance(cache_identity, DFlashPrefixKey):
+        return (
+            cache_identity.target_model_id,
+            cache_identity.draft_model_id,
+        )
+    return cache_identity
 
 
 def _prefix_cache_config_key(

--- a/dflash_mlx/cache/manager.py
+++ b/dflash_mlx/cache/manager.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, cast
 
 HitKind = Literal["miss", "l1_exact", "l1_prefix", "l2_exact", "l2_prefix"]
 
@@ -119,7 +119,7 @@ class RuntimeCacheManager:
                 request_id=request_id,
                 require_full_coverage=require_full_coverage,
             )
-            hit_kind: HitKind = self._store._last_hit_kind  # type: ignore[assignment]
+            hit_kind = cast(HitKind, self._store.last_hit_kind)
         return PrefixCacheLookupResult(
             matched_tokens=int(matched_len),
             snapshot=snapshot,

--- a/dflash_mlx/cache/manager.py
+++ b/dflash_mlx/cache/manager.py
@@ -18,8 +18,16 @@ from dflash_mlx.cache.prefix_l2 import DFlashPrefixL2Cache
 from dflash_mlx.cache.snapshot import DFlashPrefixSnapshot
 from dflash_mlx.cache.store import PrefixSnapshotStore
 
-_DFLASH_RUNTIME_CACHE_MANAGER: Optional["RuntimeCacheManager"] = None
-_DFLASH_RUNTIME_CACHE_CONFIG_KEY: Optional[tuple[Any, ...]] = None
+# Live cache managers keyed by per-model cache_identity (config_key[0]), so a
+# host serving several models in one process keeps each model's prefix cache
+# alive instead of retiring it when another model loads. The stored config_key
+# distinguishes a same-model reconfiguration (replace the entry) from a
+# different-model load (keep both). The standalone server loads one model, so
+# the registry holds a single entry; embedders may host several at once.
+_DFLASH_RUNTIME_CACHE_REGISTRY: "dict[Any, tuple[tuple[Any, ...], RuntimeCacheManager]]" = {}
+# Identity of the most recently resolved manager — backs the keyless
+# current_runtime_cache_manager() used by the single-model metrics endpoint.
+_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY: Any = None
 _DFLASH_RUNTIME_CACHE_LOCK = threading.Lock()
 _MIN_L2_FRONTIER_STRIDE = 8192
 
@@ -222,30 +230,31 @@ def get_runtime_cache_manager(
     *,
     cache_identity: Any = None,
 ) -> Optional[RuntimeCacheManager]:
-    global _DFLASH_RUNTIME_CACHE_CONFIG_KEY, _DFLASH_RUNTIME_CACHE_MANAGER
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
     if runtime_context is None:
         return None
     if _runtime_cache_disabled(runtime_context):
-        _clear_runtime_cache_manager()
+        _clear_runtime_cache_identity(cache_identity)
         return None
     config_key = _prefix_cache_config_key(runtime_context, cache_identity=cache_identity)
+    identity = config_key[0]
     trace_config = runtime_context.diagnostics.trace
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
-        if (
-            manager is not None
-            and _DFLASH_RUNTIME_CACHE_CONFIG_KEY == config_key
-            and not manager._is_retired()
-        ):
-            manager.set_trace_config(trace_config)
-            return manager
-        if manager is not None:
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
+        if entry is not None:
+            existing_key, manager = entry
+            if existing_key == config_key and not manager._is_retired():
+                manager.set_trace_config(trace_config)
+                _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = identity
+                return manager
+            # Same model, reconfigured (or retired): retire the old entry and
+            # rebuild. A shutdown failure here leaves the retired entry in place
+            # and propagates, mirroring the single-slot contract.
             _shutdown_manager(manager)
-            _DFLASH_RUNTIME_CACHE_MANAGER = None
-            _DFLASH_RUNTIME_CACHE_CONFIG_KEY = None
+            del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
         manager = RuntimeCacheManager(_make_prefix_store(runtime_context))
-        _DFLASH_RUNTIME_CACHE_MANAGER = manager
-        _DFLASH_RUNTIME_CACHE_CONFIG_KEY = config_key
+        _DFLASH_RUNTIME_CACHE_REGISTRY[identity] = (config_key, manager)
+        _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = identity
         return manager
 
 
@@ -254,45 +263,85 @@ def sync_runtime_cache_manager(
     *,
     cache_identity: Any = None,
 ) -> Optional[RuntimeCacheManager]:
-    global _DFLASH_RUNTIME_CACHE_CONFIG_KEY, _DFLASH_RUNTIME_CACHE_MANAGER
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
     if runtime_context is None:
         return None
     if _runtime_cache_disabled(runtime_context):
-        _clear_runtime_cache_manager()
+        _clear_runtime_cache_identity(cache_identity)
         return None
     config_key = _prefix_cache_config_key(runtime_context, cache_identity=cache_identity)
+    identity = config_key[0]
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
-        if manager is None:
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
+        if entry is None:
             return None
-        if _DFLASH_RUNTIME_CACHE_CONFIG_KEY != config_key or manager._is_retired():
+        existing_key, manager = entry
+        if existing_key != config_key or manager._is_retired():
             _shutdown_manager(manager)
-            _DFLASH_RUNTIME_CACHE_MANAGER = None
-            _DFLASH_RUNTIME_CACHE_CONFIG_KEY = None
+            del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+            if _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY == identity:
+                _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
             return None
         manager.set_trace_config(runtime_context.diagnostics.trace)
+        _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = identity
         return manager
 
 
 def current_runtime_cache_manager() -> Optional[RuntimeCacheManager]:
+    """Return the most recently resolved manager (single-model metrics view).
+
+    With several models registered this is the last one get/sync'd. Per-request
+    code must use the manager carried on its ``PrefixCacheFlow`` instead, which
+    is always the right model regardless of interleaving.
+    """
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
-        if manager is None or manager._is_retired():
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY)
+        if entry is None:
+            return None
+        _, manager = entry
+        if manager._is_retired():
             return None
         return manager
 
 
-def shutdown_runtime_cache_manager() -> None:
-    _clear_runtime_cache_manager(raise_on_error=False)
+def shutdown_runtime_cache_manager(
+    runtime_context: Optional[Any] = None,
+    *,
+    cache_identity: Any = None,
+) -> None:
+    """Retire cache managers.
+
+    No args retires *all* registered managers (process/server teardown). Passing
+    a ``runtime_context`` and/or ``cache_identity`` retires just that model's
+    manager, leaving any others serving (oMLX per-engine unload).
+    """
+    if runtime_context is None and cache_identity is None:
+        _clear_all_runtime_cache_managers(raise_on_error=False)
+        return
+    _clear_runtime_cache_identity(cache_identity, raise_on_error=False)
 
 
-def _clear_runtime_cache_manager(*, raise_on_error: bool = True) -> None:
-    global _DFLASH_RUNTIME_CACHE_CONFIG_KEY, _DFLASH_RUNTIME_CACHE_MANAGER
+def _clear_runtime_cache_identity(identity: Any, *, raise_on_error: bool = True) -> None:
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
     with _DFLASH_RUNTIME_CACHE_LOCK:
-        manager = _DFLASH_RUNTIME_CACHE_MANAGER
+        entry = _DFLASH_RUNTIME_CACHE_REGISTRY.get(identity)
+        if entry is None:
+            return
+        _, manager = entry
         if _shutdown_manager(manager, raise_on_error=raise_on_error):
-            _DFLASH_RUNTIME_CACHE_MANAGER = None
-            _DFLASH_RUNTIME_CACHE_CONFIG_KEY = None
+            del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+            if _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY == identity:
+                _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
+
+
+def _clear_all_runtime_cache_managers(*, raise_on_error: bool = True) -> None:
+    global _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY
+    with _DFLASH_RUNTIME_CACHE_LOCK:
+        for identity in list(_DFLASH_RUNTIME_CACHE_REGISTRY.keys()):
+            _, manager = _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+            if _shutdown_manager(manager, raise_on_error=raise_on_error):
+                del _DFLASH_RUNTIME_CACHE_REGISTRY[identity]
+        _DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY = None
 
 
 def _prefix_cache_config_key(

--- a/dflash_mlx/cache/prefix_l1.py
+++ b/dflash_mlx/cache/prefix_l1.py
@@ -11,7 +11,10 @@ from typing import Any, Optional
 
 from dflash_mlx.observability.cache import record_cache_event
 from dflash_mlx.diagnostics import TraceConfig
-from dflash_mlx.cache.codecs import slice_snapshot_at_sidecar_boundary
+from dflash_mlx.cache.codecs import (
+    slice_snapshot_at_sidecar_boundary,
+    snapshot_covers_sidecar_context,
+)
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 from dflash_mlx.cache.snapshot import DFlashPrefixSnapshot
 from dflash_mlx.engine.prefill import snapshot_covers_prefix
@@ -79,6 +82,7 @@ class DFlashPrefixCache:
     def _usable_sidecar_boundary(
         snap: DFlashPrefixSnapshot,
         req_tuple: tuple[int, ...],
+        require_full_coverage: bool = False,
     ) -> int:
         boundary = int(snap.sidecar_boundary)
         if boundary <= 0 or boundary > len(req_tuple):
@@ -87,7 +91,11 @@ class DFlashPrefixCache:
             return 0
         if req_tuple[:boundary] != snap.token_ids[:boundary]:
             return 0
-        if not snapshot_covers_prefix(snap, boundary):
+        if not snapshot_covers_sidecar_context(
+            snap,
+            boundary,
+            require_full_coverage=require_full_coverage,
+        ):
             return 0
         return boundary
 
@@ -120,7 +128,9 @@ class DFlashPrefixCache:
                     continue
                 snap_len = len(snap.token_ids)
                 if snap_len == 0 or snap_len > len(req_tuple):
-                    boundary = self._usable_sidecar_boundary(snap, req_tuple)
+                    boundary = self._usable_sidecar_boundary(
+                        snap, req_tuple, require_full_coverage
+                    )
                     if boundary > best_sidecar_len:
                         best_sidecar_len = boundary
                         best_sidecar_id = eid
@@ -136,7 +146,9 @@ class DFlashPrefixCache:
                     if common > longest_fingerprint_match_len:
                         longest_fingerprint_match_len = common
                         longest_fingerprint_first_divergence = common
-                    boundary = self._usable_sidecar_boundary(snap, req_tuple)
+                    boundary = self._usable_sidecar_boundary(
+                        snap, req_tuple, require_full_coverage
+                    )
                     if boundary > best_sidecar_len:
                         best_sidecar_len = boundary
                         best_sidecar_id = eid
@@ -155,7 +167,8 @@ class DFlashPrefixCache:
                 best_len = best_sidecar_len
                 best_id = best_sidecar_id
                 best_snapshot = slice_snapshot_at_sidecar_boundary(
-                    best_sidecar_carrier
+                    best_sidecar_carrier,
+                    require_full_coverage=require_full_coverage,
                 )
                 sidecar_used = True
 

--- a/dflash_mlx/cache/prefix_l2.py
+++ b/dflash_mlx/cache/prefix_l2.py
@@ -236,10 +236,24 @@ def _serialize(snapshot: DFlashPrefixSnapshot) -> tuple[dict[str, mx.array], dic
             gdn_array_present.append(mask)
 
     chunk_spans: list[list[int]] = []
-    for c, chunk in enumerate(snapshot.target_hidden_chunks):
-        arrays[f"target_hidden_{c}"] = chunk
-    for span in snapshot.target_hidden_chunk_spans:
+    array_idx = 0
+    for chunk, span in zip(
+        snapshot.target_hidden_chunks, snapshot.target_hidden_chunk_spans
+    ):
+        # Skip zero-length chunks (e.g. an empty sink slice when
+        # draft_sink_size == 0). mx.save_safetensors refuses to serialize
+        # empty arrays, which crashed the L2 writer thread and prevented
+        # any snapshot from persisting. Spans are kept in lockstep with the
+        # arrays so _deserialize (which keys off len(chunk_spans_raw))
+        # rebuilds the same set.
+        if chunk is None or 0 in chunk.shape:
+            continue
+        # Name arrays positionally (0..k) — _deserialize reads
+        # target_hidden_{c} for c in range(len(chunk_spans)), so a skipped
+        # chunk must not leave a hole in the sequence.
+        arrays[f"target_hidden_{array_idx}"] = chunk
         chunk_spans.append([int(span[0]), int(span[1])])
+        array_idx += 1
 
     has_last_logits = snapshot.last_logits is not None
     if has_last_logits:

--- a/dflash_mlx/cache/prefix_l2.py
+++ b/dflash_mlx/cache/prefix_l2.py
@@ -235,25 +235,17 @@ def _serialize(snapshot: DFlashPrefixSnapshot) -> tuple[dict[str, mx.array], dic
                     mask.append(True)
             gdn_array_present.append(mask)
 
+    if len(snapshot.target_hidden_chunks) != len(snapshot.target_hidden_chunk_spans):
+        raise ValueError("target-hidden chunks/spans length mismatch")
     chunk_spans: list[list[int]] = []
-    array_idx = 0
     for chunk, span in zip(
         snapshot.target_hidden_chunks, snapshot.target_hidden_chunk_spans
     ):
-        # Skip zero-length chunks (e.g. an empty sink slice when
-        # draft_sink_size == 0). mx.save_safetensors refuses to serialize
-        # empty arrays, which crashed the L2 writer thread and prevented
-        # any snapshot from persisting. Spans are kept in lockstep with the
-        # arrays so _deserialize (which keys off len(chunk_spans_raw))
-        # rebuilds the same set.
-        if chunk is None or 0 in chunk.shape:
-            continue
-        # Name arrays positionally (0..k) — _deserialize reads
-        # target_hidden_{c} for c in range(len(chunk_spans)), so a skipped
-        # chunk must not leave a hole in the sequence.
-        arrays[f"target_hidden_{array_idx}"] = chunk
+        start, end = int(span[0]), int(span[1])
+        if 0 in chunk.shape or end <= start or int(chunk.shape[1]) != end - start:
+            raise ValueError(f"invalid target-hidden chunk for span ({start}, {end})")
+        arrays[f"target_hidden_{len(chunk_spans)}"] = chunk
         chunk_spans.append([int(span[0]), int(span[1])])
-        array_idx += 1
 
     has_last_logits = snapshot.last_logits is not None
     if has_last_logits:

--- a/dflash_mlx/cache/store.py
+++ b/dflash_mlx/cache/store.py
@@ -40,6 +40,10 @@ class PrefixSnapshotStore:
         # Readable by RuntimeCacheManager while holding _state_lock.
         self._last_hit_kind: str = "miss"
 
+    @property
+    def last_hit_kind(self) -> str:
+        return self._last_hit_kind
+
     def set_trace_config(self, trace_config: TraceConfig | None) -> None:
         self._trace_config = trace_config
         self._l1.set_trace_config(trace_config)

--- a/dflash_mlx/draft/__init__.py
+++ b/dflash_mlx/draft/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)

--- a/dflash_mlx/draft/checkpoint.py
+++ b/dflash_mlx/draft/checkpoint.py
@@ -1,0 +1,33 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+from __future__ import annotations
+
+from typing import Any
+
+from dflash_mlx.draft.dflash2 import (
+    DFlash2DraftModel,
+    DFlash2DraftModelArgs,
+    has_dflash2_architecture,
+    normalize_dflash2_config,
+)
+from dflash_mlx.model import DFlashDraftModel, DFlashDraftModelArgs
+
+
+def get_draft_model_classes(config: dict[str, Any]):
+    if has_dflash2_architecture(config):
+        normalize_dflash2_config(config)
+        return DFlash2DraftModel, DFlash2DraftModelArgs
+    architectures = tuple(str(value) for value in config.get("architectures") or ())
+    unknown_dflash = [
+        value
+        for value in architectures
+        if value.startswith("DFlash") and value != "DFlashDraftModel"
+    ]
+    if unknown_dflash:
+        raise ValueError(
+            "Unsupported DFlash draft architecture(s): "
+            + ", ".join(sorted(unknown_dflash))
+        )
+    return DFlashDraftModel, DFlashDraftModelArgs

--- a/dflash_mlx/draft/dflash2.py
+++ b/dflash_mlx/draft/dflash2.py
@@ -1,0 +1,484 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.qwen3 import MLP
+
+from dflash_mlx.model import (
+    DFlashAttention,
+    DFlashDraftModel,
+    DFlashDraftModelArgs,
+    DraftRuntimeCapabilities,
+)
+
+_DFLASH2_ARCHITECTURE = "DFlash2DraftModel"
+_DFLASH2_REQUIRED_DFLASH_FIELDS = frozenset(
+    (
+        "block_size",
+        "conv_group_size",
+        "conv_kernel_size",
+        "mask_token_id",
+        "selector_rank",
+        "selector_top_k",
+        "target_layer_ids",
+    )
+)
+
+
+@dataclass(frozen=True)
+class DraftProposal:
+    token_ids: mx.array
+    q_token_ids: Optional[mx.array] = None
+    q_probs: Optional[mx.array] = None
+
+
+def has_dflash2_architecture(config: dict[str, Any]) -> bool:
+    return _DFLASH2_ARCHITECTURE in tuple(str(v) for v in config.get("architectures") or ())
+
+
+def normalize_dflash2_config(config: dict[str, Any]) -> dict[str, Any]:
+    data = dict(config)
+    if not has_dflash2_architecture(data):
+        raise ValueError("DFlash2 draft config must declare architectures=['DFlash2DraftModel']")
+    dflash_config = data.get("dflash_config")
+    if not isinstance(dflash_config, dict):
+        raise ValueError("DFlash2 draft config requires object dflash_config")
+    missing = sorted(_DFLASH2_REQUIRED_DFLASH_FIELDS - set(dflash_config))
+    if missing:
+        raise ValueError(
+            "DFlash2 draft config missing dflash_config field(s): "
+            + ", ".join(missing)
+        )
+    if data.get("is_causal") is not False:
+        raise ValueError("DFlash2 draft config requires is_causal=false")
+    layer_types = tuple(data.get("layer_types") or ())
+    if not layer_types:
+        raise ValueError("DFlash2 draft config requires layer_types")
+    if len(layer_types) != int(data["num_hidden_layers"]):
+        raise ValueError(
+            "DFlash2 draft layer_types length must match num_hidden_layers: "
+            f"{len(layer_types)} != {int(data['num_hidden_layers'])}"
+        )
+    if set(layer_types) != {"sliding_attention"}:
+        raise ValueError("DFlash2 MLX support requires all draft layers to be sliding_attention")
+    rope_parameters = data.get("rope_parameters")
+    rope_scaling = data.get("rope_scaling")
+    rope = rope_parameters or rope_scaling or {}
+    if "rope_theta" not in data:
+        data["rope_theta"] = rope.get("rope_theta", 10000.0)
+    if rope_scaling is None and isinstance(rope_parameters, dict):
+        rope_type = (
+            rope_parameters.get("type")
+            or rope_parameters.get("rope_type")
+            or "default"
+        )
+        data["rope_scaling"] = (
+            None
+            if rope_type == "default"
+            else {
+                key: value
+                for key, value in rope_parameters.items()
+                if key != "rope_theta"
+            }
+        )
+    for key, value in dflash_config.items():
+        data[key] = value
+    return data
+
+
+def remap_dflash2_codebook_weights(weights: dict[str, mx.array]) -> dict[str, mx.array]:
+    remapped = dict(weights)
+    for name in ("predecessor_codebook", "successor_codebook"):
+        old_key = f"candidate_selector.{name}"
+        new_key = f"{old_key}.weight"
+        if old_key not in remapped:
+            continue
+        if new_key in remapped:
+            raise ValueError(
+                f"DFlash2 safetensors contain both {old_key!r} and {new_key!r}"
+            )
+        remapped[new_key] = remapped.pop(old_key)
+    return remapped
+
+
+@dataclass
+class DFlash2DraftModelArgs(DFlashDraftModelArgs):
+    conv_kernel_size: int = 2
+    conv_group_size: int = 16
+    selector_rank: int = 256
+    selector_top_k: int = 16
+    is_causal: bool = False
+    final_logit_softcapping: Optional[float] = None
+    input_embedding_scale: float = 1.0
+    output_multiplier: float = 1.0
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> "DFlash2DraftModelArgs":
+        data = normalize_dflash2_config(params)
+        names = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in data.items() if key in names})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.is_causal is not False:
+            raise ValueError("DFlash2 draft attention must be non-causal")
+        if int(self.conv_kernel_size) != 2:
+            raise ValueError("DFlash2 MLX support requires two-tap dynamic conv")
+        if int(self.conv_group_size) != 16:
+            raise ValueError("DFlash2 MLX support requires dynamic conv group size 16")
+        if int(self.selector_rank) != 256:
+            raise ValueError("DFlash2 MLX support requires selector rank 256")
+        if int(self.selector_top_k) != 16:
+            raise ValueError("DFlash2 MLX support requires selector_top_k 16")
+        if int(self.hidden_size) % int(self.conv_group_size) != 0:
+            raise ValueError("DFlash2 hidden_size must be divisible by conv_group_size")
+        if set(self.layer_types) != {"sliding_attention"}:
+            raise ValueError("DFlash2 MLX support requires all draft layers to be sliding_attention")
+
+
+def _grouped_dynamic_convolve(
+    hidden: mx.array,
+    dynamic: mx.array,
+    base: mx.array,
+    group_size: int,
+) -> mx.array:
+    batch, length, hidden_size = hidden.shape
+    groups = hidden_size // int(group_size)
+    blocks = hidden.reshape(batch, length, groups, int(group_size))
+    dynamic = dynamic.reshape(batch, length, int(base.shape[0]), groups, 1)
+    output = mx.zeros_like(blocks)
+    for offset in range(int(base.shape[0])):
+        if offset == 0:
+            values = blocks
+        else:
+            values = mx.concatenate(
+                (mx.zeros_like(blocks[:, :offset]), blocks[:, :-offset]),
+                axis=1,
+            )
+        kernel = base[offset].reshape(1, 1, groups, int(group_size)).astype(hidden.dtype)
+        output = output + kernel * values
+        output = output + dynamic[:, :, offset] * values
+    return output.reshape(hidden.shape)
+
+
+class GroupedDynamicCausalConv(nn.Module):
+    def __init__(self, hidden_size: int, kernel_size: int, group_size: int):
+        super().__init__()
+        self.kernel_size = int(kernel_size)
+        self.group_size = int(group_size)
+        groups = int(hidden_size) // self.group_size
+        self.base_kernel = mx.zeros((2, self.kernel_size, int(hidden_size)))
+        self.kernel_projection = nn.Linear(
+            int(hidden_size),
+            2 * self.kernel_size * groups,
+            bias=False,
+        )
+
+    def prepare(self, hidden: mx.array) -> tuple[mx.array, mx.array]:
+        groups = int(hidden.shape[-1]) // self.group_size
+        dynamic = self.kernel_projection(hidden).reshape(
+            *hidden.shape[:-1],
+            2,
+            self.kernel_size,
+            groups,
+        )
+        return (
+            _grouped_dynamic_convolve(
+                hidden,
+                dynamic[..., 0, :, :],
+                self.base_kernel[0],
+                self.group_size,
+            ),
+            dynamic[..., 1, :, :],
+        )
+
+    def finish(self, hidden: mx.array, dynamic: mx.array) -> mx.array:
+        return _grouped_dynamic_convolve(
+            hidden,
+            dynamic,
+            self.base_kernel[1],
+            self.group_size,
+        )
+
+
+class DFlash2Attention(DFlashAttention):
+    def __init__(self, args: DFlash2DraftModelArgs, layer_idx: int):
+        super().__init__(args, layer_idx)
+        self.is_causal = bool(args.is_causal)
+
+    def _attention_mask(
+        self,
+        *,
+        block_len: int,
+        query_offset: int,
+        key_len: int,
+        key_positions: Optional[mx.array] = None,
+    ) -> Optional[mx.array]:
+        if self.sliding_window is None and not self.is_causal:
+            return None
+        query_positions = mx.arange(
+            query_offset,
+            query_offset + int(block_len),
+            dtype=mx.int32,
+        )
+        if key_positions is None:
+            key_start = query_offset + int(block_len) - int(key_len)
+            key_positions = mx.arange(key_start, key_start + int(key_len), dtype=mx.int32)
+        if self.sliding_window is None:
+            return key_positions[None, :] <= query_positions[:, None]
+        context = (key_positions[None, :] < int(query_offset)) & (
+            query_positions[:, None] - key_positions[None, :] < int(self.sliding_window)
+        )
+        block = key_positions[None, :] >= int(query_offset)
+        if self.is_causal:
+            block = block & (key_positions[None, :] <= query_positions[:, None])
+        return context | block
+
+
+class DFlash2DecoderLayer(nn.Module):
+    def __init__(self, args: DFlash2DraftModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = DFlash2Attention(args, layer_idx)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.attention_conv = GroupedDynamicCausalConv(
+            args.hidden_size,
+            args.conv_kernel_size,
+            args.conv_group_size,
+        )
+        self.mlp_conv = GroupedDynamicCausalConv(
+            args.hidden_size,
+            args.conv_kernel_size,
+            args.conv_group_size,
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        target_hidden: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        residual = hidden_states
+        hidden_states, dynamic = self.attention_conv.prepare(
+            self.input_layernorm(hidden_states)
+        )
+        hidden_states = residual + self.attention_conv.finish(
+            self.self_attn(
+                hidden_states,
+                target_hidden=target_hidden,
+                cache=cache,
+            ),
+            dynamic,
+        )
+        residual = hidden_states
+        hidden_states, dynamic = self.mlp_conv.prepare(
+            self.post_attention_layernorm(hidden_states)
+        )
+        return residual + self.mlp_conv.finish(self.mlp(hidden_states), dynamic)
+
+    def advance_projected_context_cache(
+        self,
+        *,
+        target_hidden: mx.array,
+        cache: Any,
+    ) -> None:
+        self.self_attn.append_projected_context_cache(
+            target_hidden=target_hidden,
+            cache=cache,
+        )
+
+
+def _sample_probs(probs: mx.array) -> mx.array:
+    return mx.random.categorical(mx.log(probs))
+
+
+def _selector_probabilities(scores: mx.array, temperature: float) -> mx.array:
+    if float(temperature) <= 0:
+        raise ValueError("DFlash2 selector temperature must be positive")
+    return mx.softmax(scores.astype(mx.float32) / float(temperature), axis=-1)
+
+
+@dataclass(frozen=True)
+class _CandidateSelection:
+    token_ids: mx.array
+    candidate_ids: mx.array
+    probabilities: Optional[mx.array]
+
+
+class CandidateSelector(nn.Module):
+    def __init__(self, args: DFlash2DraftModelArgs):
+        super().__init__()
+        self.top_k = int(args.selector_top_k)
+        self.predecessor_codebook = nn.Embedding(args.vocab_size, int(args.selector_rank))
+        self.successor_codebook = nn.Embedding(args.vocab_size, int(args.selector_rank))
+        self.hidden_projection = nn.Linear(args.hidden_size, int(args.selector_rank), bias=False)
+
+    def _edge_scores(
+        self,
+        predecessor_ids: mx.array,
+        successor_vectors: mx.array,
+        hidden: mx.array,
+    ) -> mx.array:
+        return mx.sum(
+            self.predecessor_codebook(predecessor_ids)[:, :, None]
+            * hidden[:, None, None]
+            * successor_vectors[:, None],
+            axis=-1,
+        )
+
+    def _select_ancestral(
+        self,
+        *,
+        candidates: mx.array,
+        unary: mx.array,
+        hidden: mx.array,
+        anchor_ids: mx.array,
+        successors: mx.array,
+        temperature: float,
+        capture_q: bool,
+    ) -> _CandidateSelection:
+        predecessor = anchor_ids
+        path = []
+        q_rows = []
+        for position in range(int(hidden.shape[1])):
+            edges = self._edge_scores(
+                predecessor[:, None],
+                successors[:, position],
+                hidden[:, position],
+            )[:, 0]
+            scores = unary[:, position] + edges
+            if float(temperature) > 0 or capture_q:
+                q = _selector_probabilities(
+                    scores,
+                    float(temperature) if float(temperature) > 0 else 1.0,
+                )
+                q_rows.append(q)
+            if float(temperature) > 0:
+                selected = _sample_probs(q)
+            else:
+                selected = mx.argmax(scores, axis=-1)
+            predecessor = mx.take_along_axis(
+                candidates[:, position],
+                selected[:, None],
+                axis=-1,
+            )[:, 0]
+            path.append(predecessor)
+        sparse_q = mx.stack(q_rows, axis=1) if q_rows else None
+        return _CandidateSelection(
+            token_ids=mx.stack(path, axis=1),
+            candidate_ids=candidates,
+            probabilities=sparse_q,
+        )
+
+    def select(
+        self,
+        hidden: mx.array,
+        logits: mx.array,
+        anchor_ids: mx.array,
+        temperature: float,
+        capture_q: bool = False,
+    ) -> _CandidateSelection:
+        if len(hidden.shape) != 3 or len(logits.shape) != 3:
+            raise ValueError("DFlash2 selector requires 3D hidden and logits")
+        if tuple(hidden.shape[:2]) != tuple(logits.shape[:2]):
+            raise ValueError("DFlash2 selector hidden/logits batch and length must match")
+        if int(logits.shape[-1]) < self.top_k:
+            raise ValueError("DFlash2 selector vocabulary must be at least top_k")
+        anchor_ids = anchor_ids.reshape(-1)
+        if int(anchor_ids.shape[0]) != int(hidden.shape[0]):
+            raise ValueError("DFlash2 selector anchor batch must match hidden batch")
+
+        candidates = mx.argpartition(logits, -self.top_k, axis=-1)[..., -self.top_k :]
+        unary = mx.take_along_axis(logits, candidates, axis=-1)
+        hidden = self.hidden_projection(hidden)
+        successors = self.successor_codebook(candidates)
+        return self._select_ancestral(
+            candidates=candidates,
+            unary=unary,
+            hidden=hidden,
+            anchor_ids=anchor_ids,
+            successors=successors,
+            temperature=float(temperature),
+            capture_q=bool(capture_q),
+        )
+
+
+class DFlash2DraftModel(DFlashDraftModel):
+    def __init__(self, args: DFlash2DraftModelArgs):
+        super().__init__(args)
+        self.model_type = "dflash2_qwen3"
+        self.args = args
+        self.candidate_selector = CandidateSelector(args)
+        self.capabilities = DraftRuntimeCapabilities(
+            default_block_tokens=5,
+            max_block_tokens=min(5, int(args.block_size)),
+            supports_copyspec=False,
+            supports_ddtree=False,
+            supports_early_rollback_launch=True,
+        )
+
+    def _build_layers(self, args: DFlashDraftModelArgs) -> list[nn.Module]:
+        if not isinstance(args, DFlash2DraftModelArgs):
+            raise TypeError("DFlash2 layer construction requires DFlash2 arguments")
+        return [
+            DFlash2DecoderLayer(args, layer_idx)
+            for layer_idx in range(args.num_hidden_layers)
+        ]
+
+    def bind_target_model(self, target_model: Any, *, target_ops: Any) -> None:
+        super().bind_target_model(target_model, target_ops=target_ops)
+        self.embed_scale *= float(self.args.input_embedding_scale)
+
+    def compute_logits(self, logits: mx.array) -> mx.array:
+        logits = logits * float(self.args.output_multiplier)
+        cap = self.args.final_logit_softcapping
+        if cap is not None and float(cap) > 0:
+            cap_value = float(cap)
+            logits = mx.tanh(logits / cap_value) * cap_value
+        return logits
+
+    def select_proposal(
+        self,
+        *,
+        draft_hidden: mx.array,
+        logits: mx.array,
+        anchor_ids: mx.array,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        min_p: float = 0.0,
+        top_k: int = 0,
+        capture_q: bool = False,
+    ) -> DraftProposal:
+        del top_p, min_p, top_k
+        proposal = self.candidate_selector.select(
+            draft_hidden,
+            self.compute_logits(logits),
+            anchor_ids,
+            temperature,
+            capture_q=capture_q,
+        )
+        return DraftProposal(
+            token_ids=proposal.token_ids.squeeze(0),
+            q_token_ids=(
+                proposal.candidate_ids.squeeze(0)
+                if proposal.probabilities is not None
+                else None
+            ),
+            q_probs=(
+                proposal.probabilities.squeeze(0)
+                if proposal.probabilities is not None
+                else None
+            ),
+        )
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        return remap_dflash2_codebook_weights(weights)

--- a/dflash_mlx/draft_backend.py
+++ b/dflash_mlx/draft_backend.py
@@ -43,6 +43,26 @@ class DraftBackend(Protocol):
     ) -> mx.array:
         ...
 
+    def propose_block(
+        self,
+        *,
+        target_model: Any,
+        target_ops: Any,
+        draft_model: DFlashDraftModel,
+        draft_cache: list[Any],
+        staged_first: mx.array,
+        draft_context: mx.array,
+        block_len: int,
+        mask_token_tail: mx.array,
+        suppress_token_mask: Optional[mx.array],
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        min_p: float = 0.0,
+        top_k: int = 0,
+        capture_q: bool = False,
+    ) -> Any:
+        ...
+
     def draft_with_topk(
         self,
         *,
@@ -123,7 +143,7 @@ class EagerDraftBackend:
                 )
         return caches
 
-    def _draft_block_logits(
+    def _draft_hidden_and_logits(
         self,
         *,
         target_model: Any,
@@ -154,10 +174,87 @@ class EagerDraftBackend:
             draft_context=draft_context,
             cache=draft_cache,
         )
-        return target_ops.logits_from_hidden(
+        logits = target_ops.logits_from_hidden(
             target_model,
             draft_hidden[:, 1:, :],
         )
+        return draft_hidden[:, 1:, :], logits
+
+    def _draft_block_logits(
+        self,
+        *,
+        target_model: Any,
+        target_ops: Any,
+        draft_model: DFlashDraftModel,
+        draft_cache: list[Any],
+        staged_first: mx.array,
+        draft_context: mx.array,
+        block_len: int,
+        mask_token_tail: mx.array,
+    ) -> mx.array:
+        _draft_hidden, draft_logits = self._draft_hidden_and_logits(
+            target_model=target_model,
+            target_ops=target_ops,
+            draft_model=draft_model,
+            draft_cache=draft_cache,
+            staged_first=staged_first,
+            draft_context=draft_context,
+            block_len=block_len,
+            mask_token_tail=mask_token_tail,
+        )
+        return draft_logits
+
+    def propose_block(
+        self,
+        *,
+        target_model: Any,
+        target_ops: Any,
+        draft_model: DFlashDraftModel,
+        draft_cache: list[Any],
+        staged_first: mx.array,
+        draft_context: mx.array,
+        block_len: int,
+        mask_token_tail: mx.array,
+        suppress_token_mask: Optional[mx.array],
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        min_p: float = 0.0,
+        top_k: int = 0,
+        capture_q: bool = False,
+    ) -> Any:
+        selector = getattr(draft_model, "select_proposal", None)
+        if not callable(selector):
+            raise ValueError("draft model does not expose a proposal selector")
+        draft_hidden, logits = self._draft_hidden_and_logits(
+            target_model=target_model,
+            target_ops=target_ops,
+            draft_model=draft_model,
+            draft_cache=draft_cache,
+            staged_first=staged_first,
+            draft_context=draft_context,
+            block_len=block_len,
+            mask_token_tail=mask_token_tail,
+        )
+        if suppress_token_mask is not None:
+            floor = mx.array(-1e9, dtype=logits.dtype)
+            logits = mx.where(suppress_token_mask, floor, logits)
+        proposal = selector(
+            draft_hidden=draft_hidden,
+            logits=logits,
+            anchor_ids=staged_first[:1],
+            temperature=float(temperature),
+            top_p=float(top_p),
+            min_p=float(min_p),
+            top_k=int(top_k),
+            capture_q=bool(capture_q),
+        )
+        expected_rows = int(block_len) - 1
+        if int(proposal.token_ids.shape[0]) != expected_rows:
+            raise ValueError(
+                "draft proposal token rows must match the verify width: "
+                f"expected {expected_rows}, got {proposal.token_ids.shape[0]}"
+            )
+        return proposal
 
     def draft_greedy(
         self,
@@ -173,6 +270,25 @@ class EagerDraftBackend:
         suppress_token_mask: Optional[mx.array],
         async_launch: bool,
     ) -> mx.array:
+        if callable(getattr(draft_model, "select_proposal", None)):
+            proposal = self.propose_block(
+                target_model=target_model,
+                target_ops=target_ops,
+                draft_model=draft_model,
+                draft_cache=draft_cache,
+                staged_first=staged_first,
+                draft_context=draft_context,
+                block_len=block_len,
+                mask_token_tail=mask_token_tail,
+                suppress_token_mask=suppress_token_mask,
+            )
+            drafted = proposal.token_ids.astype(mx.uint32)
+            if async_launch:
+                mx.async_eval(drafted)
+            else:
+                mx.eval(drafted)
+            return drafted
+
         draft_logits = self._draft_block_logits(
             target_model=target_model,
             target_ops=target_ops,
@@ -208,6 +324,34 @@ class EagerDraftBackend:
         async_launch: bool,
         top_width: int,
     ) -> tuple[mx.array, mx.array, mx.array]:
+        if callable(getattr(draft_model, "select_proposal", None)):
+            proposal = self.propose_block(
+                target_model=target_model,
+                target_ops=target_ops,
+                draft_model=draft_model,
+                draft_cache=draft_cache,
+                staged_first=staged_first,
+                draft_context=draft_context,
+                block_len=block_len,
+                mask_token_tail=mask_token_tail,
+                suppress_token_mask=suppress_token_mask,
+                capture_q=True,
+            )
+            if proposal.q_token_ids is None or proposal.q_probs is None:
+                raise ValueError("draft proposal did not return capture candidates")
+            width = min(int(top_width), int(proposal.q_token_ids.shape[-1]))
+            order = mx.argsort(proposal.q_probs, axis=-1)[..., -width:]
+            order = mx.flip(order, axis=-1)
+            top_ids = mx.take_along_axis(proposal.q_token_ids, order, axis=-1)
+            top_logprobs = mx.log(
+                mx.take_along_axis(proposal.q_probs, order, axis=-1)
+            )
+            drafted = proposal.token_ids.astype(mx.uint32)
+            if async_launch:
+                mx.async_eval(drafted, top_ids, top_logprobs)
+            else:
+                mx.eval(drafted, top_ids, top_logprobs)
+            return drafted, top_ids, top_logprobs
         draft_logits = self._draft_block_logits(
             target_model=target_model,
             target_ops=target_ops,
@@ -246,6 +390,8 @@ class EagerDraftBackend:
         suppress_token_mask: Optional[mx.array],
         top_width: int,
     ) -> tuple[mx.array, list[list[int]], list[list[float]]]:
+        if callable(getattr(draft_model, "select_proposal", None)):
+            raise ValueError("DFlash2 drafts do not support DDTree/top-k draft paths")
         from dflash_mlx.engine.ddtree import draft_block_with_topk
 
         drafted, top_ids, top_values, _draft_us = draft_block_with_topk(
@@ -273,6 +419,8 @@ class EagerDraftBackend:
         block_len: int,
         suppress_token_mask: Optional[mx.array],
     ) -> list[mx.array]:
+        if callable(getattr(draft_model, "select_proposal", None)):
+            raise ValueError("DFlash2 drafts do not support DDTree/top-k draft paths")
         from dflash_mlx.engine.ddtree import draft_branch_blocks_batch
 
         candidate_ids, _draft_us = draft_branch_blocks_batch(

--- a/dflash_mlx/engine/_hook_guard.py
+++ b/dflash_mlx/engine/_hook_guard.py
@@ -1,0 +1,40 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Guard for class-level target hooks shared across backends.
+
+Target backends install speculative hooks by replacing ``cls.__call__`` on a
+model's attention class and tagging the class with a marker so a second install
+is a no-op. The marker is keyed by the class *object*, which is safe only while
+each attention class resolves to exactly one target backend. Should two model
+families that resolve to different backends ever share an attention class, a
+bare boolean marker would let whichever backend installed first silently run
+its attention for the other model. This guard makes that case fail loudly.
+"""
+from __future__ import annotations
+
+
+class DFlashHookConflict(RuntimeError):
+    """Two target backends tried to patch the same attention class."""
+
+
+def claim_class_hook(cls: type, attr: str, owner: str) -> bool:
+    """Claim the class-level hook slot ``attr`` on ``cls`` for ``owner``.
+
+    Returns ``True`` when the slot is free (the caller should install and then
+    set ``cls.attr = owner``) and ``False`` when ``owner`` already installed it
+    (the caller should no-op). Raises :class:`DFlashHookConflict` when a
+    *different* backend already owns the slot.
+    """
+    existing = getattr(cls, attr, None)
+    if existing is None:
+        return True
+    if existing == owner:
+        return False
+    raise DFlashHookConflict(
+        f"{cls.__module__}.{cls.__qualname__} is already patched by DFlash target "
+        f"backend {existing!r}; backend {owner!r} cannot reuse the same attention "
+        f"class. Two model families that share an attention class must resolve to "
+        f"the same target backend."
+    )

--- a/dflash_mlx/engine/config.py
+++ b/dflash_mlx/engine/config.py
@@ -28,16 +28,34 @@ def verify_token_count_for_block(block_len: int, verify_len_cap: int) -> int:
     return max(1, min(int(block_len), int(verify_len_cap)))
 
 
+def draft_capability(draft_model: Any, name: str, default: Any) -> Any:
+    capabilities = getattr(draft_model, "capabilities", None)
+    if capabilities is None:
+        return default
+    return getattr(capabilities, name, default)
+
+
 def resolve_speculative_cycle_config(
     runtime_config: Any,
     draft_model: Any,
     block_tokens: Optional[int],
 ) -> SpeculativeCycleConfig:
     draft_block_size = int(draft_model.block_size)
-    requested_block_tokens = (
-        draft_block_size if block_tokens is None else int(block_tokens)
+    default_block_tokens = int(
+        draft_capability(draft_model, "default_block_tokens", draft_block_size)
+        or draft_block_size
     )
-    effective_block_tokens = max(1, min(requested_block_tokens, draft_block_size))
+    max_block_tokens = int(
+        draft_capability(draft_model, "max_block_tokens", draft_block_size)
+        or draft_block_size
+    )
+    requested_block_tokens = (
+        default_block_tokens if block_tokens is None else int(block_tokens)
+    )
+    effective_block_tokens = max(
+        1,
+        min(requested_block_tokens, draft_block_size, max_block_tokens),
+    )
     return SpeculativeCycleConfig(
         draft_block_size=draft_block_size,
         requested_block_tokens=requested_block_tokens,

--- a/dflash_mlx/engine/spec_epoch.py
+++ b/dflash_mlx/engine/spec_epoch.py
@@ -63,6 +63,7 @@ from dflash_mlx.engine.sampling import (
 from dflash_mlx.engine.target_features import TargetFeatureStore
 from dflash_mlx.engine.config import (
     _profile_dflash_cycles_enabled,
+    draft_capability,
     resolve_draft_window,
     resolve_speculative_cycle_config,
     verify_token_count_for_block,
@@ -607,6 +608,25 @@ def _capture_rows_float(arr: mx.array) -> tuple[tuple[float, ...], ...]:
     return tuple(tuple(float(v) for v in row) for row in arr.tolist())
 
 
+def _draft_capability(
+    draft_model: Any,
+    capability: str,
+    *,
+    default: bool,
+) -> bool:
+    return bool(draft_capability(draft_model, capability, default))
+
+
+def _validate_draft_runtime_compatibility(
+    draft_model: Any,
+    runtime_config: Any,
+) -> None:
+    if str(getattr(runtime_config, "verify_mode", "dflash")) == "ddtree" and not (
+        _draft_capability(draft_model, "supports_ddtree", default=True)
+    ):
+        raise ValueError("draft model does not support --verify-mode ddtree")
+
+
 @dataclass
 class SpeculativeSession:
     target_model: Any
@@ -704,6 +724,9 @@ class SpeculativeSession:
         profile_cycles = _profile_dflash_cycles_enabled(diagnostics)
         memory_waterfall = _memory_waterfall_enabled(diagnostics)
         capture_logits = os.environ.get("DFLASH_CAPTURE_LOGITS", "") == "1"
+        copyspec_mode = str(getattr(runtime_config, "copyspec_mode", "conservative"))
+        if not _draft_capability(draft_model, "supports_copyspec", default=True):
+            copyspec_mode = "off"
         return cls(
             target_model=target_model,
             draft_model=draft_model,
@@ -728,7 +751,7 @@ class SpeculativeSession:
             clear_cache_boundaries=bool(runtime_config.clear_cache_boundaries),
             target_fa_window=target_fa_window,
             copyspec_index=CopySpecIndex(prompt_tokens),
-            copyspec_mode=str(getattr(runtime_config, "copyspec_mode", "conservative")),
+            copyspec_mode=copyspec_mode,
         )
 
     def clear_cache_boundary(self) -> None:
@@ -2835,6 +2858,7 @@ def stream_dflash_generate_impl(
     if runtime_context is None:
         raise ValueError("runtime_context is required")
     runtime_config = runtime_context.runtime
+    _validate_draft_runtime_compatibility(draft_model, runtime_config)
     prompt_len = len(prompt_tokens)
     configured_max_ctx = int(runtime_config.dflash_max_ctx)
     dflash_max_ctx = configured_max_ctx if configured_max_ctx > 0 else sys.maxsize

--- a/dflash_mlx/engine/target_gemma4.py
+++ b/dflash_mlx/engine/target_gemma4.py
@@ -16,6 +16,7 @@ from dflash_mlx.engine.gqa_sdpa import (
     per_head_gqa_sdpa,
     repeat_gqa_mask,
 )
+from dflash_mlx.engine._hook_guard import claim_class_hook
 from dflash_mlx.engine.sparse_rope import SPARSE_POSITIONS_ATTR
 from dflash_mlx.engine.target_ops import TargetCapabilities
 
@@ -216,7 +217,7 @@ def _gemma4_full_gqa_sdpa(
 
 def _install_full_attention_gqa_hook(attn: Any) -> None:
     cls = type(attn)
-    if getattr(cls, "_dflash_full_attention_gqa_installed", False):
+    if not claim_class_hook(cls, "_dflash_full_attention_gqa_installed", "gemma4"):
         return
 
     original_call = cls.__call__
@@ -279,7 +280,7 @@ def _install_full_attention_gqa_hook(attn: Any) -> None:
         return self.o_proj(output), (keys, values), offset
 
     cls.__call__ = attention_call
-    cls._dflash_full_attention_gqa_installed = True
+    cls._dflash_full_attention_gqa_installed = "gemma4"
 
 
 class Gemma4TargetOps:

--- a/dflash_mlx/engine/target_qwen_gdn.py
+++ b/dflash_mlx/engine/target_qwen_gdn.py
@@ -17,6 +17,7 @@ from mlx_lm.models.base import (
     scaled_dot_product_attention,
 )
 
+from dflash_mlx.engine._hook_guard import claim_class_hook
 from dflash_mlx.engine.gqa_sdpa import (
     async_per_head_gqa_sdpa,
     grouped_gqa_sdpa,
@@ -543,7 +544,7 @@ def _commit_recurrent_tree_path(
 
 def _install_speculative_linear_cache_hook(linear_attn: Any) -> None:
     cls = type(linear_attn)
-    if getattr(cls, "_dflash_speculative_call_installed", False):
+    if not claim_class_hook(cls, "_dflash_speculative_call_installed", "qwen_gdn"):
         return
 
     original_call = cls.__call__
@@ -651,11 +652,11 @@ def _install_speculative_linear_cache_hook(linear_attn: Any) -> None:
         return out
 
     cls.__call__ = speculative_call
-    cls._dflash_speculative_call_installed = True
+    cls._dflash_speculative_call_installed = "qwen_gdn"
 
 def _install_full_attention_gqa_hook(attn: Any) -> None:
     cls = type(attn)
-    if getattr(cls, "_dflash_full_attention_gqa_installed", False):
+    if not claim_class_hook(cls, "_dflash_full_attention_gqa_installed", "qwen_gdn"):
         return
 
     original_call = cls.__call__
@@ -725,7 +726,7 @@ def _install_full_attention_gqa_hook(attn: Any) -> None:
         return self.o_proj(gated_output)
 
     cls.__call__ = attention_call
-    cls._dflash_full_attention_gqa_installed = True
+    cls._dflash_full_attention_gqa_installed = "qwen_gdn"
 
 class QwenGdnTargetOps:
     backend_name = "qwen_gdn"

--- a/dflash_mlx/engine/target_qwen_gdn.py
+++ b/dflash_mlx/engine/target_qwen_gdn.py
@@ -116,12 +116,16 @@ def _gqa_reshape_sdpa(
             mask=mask,
         )
 
-    use_native_gqa = (q_len_i == 1 and kv_len_i >= 4096) or (
-        q_len_i == 4
-        and (
-            kv_len_i <= 8192
-            or (int(gqa) <= 4 and kv_len_i <= 32768)
-            or (kv_heads_i >= 4 and kv_len_i <= 16384)
+    use_native_gqa = (
+        (q_len_i == 1 and kv_len_i >= 4096)
+        or (q_len_i == 5 and kv_len_i >= 8192)
+        or (
+            q_len_i == 4
+            and (
+                kv_len_i <= 8192
+                or (int(gqa) <= 4 and kv_len_i <= 32768)
+                or (kv_heads_i >= 4 and kv_len_i <= 16384)
+            )
         )
     )
     if use_native_gqa:

--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -283,6 +283,16 @@ class DFlashDraftModelArgs:
                 data["sliding_window"] = _GEMMA4_DEFAULT_SLIDING_WINDOW
         data["layer_types"] = layer_types
         data["dflash_config"] = dict(data.get("dflash_config") or {})
+        if "block_size" not in data:
+            nested_block_size = data["dflash_config"].get("block_size")
+            if nested_block_size is not None:
+                data["block_size"] = nested_block_size
+        if "rope_theta" not in data:
+            rope_parameters = data.get("rope_parameters") or {}
+            if isinstance(rope_parameters, dict) and "rope_theta" in rope_parameters:
+                data["rope_theta"] = rope_parameters["rope_theta"]
+            elif isinstance(data.get("rope_scaling"), dict) and "rope_theta" in data["rope_scaling"]:
+                data["rope_theta"] = data["rope_scaling"]["rope_theta"]
         return cls(
             **{key: value for key, value in data.items() if key in cls.__annotations__}
         )

--- a/dflash_mlx/model.py
+++ b/dflash_mlx/model.py
@@ -291,7 +291,10 @@ class DFlashDraftModelArgs:
             rope_parameters = data.get("rope_parameters") or {}
             if isinstance(rope_parameters, dict) and "rope_theta" in rope_parameters:
                 data["rope_theta"] = rope_parameters["rope_theta"]
-            elif isinstance(data.get("rope_scaling"), dict) and "rope_theta" in data["rope_scaling"]:
+            elif (
+                isinstance(data.get("rope_scaling"), dict)
+                and "rope_theta" in data["rope_scaling"]
+            ):
                 data["rope_theta"] = data["rope_scaling"]["rope_theta"]
         return cls(
             **{key: value for key, value in data.items() if key in cls.__annotations__}
@@ -321,6 +324,16 @@ class DFlashDraftModelArgs:
         if "sliding_attention" in layer_types and int(self.sliding_window or 0) <= 0:
             raise ValueError("sliding_attention draft layers require a positive sliding_window")
         self.layer_types = layer_types
+
+
+@dataclass(frozen=True)
+class DraftRuntimeCapabilities:
+    default_block_tokens: int
+    max_block_tokens: int
+    supports_copyspec: bool = True
+    supports_ddtree: bool = True
+    supports_early_rollback_launch: bool = True
+
 
 class DFlashAttention(nn.Module):
     def __init__(self, args: DFlashDraftModelArgs, layer_idx: int):
@@ -706,15 +719,13 @@ class DFlashDecoderLayer(nn.Module):
             cache=cache,
         )
 
+
 class DFlashDraftModel(nn.Module):
     def __init__(self, args: DFlashDraftModelArgs):
         super().__init__()
         self.args = args
         self.model_type = "dflash_qwen3"
-        self.layers = [
-            DFlashDecoderLayer(args, layer_idx)
-            for layer_idx in range(args.num_hidden_layers)
-        ]
+        self.layers = self._build_layers(args)
         target_layer_ids = list((args.dflash_config or {}).get("target_layer_ids") or ())
         self.target_layer_ids = target_layer_ids or build_target_layer_ids(
             args.num_target_layers,
@@ -726,6 +737,16 @@ class DFlashDraftModel(nn.Module):
         self.block_size = int(args.block_size)
         self.mask_token_id = int((args.dflash_config or {}).get("mask_token_id", 0) or 0)
         self.embed_scale = 1.0
+        self.capabilities = DraftRuntimeCapabilities(
+            default_block_tokens=self.block_size,
+            max_block_tokens=self.block_size,
+        )
+
+    def _build_layers(self, args: DFlashDraftModelArgs) -> list[nn.Module]:
+        return [
+            DFlashDecoderLayer(args, layer_idx)
+            for layer_idx in range(args.num_hidden_layers)
+        ]
 
     def bind_target_model(self, target_model: Any, *, target_ops: Any) -> None:
         text_model = target_ops.text_model(target_model)

--- a/dflash_mlx/runtime/loading.py
+++ b/dflash_mlx/runtime/loading.py
@@ -50,8 +50,9 @@ def resolve_model_ref(model_ref: str | Path | None, *, kind: str) -> str:
 
 
 def _get_dflash_model_classes(config: dict[str, Any]):
-    del config
-    return DFlashDraftModel, DFlashDraftModelArgs
+    from dflash_mlx.draft.checkpoint import get_draft_model_classes
+
+    return get_draft_model_classes(config)
 
 
 def _resolve_local_model_path(model_ref: str | Path) -> Path:

--- a/dflash_mlx/runtime/registry.py
+++ b/dflash_mlx/runtime/registry.py
@@ -45,6 +45,9 @@ MODEL_SUPPORT_SPECS: tuple[ModelSupportSpec, ...] = (
         "hybrid_gdn",
         W4_DEFAULTS,
     ),
+    ModelSupportSpec(
+        ("Qwen3.8-27B",), "z-lab/Qwen3.8-27B-DFlash2", "hybrid_gdn", W4_DEFAULTS
+    ),
     ModelSupportSpec(("Qwen3-4B",), "z-lab/Qwen3-4B-DFlash-b16", "pure_attention"),
     ModelSupportSpec(("Qwen3-8B",), "z-lab/Qwen3-8B-DFlash-b16", "pure_attention"),
     ModelSupportSpec(

--- a/dflash_mlx/server/metrics.py
+++ b/dflash_mlx/server/metrics.py
@@ -30,7 +30,10 @@ from dflash_mlx.cache.manager import (
 from dflash_mlx.diagnostics import DiagnosticsConfig
 from dflash_mlx.engine.events import PrefillCompleteEvent, SummaryEvent
 from dflash_mlx.observability.memory import live_memory_payload
-from dflash_mlx.server.prefix_cache_manager import build_prefix_key
+from dflash_mlx.server.prefix_cache_manager import (
+    build_prefix_key,
+    build_runtime_cache_identity,
+)
 
 _LIVE_LOCK = threading.Lock()
 _LIVE_STARTED_AT = time.time()
@@ -412,7 +415,11 @@ def configure_live_metrics(
         and int(target_fa_window or 0) <= 0
     )
     runtime_context = getattr(cli_args, "runtime_context", None)
-    cache_identity: Any = tuple(model_key)
+    cache_identity: Any = (
+        build_runtime_cache_identity(model_provider)
+        if runtime_context is not None
+        else tuple(model_key)
+    )
     draft_model = getattr(model_provider, "draft_model", None)
     if prefix_cache_enabled and runtime_context is not None and draft_model is not None:
         cache_identity = build_prefix_key(model_provider, draft_model, runtime_context)

--- a/dflash_mlx/server/prefix_cache_flow.py
+++ b/dflash_mlx/server/prefix_cache_flow.py
@@ -21,6 +21,7 @@ from dflash_mlx.cache.snapshot_service import SnapshotService
 from dflash_mlx.engine.spec_epoch import resolve_full_context_draft_layers
 from dflash_mlx.server.prefix_cache_manager import (
     build_prefix_key,
+    build_runtime_cache_identity,
     chat_template_stable_marker,
 )
 
@@ -124,7 +125,10 @@ class PrefixCacheFlow:
 
         runtime_config = runtime_context.runtime
         if runtime_config.target_fa_window > 0 or not runtime_config.prefix_cache:
-            get_runtime_cache_manager(runtime_context)
+            get_runtime_cache_manager(
+                runtime_context,
+                cache_identity=build_runtime_cache_identity(model_provider),
+            )
             return cls(cache_manager=None)
 
         key = build_prefix_key(model_provider, draft_model, runtime_context)

--- a/dflash_mlx/server/prefix_cache_manager.py
+++ b/dflash_mlx/server/prefix_cache_manager.py
@@ -10,11 +10,8 @@ from typing import Any
 
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 
-def build_prefix_key(
-    model_provider: Any,
-    draft_model: Any,
-    runtime_context: Any,
-) -> DFlashPrefixKey:
+
+def build_runtime_cache_identity(model_provider: Any) -> tuple[str, str]:
     model_key = getattr(model_provider, "model_key", None)
     if not isinstance(model_key, (list, tuple)) or len(model_key) < 3:
         raise ValueError("model provider is missing a loaded model_key")
@@ -22,6 +19,15 @@ def build_prefix_key(
     draft_id = str(model_key[2]) if model_key[2] is not None else ""
     if not target_id or not draft_id:
         raise ValueError("prefix cache requires loaded target and draft model ids")
+    return target_id, draft_id
+
+
+def build_prefix_key(
+    model_provider: Any,
+    draft_model: Any,
+    runtime_context: Any,
+) -> DFlashPrefixKey:
+    target_id, draft_id = build_runtime_cache_identity(model_provider)
 
     raw_capture_ids = getattr(draft_model, "target_layer_ids", None)
     if raw_capture_ids is None:

--- a/dflash_mlx/server/request_loop.py
+++ b/dflash_mlx/server/request_loop.py
@@ -24,7 +24,6 @@ from dflash_mlx.engine.events import (
     SummaryEvent,
     TokenEvent,
 )
-from dflash_mlx.cache.manager import current_runtime_cache_manager
 from dflash_mlx.observability.memory import process_memory_snapshot
 from dflash_mlx.server.prefix_cache_flow import PrefixCacheFlow
 from dflash_mlx.server.metrics import record_cycle_diagnostic, update_live_request
@@ -118,7 +117,11 @@ def consume_dflash_events(
                 fields=memory_start,
             )
 
-    cache_manager = current_runtime_cache_manager()
+    # Use the manager resolved for THIS request rather than the process-wide
+    # "current" one: with several models registered, the global current can
+    # point at a different model when requests interleave. prefix_flow carries
+    # the right model's manager (or None when the cache is off for it).
+    cache_manager = prefix_flow.cache_manager if prefix_flow is not None else None
     if cache_manager is not None:
         cache_manager.begin_request()
     try:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,8 @@ Engine:
 Draft/model/kernels:
 
 - `dflash_mlx/model.py` - DFlash draft model;
+- `dflash_mlx/draft/` - draft architecture dispatch and DFlash2-specific
+  draft modules;
 - `dflash_mlx/draft_backend.py` - masked-block draft call;
 - `dflash_mlx/kernels.py` - local kernel helpers;
 - `dflash_mlx/verify_linear.py` and `dflash_mlx/verify_qmm.py` - verify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 authors = [{name = "bstnxbt"}]
 dependencies = [
-    "mlx>=0.31.0",
-    "mlx-lm>=0.31.0",
+    "mlx>=0.32.1",
+    "mlx-lm>=0.31.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cache_manager_registry.py
+++ b/tests/test_cache_manager_registry.py
@@ -1,0 +1,115 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Registry semantics for the runtime cache manager.
+
+Two DFlash models loaded in one process (e.g. an embedding host's engine
+pool) must each keep their own prefix-cache manager alive concurrently.
+Previously a single process-global slot meant loading the second model
+retired the first's cache. These tests pin the registry contract:
+
+  * distinct cache identities coexist (neither retired),
+  * the same identity + same config returns the same manager,
+  * the same identity reconfigured replaces (and retires) the old one,
+  * shutdown can target one identity or clear all.
+"""
+from __future__ import annotations
+
+import pytest
+
+import dflash_mlx.cache.manager as cm
+from dflash_mlx.runtime.config import runtime_config_from_defaults
+from dflash_mlx.runtime.context import build_runtime_context
+
+
+def _ctx(**overrides):
+    values = dict(
+        prefix_cache=True,
+        prefix_cache_l2=False,
+        prefix_cache_l2_dir="/tmp/dflash-prefix-l2-registry-test",
+    )
+    values.update(overrides)
+    return build_runtime_context(runtime_config_from_defaults(**values))
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    # Start and end each test with an empty registry so order can't leak state.
+    cm.shutdown_runtime_cache_manager()
+    yield
+    cm.shutdown_runtime_cache_manager()
+
+
+def test_distinct_identities_coexist():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+
+    assert mgr_a is not None and mgr_b is not None
+    assert mgr_a is not mgr_b
+    # The crux of #1892: loading B must NOT retire A.
+    assert mgr_a.active
+    assert mgr_b.active
+
+
+def test_same_identity_same_config_returns_same_manager():
+    ctx = _ctx()
+    first = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    second = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    assert first is second
+
+
+def test_same_identity_reconfig_replaces_and_retires_old():
+    first = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache_max_entries=2), cache_identity="model-A"
+    )
+    second = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache_max_entries=7), cache_identity="model-A"
+    )
+    assert first is not second
+    assert not first.active  # reconfigured -> old retired
+    assert second.active
+    assert second.stats()["max_entries"] == 7
+
+
+def test_reconfig_of_one_identity_leaves_other_untouched():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    # Reconfigure only A.
+    mgr_a2 = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache_max_entries=9), cache_identity="model-A"
+    )
+    assert mgr_a2 is not mgr_a
+    assert not mgr_a.active
+    assert mgr_a2.active
+    assert mgr_b.active  # B is unaffected
+
+
+def test_sync_resolves_per_identity():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-A") is mgr_a
+    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-B") is mgr_b
+
+
+def test_keyed_shutdown_only_retires_that_identity():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    cm.shutdown_runtime_cache_manager(ctx, cache_identity="model-A")
+    assert not mgr_a.active
+    assert mgr_b.active  # B survives A's unload
+    # A's slot is gone; B is still resolvable.
+    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-B") is mgr_b
+
+
+def test_shutdown_all_retires_everything():
+    ctx = _ctx()
+    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
+    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
+    cm.shutdown_runtime_cache_manager()  # no args == teardown all
+    assert not mgr_a.active
+    assert not mgr_b.active

--- a/tests/test_cache_manager_registry.py
+++ b/tests/test_cache_manager_registry.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import pytest
 
 import dflash_mlx.cache.manager as cm
+from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 from dflash_mlx.runtime.config import runtime_config_from_defaults
 from dflash_mlx.runtime.context import build_runtime_context
 
@@ -31,6 +32,18 @@ def _ctx(**overrides):
     )
     values.update(overrides)
     return build_runtime_context(runtime_config_from_defaults(**values))
+
+
+def _key(*, target: str = "target-A", window: int = 1024) -> DFlashPrefixKey:
+    return DFlashPrefixKey(
+        target_model_id=target,
+        draft_model_id="draft-A",
+        capture_layer_ids=(1, 2),
+        draft_sink_size=64,
+        draft_window_size=window,
+        template_hash="a" * 64,
+        prompt_policy_hash="b" * 64,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -71,6 +84,29 @@ def test_same_identity_reconfig_replaces_and_retires_old():
     assert not first.active  # reconfigured -> old retired
     assert second.active
     assert second.stats()["max_entries"] == 7
+
+
+def test_same_model_fingerprint_change_replaces_old_manager():
+    ctx = _ctx()
+    first = cm.get_runtime_cache_manager(ctx, cache_identity=_key(window=1024))
+    second = cm.get_runtime_cache_manager(ctx, cache_identity=_key(window=2048))
+
+    assert first is not None and second is not None
+    assert first is not second
+    assert not first.active
+    assert second.active
+
+
+def test_disabled_same_model_runtime_retires_existing_manager():
+    first = cm.get_runtime_cache_manager(_ctx(), cache_identity=_key())
+
+    disabled = cm.get_runtime_cache_manager(
+        _ctx(prefix_cache=False),
+        cache_identity=_key(),
+    )
+
+    assert disabled is None
+    assert first is not None and not first.active
 
 
 def test_reconfig_of_one_identity_leaves_other_untouched():

--- a/tests/test_dflash2_draft.py
+++ b/tests/test_dflash2_draft.py
@@ -1,0 +1,431 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+import mlx.core as mx
+import pytest
+
+from dflash_mlx.draft.checkpoint import get_draft_model_classes
+from dflash_mlx.draft.dflash2 import (
+    CandidateSelector,
+    DFlash2Attention,
+    DFlash2DraftModel,
+    DFlash2DraftModelArgs,
+    DraftProposal,
+    _grouped_dynamic_convolve,
+    normalize_dflash2_config,
+    remap_dflash2_codebook_weights,
+)
+from dflash_mlx.draft_backend import EagerDraftBackend
+from dflash_mlx.model import DFlashDraftModel, DFlashDraftModelArgs
+from dflash_mlx.runtime import loading as runtime_loading
+
+
+def _dflash2_config(**overrides):
+    config = {
+        "architectures": ["DFlash2DraftModel"],
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "is_causal": False,
+        "dflash_config": {
+            "block_size": 8,
+            "conv_group_size": 16,
+            "conv_kernel_size": 2,
+            "mask_token_id": 5,
+            "selector_rank": 256,
+            "selector_top_k": 16,
+            "target_layer_ids": [1],
+        },
+        "head_dim": 8,
+        "hidden_size": 32,
+        "intermediate_size": 64,
+        "layer_types": ["sliding_attention"],
+        "max_position_embeddings": 4096,
+        "model_type": "qwen3",
+        "num_attention_heads": 4,
+        "num_hidden_layers": 1,
+        "num_key_value_heads": 2,
+        "num_target_layers": 8,
+        "rms_norm_eps": 1e-6,
+        "rope_parameters": {"rope_theta": 1_000_000.0, "rope_type": "default"},
+        "sliding_window": 4,
+        "tie_word_embeddings": False,
+        "vocab_size": 32,
+    }
+    for key, value in overrides.items():
+        if key == "dflash_config":
+            nested = dict(config["dflash_config"])
+            nested.update(value)
+            config["dflash_config"] = nested
+        else:
+            config[key] = value
+    return config
+
+
+def test_dflash2_config_normalizes_nested_checkpoint_contract():
+    normalized = normalize_dflash2_config(_dflash2_config())
+
+    assert normalized["block_size"] == 8
+    assert normalized["conv_kernel_size"] == 2
+    assert normalized["conv_group_size"] == 16
+    assert normalized["selector_top_k"] == 16
+    assert normalized["selector_rank"] == 256
+    assert normalized["target_layer_ids"] == [1]
+    assert normalized["rope_theta"] == 1_000_000.0
+    assert normalized["rope_scaling"] is None
+
+
+def test_dflash2_config_preserves_non_default_rope_scaling():
+    normalized = normalize_dflash2_config(
+        _dflash2_config(
+            rope_parameters={
+                "factor": 4.0,
+                "rope_theta": 1_000_000.0,
+                "rope_type": "yarn",
+            }
+        )
+    )
+
+    assert normalized["rope_theta"] == 1_000_000.0
+    assert normalized["rope_scaling"] == {"factor": 4.0, "rope_type": "yarn"}
+
+
+def test_dflash2_config_fails_fast_on_malformed_schema():
+    with pytest.raises(ValueError, match="is_causal=false"):
+        DFlash2DraftModelArgs.from_dict(_dflash2_config(is_causal=True))
+
+    bad = _dflash2_config()
+    del bad["dflash_config"]["selector_top_k"]
+    with pytest.raises(ValueError, match="selector_top_k"):
+        DFlash2DraftModelArgs.from_dict(bad)
+
+    with pytest.raises(ValueError, match="two-tap dynamic conv"):
+        DFlash2DraftModelArgs.from_dict(
+            _dflash2_config(dflash_config={"conv_kernel_size": 3})
+        )
+
+
+def test_checkpoint_dispatch_selects_dflash2_without_affecting_prior_dflash():
+    assert get_draft_model_classes(_dflash2_config()) == (
+        DFlash2DraftModel,
+        DFlash2DraftModelArgs,
+    )
+    capabilities = DFlash2DraftModel(
+        DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    ).capabilities
+    assert capabilities.default_block_tokens == 5
+    assert capabilities.max_block_tokens == 5
+    assert not capabilities.supports_copyspec
+    assert not capabilities.supports_ddtree
+    assert capabilities.supports_early_rollback_launch
+
+    prior_config = {
+        "model_type": "qwen3",
+        "hidden_size": 32,
+        "num_hidden_layers": 1,
+        "intermediate_size": 64,
+        "num_attention_heads": 4,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 32,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 4096,
+        "rope_theta": 1_000_000.0,
+        "head_dim": 8,
+        "tie_word_embeddings": False,
+        "num_target_layers": 8,
+        "block_size": 16,
+    }
+
+    assert get_draft_model_classes(prior_config) == (
+        DFlashDraftModel,
+        DFlashDraftModelArgs,
+    )
+
+
+def test_dflash2_non_causal_block_attention_allows_future_block_tokens():
+    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    attn = DFlash2Attention(args, layer_idx=0)
+
+    mask = attn._attention_mask(
+        block_len=2,
+        query_offset=4,
+        key_len=6,
+        key_positions=mx.array([0, 1, 2, 3, 4, 5], dtype=mx.int32),
+    )
+    expected = mx.array(
+        [
+            [False, True, True, True, True, True],
+            [False, False, True, True, True, True],
+        ],
+        dtype=mx.bool_,
+    )
+    mx.eval(mask, expected)
+
+    assert bool(mx.all(mask == expected).item())
+
+
+def test_dflash2_grouped_dynamic_conv_matches_reference():
+    hidden = mx.arange(1 * 4 * 32, dtype=mx.float32).reshape(1, 4, 32) / 32.0
+    dynamic = mx.arange(1 * 4 * 2 * 2, dtype=mx.float32).reshape(1, 4, 2, 2) / 10.0
+    base = mx.arange(2 * 32, dtype=mx.float32).reshape(2, 32) / 100.0
+
+    out = _grouped_dynamic_convolve(hidden, dynamic, base, group_size=16)
+    mx.eval(out)
+
+    h = hidden.tolist()
+    d = dynamic.tolist()
+    b = base.tolist()
+    expected = []
+    for pos in range(4):
+        row = []
+        for channel in range(32):
+            group = channel // 16
+            value = 0.0
+            for offset in range(2):
+                src = pos - offset
+                if src < 0:
+                    continue
+                source = h[0][src][channel]
+                value += b[offset][channel] * source
+                value += d[0][pos][offset][group] * source
+            row.append(value)
+        expected.append(row)
+
+    assert out.shape == hidden.shape
+    assert mx.allclose(
+        out,
+        mx.array([expected], dtype=mx.float32),
+        rtol=1e-5,
+        atol=1e-5,
+    ).item()
+
+
+def test_dflash2_candidate_selector_uses_predecessor_path_edges():
+    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    selector = CandidateSelector(args)
+    selector.hidden_projection.weight = mx.zeros_like(selector.hidden_projection.weight)
+    selector.hidden_projection.weight[0, 0] = 1.0
+    selector.hidden_projection.weight[1, 1] = 1.0
+    selector.predecessor_codebook.weight = mx.zeros_like(
+        selector.predecessor_codebook.weight
+    )
+    selector.successor_codebook.weight = mx.zeros_like(selector.successor_codebook.weight)
+    selector.predecessor_codebook.weight[7, 0] = 1.0
+    selector.successor_codebook.weight[20, 0] = 10.0
+    selector.predecessor_codebook.weight[20, 1] = 1.0
+    selector.successor_codebook.weight[21, 1] = 10.0
+
+    hidden = mx.array([[[1.0, 0.0] + [0.0] * 30, [0.0, 1.0] + [0.0] * 30]])
+    logits = mx.broadcast_to(
+        mx.arange(32, dtype=mx.float32).reshape(1, 1, 32) / 100.0,
+        (1, 2, 32),
+    )
+
+    proposal = selector.select(
+        hidden,
+        logits,
+        mx.array([7], dtype=mx.uint32),
+        temperature=0.0,
+    )
+    mx.eval(proposal.token_ids, proposal.candidate_ids)
+
+    assert proposal.token_ids.tolist() == [[20, 21]]
+    assert proposal.candidate_ids.shape == (1, 2, 16)
+    assert proposal.probabilities is None
+
+
+def test_dflash2_candidate_selector_keeps_batch_edges_independent():
+    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    selector = CandidateSelector(args)
+    selector.hidden_projection.weight = mx.zeros_like(selector.hidden_projection.weight)
+    for dim in range(4):
+        selector.hidden_projection.weight[dim, dim] = 1.0
+    selector.predecessor_codebook.weight = mx.zeros_like(
+        selector.predecessor_codebook.weight
+    )
+    selector.successor_codebook.weight = mx.zeros_like(selector.successor_codebook.weight)
+    selector.predecessor_codebook.weight[7, 0] = 1.0
+    selector.successor_codebook.weight[20, 0] = 10.0
+    selector.predecessor_codebook.weight[20, 1] = 1.0
+    selector.successor_codebook.weight[21, 1] = 10.0
+    selector.predecessor_codebook.weight[8, 2] = 1.0
+    selector.successor_codebook.weight[22, 2] = 10.0
+    selector.predecessor_codebook.weight[22, 3] = 1.0
+    selector.successor_codebook.weight[23, 3] = 10.0
+
+    hidden = mx.array(
+        [
+            [[1.0, 0.0, 0.0, 0.0] + [0.0] * 28, [0.0, 1.0, 0.0, 0.0] + [0.0] * 28],
+            [[0.0, 0.0, 1.0, 0.0] + [0.0] * 28, [0.0, 0.0, 0.0, 1.0] + [0.0] * 28],
+        ],
+        dtype=mx.float32,
+    )
+    logits = mx.full((2, 2, 32), -100.0, dtype=mx.float32)
+    for token_id in range(16, 32):
+        logits[:, :, token_id] = -1.0
+
+    proposal = selector.select(
+        hidden,
+        logits,
+        mx.array([7, 8], dtype=mx.uint32),
+        temperature=0.0,
+    )
+    mx.eval(proposal.token_ids)
+
+    assert proposal.token_ids.tolist() == [[20, 21], [22, 23]]
+
+
+def test_dflash2_backend_proposal_uses_selector_contract():
+    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    draft_model = DFlash2DraftModel(args)
+    draft_model.forward_projected_context = lambda **_kwargs: mx.zeros(
+        (1, 8, 32), dtype=mx.float32
+    )
+
+    class _TargetOps:
+        def embed_tokens(self, _target_model):
+            return lambda token_ids: mx.zeros((*token_ids.shape, 32), dtype=mx.float32)
+
+        def logits_from_hidden(self, _target_model, hidden):
+            logits = mx.arange(32, dtype=mx.float32).reshape(1, 1, 32) / 100.0
+            return mx.broadcast_to(logits, (1, int(hidden.shape[1]), 32))
+
+    proposal = EagerDraftBackend().propose_block(
+        target_model=object(),
+        target_ops=_TargetOps(),
+        draft_model=draft_model,
+        draft_cache=[],
+        staged_first=mx.array([7], dtype=mx.uint32),
+        draft_context=mx.zeros((1, 2, 32), dtype=mx.float32),
+        block_len=8,
+        mask_token_tail=mx.full((7,), 5, dtype=mx.uint32),
+        suppress_token_mask=None,
+        capture_q=True,
+    )
+    mx.eval(proposal.token_ids, proposal.q_token_ids, proposal.q_probs)
+
+    assert proposal.token_ids.shape == (7,)
+    assert proposal.q_token_ids.shape == (7, 16)
+    assert proposal.q_probs.shape == (7, 16)
+    assert mx.allclose(mx.sum(proposal.q_probs, axis=-1), mx.ones((7,))).item()
+
+
+def test_dflash2_backend_capture_returns_selector_candidates():
+    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    draft_model = DFlash2DraftModel(args)
+    draft_model.forward_projected_context = lambda **_kwargs: mx.zeros(
+        (1, 8, 32), dtype=mx.float32
+    )
+
+    class _TargetOps:
+        def embed_tokens(self, _target_model):
+            return lambda token_ids: mx.zeros((*token_ids.shape, 32), dtype=mx.float32)
+
+        def logits_from_hidden(self, _target_model, hidden):
+            logits = mx.arange(32, dtype=mx.float32).reshape(1, 1, 32) / 100.0
+            return mx.broadcast_to(logits, (1, int(hidden.shape[1]), 32))
+
+    drafted, top_ids, top_logprobs = EagerDraftBackend().draft_greedy_capture(
+        target_model=object(),
+        target_ops=_TargetOps(),
+        draft_model=draft_model,
+        draft_cache=[],
+        staged_first=mx.array([7], dtype=mx.uint32),
+        draft_context=mx.zeros((1, 2, 32), dtype=mx.float32),
+        block_len=8,
+        mask_token_tail=mx.full((7,), 5, dtype=mx.uint32),
+        suppress_token_mask=None,
+        async_launch=False,
+        top_width=4,
+    )
+    mx.eval(drafted, top_ids, top_logprobs)
+
+    assert drafted.shape == (7,)
+    assert top_ids.shape == (7, 4)
+    assert top_logprobs.shape == (7, 4)
+    assert all(
+        row[idx] >= row[idx + 1]
+        for row in top_logprobs.tolist()
+        for idx in range(len(row) - 1)
+    )
+
+
+def test_dflash2_backend_rejects_underfilled_proposal():
+    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
+    draft_model = DFlash2DraftModel(args)
+    draft_model.forward_projected_context = lambda **_kwargs: mx.zeros(
+        (1, 5, 32), dtype=mx.float32
+    )
+    draft_model.select_proposal = lambda **_kwargs: DraftProposal(
+        token_ids=mx.zeros((3,), dtype=mx.uint32)
+    )
+
+    class _TargetOps:
+        def embed_tokens(self, _target_model):
+            return lambda token_ids: mx.zeros(
+                (*token_ids.shape, 32), dtype=mx.float32
+            )
+
+        def logits_from_hidden(self, _target_model, hidden):
+            return mx.zeros((1, int(hidden.shape[1]), 32), dtype=mx.float32)
+
+    with pytest.raises(ValueError, match="expected 4, got 3"):
+        EagerDraftBackend().propose_block(
+            target_model=object(),
+            target_ops=_TargetOps(),
+            draft_model=draft_model,
+            draft_cache=[],
+            staged_first=mx.array([7], dtype=mx.uint32),
+            draft_context=mx.zeros((1, 2, 32), dtype=mx.float32),
+            block_len=5,
+            mask_token_tail=mx.full((4,), 5, dtype=mx.uint32),
+            suppress_token_mask=None,
+        )
+
+
+def test_dflash2_safetensor_codebook_remap_is_exact():
+    pred = mx.zeros((4, 2))
+    succ = mx.ones((4, 2))
+
+    remapped = remap_dflash2_codebook_weights(
+        {
+            "candidate_selector.predecessor_codebook": pred,
+            "candidate_selector.successor_codebook": succ,
+        }
+    )
+
+    assert "candidate_selector.predecessor_codebook" not in remapped
+    assert "candidate_selector.successor_codebook" not in remapped
+    assert remapped["candidate_selector.predecessor_codebook.weight"] is pred
+    assert remapped["candidate_selector.successor_codebook.weight"] is succ
+
+    with pytest.raises(ValueError, match="both"):
+        remap_dflash2_codebook_weights(
+            {
+                "candidate_selector.predecessor_codebook": pred,
+                "candidate_selector.predecessor_codebook.weight": pred,
+            }
+        )
+
+
+def test_load_draft_bundle_dispatches_dflash2_model_classes(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_load_model(model_path, *, lazy, get_model_classes):
+        classes = get_model_classes(config=_dflash2_config())
+        calls.append((model_path, lazy, classes))
+        return object(), _dflash2_config()
+
+    monkeypatch.setattr(runtime_loading, "load_model", fake_load_model)
+
+    model, meta = runtime_loading.load_draft_bundle(tmp_path, lazy=False)
+
+    assert model is not None
+    assert meta["config"]["architectures"] == ["DFlash2DraftModel"]
+    assert calls == [
+        (
+            tmp_path,
+            False,
+            (DFlash2DraftModel, DFlash2DraftModelArgs),
+        )
+    ]

--- a/tests/test_draft_config_schema.py
+++ b/tests/test_draft_config_schema.py
@@ -1,0 +1,162 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Regression tests for DFlashDraftModelArgs.from_dict schema tolerance.
+
+z-lab iterated the DFlash draft config.json layout multiple times. This test
+pins from_dict behavior across every known schema variant so consumers do not
+silently break when HuggingFace publishes a new revision.
+
+Covered schemas:
+    * legacy (HF revisions through ~May 2026): block_size and rope_theta top-level.
+    * nested-dflash-config (z-lab HF revision c69b185, Jun 18 2026):
+      block_size moved into dflash_config; rope_theta into rope_parameters.
+    * rope-scaling-fallback: rope_theta nested inside rope_scaling (defensive).
+"""
+
+import pytest
+
+from dflash_mlx.model import DFlashDraftModelArgs
+
+
+def _base_legacy_schema() -> dict:
+    return {
+        "model_type": "dflash_qwen3",
+        "hidden_size": 2048,
+        "num_hidden_layers": 8,
+        "intermediate_size": 6144,
+        "num_attention_heads": 32,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 248320,
+        "num_key_value_heads": 4,
+        "max_position_embeddings": 4096,
+        "rope_theta": 10_000_000.0,
+        "head_dim": 128,
+        "tie_word_embeddings": False,
+        "num_target_layers": 41,
+        "block_size": 16,
+        "dflash_config": {
+            "mask_token_id": 248070,
+            "target_layer_ids": [1, 10, 19, 28, 37],
+        },
+        "layer_types": ("full_attention",) * 8,
+    }
+
+
+def _base_nested_schema() -> dict:
+    """z-lab HF revision c69b185 / f181eece (Jun 18-19 2026).
+
+    block_size moved into dflash_config; rope_theta into a new rope_parameters
+    dict; layer topology switched to mostly-sliding; layer count 8 -> 6;
+    num_key_value_heads 4 -> 8; target_layer_ids 5 -> 8 anchors.
+    """
+    return {
+        "model_type": "dflash_qwen3",
+        "hidden_size": 2048,
+        "num_hidden_layers": 6,
+        "intermediate_size": 6144,
+        "num_attention_heads": 32,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 248320,
+        "num_key_value_heads": 8,
+        "max_position_embeddings": 4096,
+        "head_dim": 128,
+        "tie_word_embeddings": False,
+        "num_target_layers": 41,
+        "sliding_window": 4096,
+        "dflash_config": {
+            "block_size": 16,
+            "mask_token_id": 248077,
+            "target_layer_ids": [1, 6, 11, 16, 22, 27, 32, 37],
+        },
+        "rope_parameters": {
+            "rope_theta": 10_000_000.0,
+            "rope_type": "default",
+        },
+        "layer_types": (
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "schema_factory,expected_layers,expected_kv_heads,expected_anchor_count",
+    [
+        ("legacy", 8, 4, 5),
+        ("nested", 6, 8, 8),
+    ],
+)
+def test_from_dict_resolves_block_size_and_rope_theta_across_schemas(
+    schema_factory: str,
+    expected_layers: int,
+    expected_kv_heads: int,
+    expected_anchor_count: int,
+):
+    factory = _base_legacy_schema if schema_factory == "legacy" else _base_nested_schema
+    data = factory()
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.block_size == 16, f"[{schema_factory}] block_size must resolve to 16"
+    assert args.rope_theta == 10_000_000.0, f"[{schema_factory}] rope_theta must resolve to 1e7"
+    assert args.num_hidden_layers == expected_layers
+    assert args.num_key_value_heads == expected_kv_heads
+    assert tuple(args.layer_types)[0:1] in (("full_attention",), ("sliding_attention",))
+
+
+def test_from_dict_unwraps_block_size_from_dflash_config_when_top_level_absent():
+    data = _base_nested_schema()
+    data.pop("block_size", None)
+    data.pop("rope_theta", None)
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.block_size == 16
+    assert args.rope_theta == 10_000_000.0
+
+
+def test_from_dict_unwraps_rope_theta_from_rope_scaling_as_fallback():
+    data = _base_legacy_schema()
+    data.pop("rope_theta", None)
+    data["rope_scaling"] = {"rope_theta": 10_000_000.0, "rope_type": "default"}
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.rope_theta == 10_000_000.0
+
+
+def test_from_dict_preserves_top_level_block_size_and_rope_theta_when_present():
+    data = _base_legacy_schema()
+    data["block_size"] = 16
+    data["rope_theta"] = 10_000_000.0
+    data["dflash_config"]["block_size"] = 99
+    data["rope_parameters"] = {"rope_theta": 1.0}
+
+    args = DFlashDraftModelArgs.from_dict(data)
+
+    assert args.block_size == 16
+    assert args.rope_theta == 10_000_000.0
+
+
+def test_nested_schema_constructs_into_a_model():
+    """The Jun 2026 nested schema must round-trip into a real DFlashDraftModel.
+
+    Guards against regressions in the model class (fc width, anchor count,
+    sliding-window setup) that could be introduced by future refactors.
+    """
+    from dflash_mlx.model import DFlashDraftModel
+
+    args = DFlashDraftModelArgs.from_dict(_base_nested_schema())
+    model = DFlashDraftModel(args)
+
+    assert len(model.layers) == 6
+    assert model.block_size == 16
+    assert model.mask_token_id == 248077
+    assert len(model.target_layer_ids) == 8
+    assert model.fc.weight.shape == (2048, 8 * 2048)

--- a/tests/test_draft_config_schema.py
+++ b/tests/test_draft_config_schema.py
@@ -22,7 +22,7 @@ from dflash_mlx.model import DFlashDraftModelArgs
 
 def _base_legacy_schema() -> dict:
     return {
-        "model_type": "dflash_qwen3",
+        "model_type": "qwen3",
         "hidden_size": 2048,
         "num_hidden_layers": 8,
         "intermediate_size": 6144,
@@ -52,7 +52,7 @@ def _base_nested_schema() -> dict:
     num_key_value_heads 4 -> 8; target_layer_ids 5 -> 8 anchors.
     """
     return {
-        "model_type": "dflash_qwen3",
+        "model_type": "qwen3",
         "hidden_size": 2048,
         "num_hidden_layers": 6,
         "intermediate_size": 6144,
@@ -119,6 +119,15 @@ def test_from_dict_unwraps_block_size_from_dflash_config_when_top_level_absent()
 
     assert args.block_size == 16
     assert args.rope_theta == 10_000_000.0
+
+
+def test_from_dict_does_not_invent_missing_block_size():
+    data = _base_nested_schema()
+    data.pop("block_size", None)
+    data["dflash_config"].pop("block_size", None)
+
+    with pytest.raises(TypeError, match="block_size"):
+        DFlashDraftModelArgs.from_dict(data)
 
 
 def test_from_dict_unwraps_rope_theta_from_rope_scaling_as_fallback():

--- a/tests/test_prefill_step_size_runtime.py
+++ b/tests/test_prefill_step_size_runtime.py
@@ -1658,6 +1658,34 @@ def test_copyspec_full_block_copy_skips_draft_backend():
     assert summary.copyspec_tokens == 3
 
 
+def test_draft_without_copyspec_capability_uses_dflash_draft():
+    target_ops = _FakeTargetOps()
+    draft_model = _draft_model()
+    draft_model.capabilities = SimpleNamespace(supports_copyspec=False)
+    draft_backend = _RecordingDraftBackend()
+
+    events = list(
+        spec_epoch.stream_dflash_generate_impl(
+            target_model=object(),
+            target_ops=target_ops,
+            tokenizer=object(),
+            draft_model=draft_model,
+            draft_backend=draft_backend,
+            prompt="unused",
+            max_new_tokens=4,
+            prompt_tokens_override=[1, 2, 3, 4, 5, 0, 0, 0, 0, 1, 2, 3, 4, 5],
+            runtime_context=_runtime_context(),
+        )
+    )
+
+    summary = next(event for event in events if isinstance(event, SummaryEvent))
+
+    assert draft_backend.calls == [(4, True)]
+    assert draft_backend.advance_context_lengths == []
+    assert summary.copyspec_hits == 0
+    assert summary.copyspec_tokens == 0
+
+
 def test_ddtree_copyspec_full_block_copy_skips_ddtree_draft_backend():
     target_ops = _FakeTargetOps()
     draft_model = _draft_model()
@@ -1688,6 +1716,27 @@ def test_ddtree_copyspec_full_block_copy_skips_ddtree_draft_backend():
     assert summary.acceptance_history == (3,)
     assert summary.copyspec_hits == 1
     assert summary.copyspec_tokens == 3
+
+
+def test_ddtree_verify_mode_fails_fast_for_unsupported_draft():
+    target_ops = _FakeTargetOps()
+    draft_model = _draft_model()
+    draft_model.capabilities = SimpleNamespace(supports_ddtree=False)
+
+    with pytest.raises(ValueError, match="does not support --verify-mode ddtree"):
+        list(
+            spec_epoch.stream_dflash_generate_impl(
+                target_model=object(),
+                target_ops=target_ops,
+                tokenizer=object(),
+                draft_model=draft_model,
+                draft_backend=_RecordingDraftBackend(),
+                prompt="unused",
+                max_new_tokens=4,
+                prompt_tokens_override=[1, 2],
+                runtime_context=_runtime_context(verify_mode="ddtree"),
+            )
+        )
 
 
 def test_ddtree_copyspec_partial_acceptance_preserves_rollback_snapshot():

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -1917,15 +1917,18 @@ class TestSidecar:
         assert hydrated[0].offset == 5
 
     def test_slice_rejects_uncovered_boundary(self):
-        key = _make_key()
+        key = _make_key(draft_sink_size=2, draft_window_size=2)
         snap = _make_sidecar_generation_snapshot(list(range(1, 9)), 5, key)
         snap.target_hidden_chunks = (
             mx.zeros((1, 2, 8), dtype=mx.float32),
-            mx.zeros((1, 2, 8), dtype=mx.float32),
+            mx.zeros((1, 5, 8), dtype=mx.float32),
         )
-        snap.target_hidden_chunk_spans = ((0, 2), (6, 8))
+        snap.target_hidden_chunk_spans = ((0, 2), (3, 8))
         with pytest.raises(ValueError, match="do not cover"):
-            slice_snapshot_at_sidecar_boundary(snap)
+            slice_snapshot_at_sidecar_boundary(snap, require_full_coverage=True)
+        sliced = slice_snapshot_at_sidecar_boundary(snap)
+        assert sliced.prefix_len == 5
+        assert sliced.target_hidden_chunk_spans == ((0, 2), (3, 5))
 
     def test_build_snapshot_sidecar_contract(self):
         key = _make_key()
@@ -2010,17 +2013,35 @@ class TestSidecar:
         assert hit is full
         assert cache.stats()["sidecar_hits"] == 0
 
-    def test_l1_lookup_sidecar_skips_uncovered_windowed_snapshot(self):
+    def test_l1_lookup_sidecar_serves_uncovered_windowed_snapshot(self):
         cache = DFlashPrefixCache(max_entries=8)
-        key = _make_key()
+        key = _make_key(draft_sink_size=2, draft_window_size=2)
         snap = _make_sidecar_generation_snapshot([1, 2, 3, 4, 5, 6, 7, 8], 5, key)
         snap.target_hidden_chunks = (
             mx.zeros((1, 2, 8), dtype=mx.float32),
-            mx.zeros((1, 2, 8), dtype=mx.float32),
+            mx.zeros((1, 5, 8), dtype=mx.float32),
         )
-        snap.target_hidden_chunk_spans = ((0, 2), (6, 8))
+        snap.target_hidden_chunk_spans = ((0, 2), (3, 8))
         cache.insert(snap)
         matched, hit = cache.lookup([1, 2, 3, 4, 5, 99], key)
+        assert matched == 5
+        assert hit is not None
+        assert hit.kind == "prefill"
+        assert cache.stats()["sidecar_hits"] == 1
+
+    def test_l1_lookup_sidecar_skips_uncovered_when_full_coverage_required(self):
+        cache = DFlashPrefixCache(max_entries=8)
+        key = _make_key(draft_sink_size=2, draft_window_size=2)
+        snap = _make_sidecar_generation_snapshot([1, 2, 3, 4, 5, 6, 7, 8], 5, key)
+        snap.target_hidden_chunks = (
+            mx.zeros((1, 2, 8), dtype=mx.float32),
+            mx.zeros((1, 5, 8), dtype=mx.float32),
+        )
+        snap.target_hidden_chunk_spans = ((0, 2), (3, 8))
+        cache.insert(snap)
+        matched, hit = cache.lookup(
+            [1, 2, 3, 4, 5, 99], key, require_full_coverage=True
+        )
         assert matched == 0
         assert hit is None
 
@@ -2108,3 +2129,61 @@ class TestCoverageFilterL1:
         stats = cache.stats()
         assert stats["sidecar_hits"] == 1
         assert stats["coverage_rejects"] == 0
+
+
+def _make_trimmed_sidecar_carrier(
+    tokens: list[int],
+    boundary: int,
+    key: DFlashPrefixKey,
+) -> DFlashPrefixSnapshot:
+    kv_cache = _make_kv_cache_populated(n_tokens=len(tokens))
+    gdn_cache = _make_gdn_cache_populated()
+    return build_snapshot(
+        token_ids=tokens,
+        target_cache=[kv_cache, gdn_cache],
+        target_hidden=mx.zeros((1, len(tokens), 8), dtype=mx.float32),
+        last_logits=mx.zeros((1, 32), dtype=mx.float32),
+        key=key,
+        kind="generation",
+        draft_sink_size=key.draft_sink_size,
+        draft_window_size=key.draft_window_size,
+        sidecar_boundary=boundary,
+        sidecar_gdn_states=capture_gdn_sidecar([kv_cache, gdn_cache]),
+        sidecar_last_logits=mx.full((1, 32), 7.0, dtype=mx.float32),
+    )
+
+
+class TestTrimmedSidecar:
+    def test_snapshot_keeps_and_slices_window_before_sidecar_boundary(self):
+        key = _make_key(draft_sink_size=4, draft_window_size=16)
+        tokens = list(range(1000, 1064))
+        carrier = _make_trimmed_sidecar_carrier(tokens, 48, key)
+
+        assert carrier.target_hidden_chunk_spans == ((0, 4), (32, 64))
+        sliced = slice_snapshot_at_sidecar_boundary(carrier)
+        assert sliced.target_hidden_chunk_spans == ((0, 4), (32, 48))
+
+    def test_l1_serves_trimmed_sidecar_for_windowed_draft(self):
+        cache = DFlashPrefixCache(max_entries=8)
+        key = _make_key(draft_sink_size=4, draft_window_size=16)
+        tokens = list(range(1000, 1064))
+        cache.insert(_make_trimmed_sidecar_carrier(tokens, 48, key))
+
+        matched, served = cache.lookup(tokens[:48], key)
+
+        assert matched == 48
+        assert served is not None and served.kind == "prefill"
+        assert cache.stats()["sidecar_hits"] == 1
+
+    def test_full_context_draft_rejects_trimmed_sidecar(self):
+        cache = DFlashPrefixCache(max_entries=8)
+        key = _make_key(draft_sink_size=4, draft_window_size=16)
+        tokens = list(range(1000, 1064))
+        cache.insert(_make_trimmed_sidecar_carrier(tokens, 48, key))
+
+        matched, served = cache.lookup(
+            tokens[:48], key, require_full_coverage=True
+        )
+
+        assert matched == 0
+        assert served is None

--- a/tests/test_prefix_cache_hit_kind.py
+++ b/tests/test_prefix_cache_hit_kind.py
@@ -2,11 +2,10 @@
 # Licensed under the Apache License, Version 2.0 - see LICENSE file
 """Tests for hit_kind classification in PrefixCacheLookupResult.
 
-Design: hit_kind is exposed only through the public RuntimeCacheManager.lookup()
-API (which returns PrefixCacheLookupResult).  Internal _l1.lookup() and
-_store.lookup() keep their existing 2-tuple signatures — they do not return
-hit_kind.  The classification is side-effected into _last_hit_kind state that
-the manager reads after the lookup under _state_lock.
+Design: hit_kind is exposed through RuntimeCacheManager.lookup(), which returns
+PrefixCacheLookupResult.  Internal _l1.lookup() and _store.lookup() keep their
+existing 2-tuple signatures; the manager reads the store's last_hit_kind
+property after each lookup under _state_lock.
 """
 
 from __future__ import annotations
@@ -128,7 +127,7 @@ class TestHitKindL1:
         assert mgr.lookup([1, 2, 3, 4, 5], key).hit_kind == "l1_prefix"
 
     def test_probe_does_not_overwrite_last_hit_kind(self):
-        """Internal record=False probes must not change _last_hit_kind."""
+        """Internal record=False probes must not change the recorded hit kind."""
         mgr = _make_manager()
         key = _make_key()
         snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
@@ -136,11 +135,11 @@ class TestHitKindL1:
 
         # Establish a recorded hit.
         mgr.lookup([1, 2, 3], key)
-        assert mgr._store._l1._last_hit_kind == "l1_exact"
+        assert mgr._store._l1.last_hit_kind == "l1_exact"
 
         # Probe (record=False) must not overwrite state.
         mgr._store._l1.lookup([1, 2, 3], key, record=False)
-        assert mgr._store._l1._last_hit_kind == "l1_exact"
+        assert mgr._store._l1.last_hit_kind == "l1_exact"
 
     def test_generation_snapshot_without_logits_reports_prefix_not_exact(self):
         """Generation snapshot without last_logits can only serve as a prefix hit."""

--- a/tests/test_prefix_cache_integration.py
+++ b/tests/test_prefix_cache_integration.py
@@ -189,7 +189,7 @@ class TestServeHelperShapes:
     def test_get_cache_disabled(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
         assert cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(prefix_cache=False)
         ) is None
@@ -197,8 +197,8 @@ class TestServeHelperShapes:
     def test_get_cache_enabled_returns_singleton(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(prefix_cache=True)
         first = cache_manager_mod.get_runtime_cache_manager(context)
         second = cache_manager_mod.get_runtime_cache_manager(context)
@@ -328,7 +328,7 @@ class TestContextConfigExposedCorrectly:
     def test_prefix_cache_config_affects_singleton(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
         assert cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(prefix_cache=False)
         ) is None
@@ -340,8 +340,8 @@ class TestContextConfigExposedCorrectly:
     def test_singleton_rebuilds_when_config_changes(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         first = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(prefix_cache=True, prefix_cache_max_entries=2)
         )
@@ -364,8 +364,8 @@ class TestContextConfigExposedCorrectly:
             shutdown_calls.append(self)
             return original_shutdown(self)
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
 
         first = cache_manager_mod.get_runtime_cache_manager(
@@ -394,29 +394,29 @@ class TestContextConfigExposedCorrectly:
             return _store(max_entries=2)
 
         old_manager = RuntimeCacheManager(_store(BrokenShutdownCache(max_entries=2)))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
 
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=True))
 
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         with pytest.raises(RuntimeError, match="shut down"):
             old_manager.stats()
         assert make_calls == []
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=True))
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         assert make_calls == []
 
     def test_retired_manager_handle_fails_after_clear(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(prefix_cache=True)
         manager = cache_manager_mod.get_runtime_cache_manager(context)
         assert manager is not None
@@ -438,7 +438,7 @@ class TestContextConfigExposedCorrectly:
         thread = threading.Thread(target=worker)
         thread.start()
         assert ready.wait(timeout=2.0)
-        cache_manager_mod._clear_runtime_cache_manager()
+        cache_manager_mod._clear_all_runtime_cache_managers()
         proceed.set()
         thread.join(timeout=2.0)
 
@@ -467,14 +467,14 @@ class TestContextConfigExposedCorrectly:
             return _store(max_entries=2)
 
         old_manager = RuntimeCacheManager(_store(BlockingShutdownCache(max_entries=2)))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
         context = _runtime_context(prefix_cache=True)
 
         def clear_worker() -> None:
             try:
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -522,12 +522,12 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingTraceCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def get_worker() -> None:
             try:
@@ -538,7 +538,7 @@ class TestContextConfigExposedCorrectly:
         def clear_worker() -> None:
             try:
                 clear_started.set()
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -579,12 +579,12 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingTraceCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def sync_worker() -> None:
             try:
@@ -595,7 +595,7 @@ class TestContextConfigExposedCorrectly:
         def clear_worker() -> None:
             try:
                 clear_started.set()
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -637,12 +637,12 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingLookupCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def lookup_worker() -> None:
             try:
@@ -653,7 +653,7 @@ class TestContextConfigExposedCorrectly:
         def clear_worker() -> None:
             try:
                 clear_started.set()
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -714,8 +714,8 @@ class TestContextConfigExposedCorrectly:
 
         context = _runtime_context(prefix_cache=True)
         old_manager = _manager(BlockingInsertCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
 
         def insert_worker() -> None:
@@ -733,7 +733,7 @@ class TestContextConfigExposedCorrectly:
 
         def clear_worker() -> None:
             try:
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -785,12 +785,12 @@ class TestContextConfigExposedCorrectly:
                 return super().shutdown()
 
         old_manager = _manager(BlockingShutdownCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         def clear_worker() -> None:
             try:
-                cache_manager_mod._clear_runtime_cache_manager()
+                cache_manager_mod._clear_all_runtime_cache_managers()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -832,8 +832,8 @@ class TestContextConfigExposedCorrectly:
 
         old_cache = TrackedShutdownCache(max_entries=2)
         old_manager = _manager(old_cache)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(
             cache_manager_mod,
             "_make_prefix_store",
@@ -846,11 +846,46 @@ class TestContextConfigExposedCorrectly:
         assert cache_manager_mod.current_runtime_cache_manager() is None
         assert shutdown_calls == [old_cache]
 
-    def test_l2_rebuild_releases_old_lock_before_new_manager(self, monkeypatch, tmp_path):
+    def test_l2_same_identity_rebuild_releases_old_lock(self, monkeypatch, tmp_path):
+        # A same-identity reconfiguration rebuilds the manager: the old one is
+        # retired and releases its L2 disk lock before the new one opens, so the
+        # replacement reclaims a writable L2 on the same directory.
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
+        l2_dir = str(tmp_path / "l2")
+
+        def _ctx(max_entries):
+            return _runtime_context(
+                prefix_cache=True,
+                prefix_cache_l2=True,
+                prefix_cache_l2_dir=l2_dir,
+                prefix_cache_max_entries=max_entries,
+            )
+
+        try:
+            first = cache_manager_mod.get_runtime_cache_manager(_ctx(2), cache_identity="model-a")
+            assert first is not None
+            assert first.stats()["l2"]["writable"] is True
+
+            second = cache_manager_mod.get_runtime_cache_manager(_ctx(7), cache_identity="model-a")
+            assert second is not None
+            assert second is not first
+            assert not first.active  # rebuild retired the old manager...
+            assert second.stats()["l2"]["writable"] is True  # ...and freed the L2 lock
+        finally:
+            cache_manager_mod.shutdown_runtime_cache_manager()
+
+    def test_l2_concurrent_models_sharing_dir_make_second_read_only(self, monkeypatch, tmp_path):
+        # Two distinct models coexist in the registry. If they happen to share an
+        # L2 directory, only the first holds the writable lock; the second serves
+        # read-only L2 (graceful L1-only degradation, never corruption). Hosts
+        # that want writable L2 per model should give each a distinct L2 dir.
+        import dflash_mlx.cache.manager as cache_manager_mod
+
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(
             prefix_cache=True,
             prefix_cache_l2=True,
@@ -859,13 +894,11 @@ class TestContextConfigExposedCorrectly:
 
         try:
             first = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-a")
-            assert first is not None
-            assert first.stats()["l2"]["writable"] is True
-
             second = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-b")
-            assert second is not None
             assert second is not first
-            assert second.stats()["l2"]["writable"] is True
+            assert first.active and second.active  # both stay loaded
+            assert first.stats()["l2"]["writable"] is True
+            assert second.stats()["l2"]["writable"] is False
         finally:
             cache_manager_mod.shutdown_runtime_cache_manager()
 
@@ -879,8 +912,8 @@ class TestContextConfigExposedCorrectly:
             shutdown_calls.append(self)
             return original_shutdown(self)
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
 
         manager = cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=True))
@@ -901,20 +934,16 @@ class TestContextConfigExposedCorrectly:
         manager = _manager(BrokenShutdownCache(max_entries=2))
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_MANAGER",
-            manager,
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (("old",), manager)},
         )
-        monkeypatch.setattr(
-            cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            ("old",),
-        )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         cache_manager_mod.shutdown_runtime_cache_manager()
 
         assert "runtime cache manager shutdown failed: broken close" in capsys.readouterr().err
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is manager
         with pytest.raises(RuntimeError, match="shut down"):
             manager.stats()
 
@@ -926,14 +955,14 @@ class TestContextConfigExposedCorrectly:
                 raise RuntimeError("cannot close")
 
         old_manager = _manager(BrokenShutdownCache(max_entries=2))
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {None: (("old",), old_manager)})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.get_runtime_cache_manager(_runtime_context(prefix_cache=False))
 
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         with pytest.raises(RuntimeError, match="shut down"):
             old_manager.stats()
 
@@ -954,19 +983,19 @@ class TestContextConfigExposedCorrectly:
         old_manager = _manager(BrokenShutdownCache(max_entries=2))
         with pytest.raises(RuntimeError, match="cannot close"):
             old_manager.shutdown()
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "_make_prefix_store", make_cache)
 
         with pytest.raises(RuntimeError, match="cannot close"):
             cache_manager_mod.sync_runtime_cache_manager(context)
 
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is old_manager
+        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY[None][1] is old_manager
         assert make_calls == []
 
     def test_sync_clears_poisoned_manager_after_successful_retry(self, monkeypatch):
@@ -985,18 +1014,18 @@ class TestContextConfigExposedCorrectly:
         old_manager = _manager(FlakyShutdownCache(max_entries=2))
         with pytest.raises(RuntimeError, match="first close failed"):
             old_manager.shutdown()
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", old_manager)
         monkeypatch.setattr(
             cache_manager_mod,
-            "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-            cache_manager_mod._prefix_cache_config_key(context),
+            "_DFLASH_RUNTIME_CACHE_REGISTRY",
+            {None: (cache_manager_mod._prefix_cache_config_key(context), old_manager)},
         )
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
 
         assert cache_manager_mod.sync_runtime_cache_manager(context) is None
 
         assert len(shutdown_calls) == 2
         assert cache_manager_mod.current_runtime_cache_manager() is None
-        assert cache_manager_mod._DFLASH_RUNTIME_CACHE_MANAGER is None
+        assert None not in cache_manager_mod._DFLASH_RUNTIME_CACHE_REGISTRY
 
     def test_chat_template_stable_marker_returns_none_without_converter(self):
         from dflash_mlx.server.prefix_cache_manager import chat_template_stable_marker
@@ -1051,8 +1080,8 @@ class TestContextConfigExposedCorrectly:
     def test_budgets_propagate_to_cache(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1068,8 +1097,8 @@ class TestContextConfigExposedCorrectly:
     def test_l2_frontier_stride_has_disk_pressure_floor(self, monkeypatch, tmp_path):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1085,8 +1114,8 @@ class TestContextConfigExposedCorrectly:
     def test_l2_frontier_stride_never_splits_prefill_chunks(self, monkeypatch, tmp_path):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1102,8 +1131,8 @@ class TestContextConfigExposedCorrectly:
     def test_l2_frontier_stride_rounds_floor_to_chunk_multiple(self, monkeypatch, tmp_path):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1121,8 +1150,8 @@ class TestContextConfigExposedCorrectly:
     ):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(
             prefix_cache=True,
             prefix_cache_l2=True,
@@ -1141,8 +1170,8 @@ class TestContextConfigExposedCorrectly:
     def test_frontier_stride_disabled_without_l2(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         manager = cache_manager_mod.get_runtime_cache_manager(
             _runtime_context(
                 prefix_cache=True,
@@ -1160,8 +1189,8 @@ class TestContextConfigExposedCorrectly:
         def raise_os_error(**_kwargs):
             raise OSError("l2 unavailable")
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "DFlashPrefixL2Cache", raise_os_error)
 
         manager = cache_manager_mod.get_runtime_cache_manager(
@@ -1178,8 +1207,8 @@ class TestContextConfigExposedCorrectly:
         def raise_type_error(**_kwargs):
             raise TypeError("bad l2 constructor")
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         monkeypatch.setattr(cache_manager_mod, "DFlashPrefixL2Cache", raise_type_error)
 
         with pytest.raises(TypeError, match="bad l2 constructor"):
@@ -1239,8 +1268,8 @@ class TestContextConfigExposedCorrectly:
     def test_singleton_rebuilds_when_identity_changes(self, monkeypatch):
         import dflash_mlx.cache.manager as cache_manager_mod
 
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
         context = _runtime_context(prefix_cache=True)
 
         first = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-a")

--- a/tests/test_prefix_l2.py
+++ b/tests/test_prefix_l2.py
@@ -35,7 +35,9 @@ from dflash_mlx.diagnostics import TraceConfig
 from dflash_mlx.engine.prefill import snapshot_covers_prefix
 from tests.test_prefix_cache import (
     _make_full_hidden_snapshot,
+    _make_gdn_cache_populated,
     _make_key,
+    _make_kv_cache_populated,
     _make_rotating_cache_populated,
     _make_synthetic_snapshot,
     _make_trimmed_snapshot,
@@ -1564,3 +1566,44 @@ class TestEvictionLruOnHit:
             assert path.stat().st_mtime_ns == 10**9
         finally:
             l2.shutdown()
+
+
+def test_serialize_skips_empty_target_hidden_chunk_when_sink_is_zero():
+    """Regression: draft_sink_size=0 produces an empty sink chunk that
+    mx.save_safetensors refuses to serialize, crashing the L2 writer thread
+    and preventing any snapshot from persisting (issue #54)."""
+    from dflash_mlx.cache.codecs import build_snapshot
+
+    key = _make_key()
+    n = 128  # > sink(0) + window, forcing the sink/tail split
+    snap = build_snapshot(
+        token_ids=list(range(n)),
+        target_cache=[
+            _make_kv_cache_populated(n_tokens=n),
+            _make_gdn_cache_populated(),
+        ],
+        target_hidden=mx.zeros((1, n, 8), dtype=mx.float32),
+        last_logits=mx.zeros((1, 32), dtype=mx.float32),
+        key=key,
+        kind="prefill",
+        draft_sink_size=0,   # reproduces the empty-sink crash
+        draft_window_size=16,
+    )
+
+    arrays, meta_dict = _serialize(snap)
+    meta = json.loads(meta_dict["dflash_meta"])
+    spans = meta["target_hidden_chunk_spans"]
+
+    # No empty arrays in the serialized payload; spans stay in lockstep.
+    assert spans, "expected at least one chunk span"
+    for c in range(len(spans)):
+        arr = arrays[f"target_hidden_{c}"]
+        assert 0 not in arr.shape, f"empty chunk serialized: target_hidden_{c}"
+
+    # Round-trip: deserialize must reconstruct the same (non-empty) chunks.
+    restored = _deserialize(arrays, meta)
+    assert len(restored.target_hidden_chunks) == len(spans)
+    for chunk, span in zip(restored.target_hidden_chunks, spans):
+        assert 0 not in chunk.shape
+        assert span[1] > span[0]
+

--- a/tests/test_prefix_l2.py
+++ b/tests/test_prefix_l2.py
@@ -1568,10 +1568,7 @@ class TestEvictionLruOnHit:
             l2.shutdown()
 
 
-def test_serialize_skips_empty_target_hidden_chunk_when_sink_is_zero():
-    """Regression: draft_sink_size=0 produces an empty sink chunk that
-    mx.save_safetensors refuses to serialize, crashing the L2 writer thread
-    and preventing any snapshot from persisting (issue #54)."""
+def test_sink_zero_snapshot_has_only_nonempty_target_hidden_chunks():
     from dflash_mlx.cache.codecs import build_snapshot
 
     key = _make_key()
@@ -1590,20 +1587,20 @@ def test_serialize_skips_empty_target_hidden_chunk_when_sink_is_zero():
         draft_window_size=16,
     )
 
+    assert snap.target_hidden_chunk_spans == ((n - 16, n),)
+    assert len(snap.target_hidden_chunks) == 1
+
     arrays, meta_dict = _serialize(snap)
     meta = json.loads(meta_dict["dflash_meta"])
     spans = meta["target_hidden_chunk_spans"]
 
-    # No empty arrays in the serialized payload; spans stay in lockstep.
-    assert spans, "expected at least one chunk span"
+    assert spans
     for c in range(len(spans)):
         arr = arrays[f"target_hidden_{c}"]
         assert 0 not in arr.shape, f"empty chunk serialized: target_hidden_{c}"
 
-    # Round-trip: deserialize must reconstruct the same (non-empty) chunks.
     restored = _deserialize(arrays, meta)
     assert len(restored.target_hidden_chunks) == len(spans)
     for chunk, span in zip(restored.target_hidden_chunks, spans):
         assert 0 not in chunk.shape
         assert span[1] > span[0]
-

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -8,6 +8,8 @@ import importlib
 import tomllib
 from pathlib import Path
 
+from setuptools import find_packages
+
 from dflash_mlx import cli
 
 def test_root_help_contains_product_commands(capsys):
@@ -70,3 +72,17 @@ def test_pyproject_scripts_import():
         module_name, func_name = target.split(":", 1)
         module = importlib.import_module(module_name)
         assert callable(getattr(module, func_name))
+
+
+def test_pyproject_mlx_dependency_floors_match_supported_runtime():
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    dependencies = set(data["project"]["dependencies"])
+
+    assert "mlx>=0.32.1" in dependencies
+    assert "mlx-lm>=0.31.3" in dependencies
+
+
+def test_setuptools_package_discovery_includes_draft_package():
+    packages = set(find_packages(include=["dflash_mlx*"]))
+
+    assert "dflash_mlx.draft" in packages

--- a/tests/test_runtime_bundle.py
+++ b/tests/test_runtime_bundle.py
@@ -23,6 +23,7 @@ EXPECTED_DRAFT_REGISTRY = {
     "Qwen3.5-35B-A3B": "z-lab/Qwen3.5-35B-A3B-DFlash",
     "Qwen3.6-27B": "z-lab/Qwen3.6-27B-DFlash",
     "Qwen3.6-35B-A3B": "z-lab/Qwen3.6-35B-A3B-DFlash",
+    "Qwen3.8-27B": "z-lab/Qwen3.8-27B-DFlash2",
     "Qwen3-4B": "z-lab/Qwen3-4B-DFlash-b16",
     "Qwen3-8B": "z-lab/Qwen3-8B-DFlash-b16",
     "gemma-4-31b-it": "z-lab/gemma-4-31B-it-DFlash",
@@ -58,6 +59,10 @@ def test_runtime_registry_preserves_draft_resolution():
         == "z-lab/Qwen3.6-27B-DFlash"
     )
     assert (
+        resolve_optional_draft_ref("mlx-community/Qwen3.8-27B-4bit", None)
+        == "z-lab/Qwen3.8-27B-DFlash2"
+    )
+    assert (
         resolve_optional_draft_ref("mlx-community/gemma-4-26b-a4b-it-4bit", None)
         == "z-lab/gemma-4-26B-A4B-it-DFlash"
     )
@@ -67,6 +72,7 @@ def test_runtime_registry_preserves_draft_resolution():
         == "gemma4_swa"
     )
     assert resolve_model_support_spec("Qwen/Qwen3.5-9B").defaults.draft_quant == "w4"
+    assert resolve_model_support_spec("Qwen/Qwen3.8-27B").defaults.draft_quant == "w4"
     assert (
         resolve_model_support_spec("mlx-community/gemma-4-31b-it-4bit").defaults.draft_quant
         == "w4"

--- a/tests/test_runtime_verify_config.py
+++ b/tests/test_runtime_verify_config.py
@@ -391,6 +391,29 @@ def test_speculative_cycle_config_defaults_to_draft_block_size():
     assert cycle.verify_len_cap == 16
 
 
+def test_speculative_cycle_config_honors_draft_default_block_capability():
+    cfg = runtime_config_from_defaults(verify_len_cap=0)
+    draft = SimpleNamespace(
+        block_size=8,
+        capabilities=SimpleNamespace(default_block_tokens=5, max_block_tokens=5),
+    )
+
+    default_cycle = resolve_speculative_cycle_config(cfg, draft, block_tokens=None)
+    low_cycle = resolve_speculative_cycle_config(cfg, draft, block_tokens=4)
+    explicit_cycle = resolve_speculative_cycle_config(cfg, draft, block_tokens=8)
+    high_cycle = resolve_speculative_cycle_config(cfg, draft, block_tokens=16)
+
+    assert default_cycle.requested_block_tokens == 5
+    assert default_cycle.effective_block_tokens == 5
+    assert default_cycle.verify_len_cap == 5
+    assert low_cycle.requested_block_tokens == 4
+    assert low_cycle.effective_block_tokens == 4
+    assert explicit_cycle.requested_block_tokens == 8
+    assert explicit_cycle.effective_block_tokens == 5
+    assert high_cycle.requested_block_tokens == 16
+    assert high_cycle.effective_block_tokens == 5
+
+
 def test_speculative_cycle_config_clamps_requested_block_size():
     cfg = runtime_config_from_defaults(verify_len_cap=0)
     draft = SimpleNamespace(block_size=16)

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -567,12 +567,15 @@ def test_metrics_startup_clears_stale_cache_when_runtime_disables_prefix_cache(m
         return original_shutdown(self)
 
     stale_cache = DFlashPrefixCache()
+    stale_identity = ("target-model", None, "draft-model")
     monkeypatch.setattr(
         cache_manager_mod,
-        "_DFLASH_RUNTIME_CACHE_MANAGER",
-        RuntimeCacheManager(PrefixSnapshotStore(l1=stale_cache)),
+        "_DFLASH_RUNTIME_CACHE_REGISTRY",
+        {stale_identity: (("old",), RuntimeCacheManager(PrefixSnapshotStore(l1=stale_cache)))},
     )
-    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", ("old",))
+    monkeypatch.setattr(
+        cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", stale_identity
+    )
     monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
     monkeypatch.setattr(
         metrics_mod,
@@ -617,8 +620,8 @@ def test_metrics_startup_preserves_request_cache_identity(monkeypatch):
         ),
     )
     cache_identity = build_prefix_key(model_provider, draft_model, runtime_context)
-    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_MANAGER", None)
-    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CONFIG_KEY", None)
+    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
+    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
     existing = cache_manager_mod.get_runtime_cache_manager(
         runtime_context,
         cache_identity=cache_identity,

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -567,7 +567,7 @@ def test_metrics_startup_clears_stale_cache_when_runtime_disables_prefix_cache(m
         return original_shutdown(self)
 
     stale_cache = DFlashPrefixCache()
-    stale_identity = ("target-model", None, "draft-model")
+    stale_identity = ("target-model", "draft-model")
     monkeypatch.setattr(
         cache_manager_mod,
         "_DFLASH_RUNTIME_CACHE_REGISTRY",

--- a/tests/test_server_request_loop.py
+++ b/tests/test_server_request_loop.py
@@ -284,7 +284,9 @@ def test_consume_dflash_events_updates_live_cycle_metrics_before_summary(monkeyp
 
 
 def test_consume_dflash_events_ignores_snapshot_publication_metadata():
-    prefix_flow = SimpleNamespace(lookup_ms=0.1, hit_tokens=2, insert_ms=0.5)
+    prefix_flow = SimpleNamespace(
+        lookup_ms=0.1, hit_tokens=2, insert_ms=0.5, cache_manager=None
+    )
     rqueue = SimpleQueue()
     events = ClosableEvents(
         [
@@ -383,6 +385,7 @@ def test_server_runtime_routes_tool_chat_generation_snapshot_policy(monkeypatch)
         snapshot_service=object(),
         stable_prefix_len=3,
         cache_active=True,
+        cache_manager=None,
         publish_generation_snapshot=True,
         insert_ms=0.0,
         prefix_cache_memory_bytes=lambda: None,
@@ -487,6 +490,7 @@ def test_memory_waterfall_events_are_enriched_with_prefix_cache_memory():
         lookup_ms = 0.0
         hit_tokens = 0
         insert_ms = 0.0
+        cache_manager = None
 
         def prefix_cache_memory_bytes(self):
             return {

--- a/tests/test_target_fa_window.py
+++ b/tests/test_target_fa_window.py
@@ -193,7 +193,7 @@ def test_prefix_cache_flow_disabled_for_windowed_target(monkeypatch):
         return original_shutdown(self)
 
     class FakeProvider:
-        pass
+        model_key = ("target", None, "draft")
 
     class FakeDraft:
         pass
@@ -208,7 +208,12 @@ def test_prefix_cache_flow_disabled_for_windowed_target(monkeypatch):
     monkeypatch.setattr(
         cache_manager_mod,
         "_DFLASH_RUNTIME_CACHE_REGISTRY",
-        {None: (("old",), RuntimeCacheManager(PrefixSnapshotStore(l1=preexisting_cache)))},
+        {
+            ("target", "draft"): (
+                ("old",),
+                RuntimeCacheManager(PrefixSnapshotStore(l1=preexisting_cache)),
+            )
+        },
     )
     monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
     monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)

--- a/tests/test_target_fa_window.py
+++ b/tests/test_target_fa_window.py
@@ -207,14 +207,10 @@ def test_prefix_cache_flow_disabled_for_windowed_target(monkeypatch):
     preexisting_cache = DFlashPrefixCache()
     monkeypatch.setattr(
         cache_manager_mod,
-        "_DFLASH_RUNTIME_CACHE_MANAGER",
-        RuntimeCacheManager(PrefixSnapshotStore(l1=preexisting_cache)),
+        "_DFLASH_RUNTIME_CACHE_REGISTRY",
+        {None: (("old",), RuntimeCacheManager(PrefixSnapshotStore(l1=preexisting_cache)))},
     )
-    monkeypatch.setattr(
-        cache_manager_mod,
-        "_DFLASH_RUNTIME_CACHE_CONFIG_KEY",
-        ("old",),
-    )
+    monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
     monkeypatch.setattr(DFlashPrefixCache, "shutdown", tracked_shutdown)
 
     flow = flow_mod.PrefixCacheFlow.for_request(

--- a/tests/test_target_hook_guard.py
+++ b/tests/test_target_hook_guard.py
@@ -1,0 +1,92 @@
+# Copyright 2026 bstnxbt
+# Licensed under the Apache License, Version 2.0 - see LICENSE file
+# Based on DFlash (arXiv:2602.06036)
+
+"""Cross-backend safety for class-level target hooks.
+
+Target backends patch the attention class (``cls.__call__``) and tag it with a
+per-class marker so a second install is a no-op. The marker is keyed by class
+*object*, which is safe only while each attention class maps to exactly one
+target backend. If a future model routed to a different backend shared an
+attention class with an existing one, a bare boolean marker would let the
+first-installed backend's attention silently run for the second model. These
+tests pin the fail-loud contract: a different backend claiming an already
+patched class raises instead of silently skipping.
+"""
+from __future__ import annotations
+
+import mlx.nn as nn
+import pytest
+
+from dflash_mlx.engine._hook_guard import DFlashHookConflict, claim_class_hook
+
+
+def test_free_slot_is_claimable():
+    class A(nn.Module):
+        pass
+
+    assert claim_class_hook(A, "_marker", "gemma4") is True
+
+
+def test_same_owner_reclaim_is_noop():
+    class A(nn.Module):
+        pass
+
+    assert claim_class_hook(A, "_marker", "gemma4") is True
+    A._marker = "gemma4"  # installer sets the marker after patching
+    assert claim_class_hook(A, "_marker", "gemma4") is False
+
+
+def test_different_owner_raises():
+    class A(nn.Module):
+        pass
+
+    A._marker = "gemma4"
+    with pytest.raises(DFlashHookConflict, match="already patched"):
+        claim_class_hook(A, "_marker", "qwen_gdn")
+
+
+def test_installers_fail_loud_on_shared_attention_class():
+    # Real installers must wire the guard: a gemma4-claimed class cannot then be
+    # claimed by the qwen backend. (The claim runs before any attention math, so
+    # this needs no real weights.)
+    from dflash_mlx.engine.target_gemma4 import (
+        _install_full_attention_gqa_hook as gemma_install,
+    )
+    from dflash_mlx.engine.target_qwen_gdn import (
+        _install_full_attention_gqa_hook as qwen_install,
+    )
+
+    class SharedAttn(nn.Module):
+        def __call__(self, *args, **kwargs):  # patched by the installer
+            return None
+
+    inst = SharedAttn()
+    gemma_install(inst)  # claims the class for gemma4
+    # A second gemma install on the same class is a no-op.
+    gemma_install(inst)
+    with pytest.raises(DFlashHookConflict):
+        qwen_install(inst)  # different backend, same class -> loud failure
+
+
+def test_same_backend_two_models_sharing_attention_class_is_safe():
+    # Two different model architectures that resolve to the SAME backend may
+    # share an attention class (e.g. plain qwen3 and qwen3-next both use
+    # qwen3_next.Qwen3NextAttention). Installing the backend's hook for the
+    # second model on the already-patched class must be a silent no-op, not a
+    # conflict — the shared call is stateless and reads per-instance weights.
+    from dflash_mlx.engine.target_qwen_gdn import (
+        _install_full_attention_gqa_hook as qwen_install,
+    )
+
+    class SharedQwenAttn(nn.Module):
+        def __call__(self, *args, **kwargs):
+            return None
+
+    model_a_attn = SharedQwenAttn()
+    model_b_attn = SharedQwenAttn()  # distinct instance, same class
+    qwen_install(model_a_attn)  # model A claims qwen_gdn
+    qwen_install(model_b_attn)  # model B: same class + backend -> no-op, no raise
+    assert (
+        getattr(SharedQwenAttn, "_dflash_full_attention_gqa_installed") == "qwen_gdn"
+    )

--- a/tests/test_target_ops.py
+++ b/tests/test_target_ops.py
@@ -333,6 +333,45 @@ def test_qwen_verify_gqa_route_is_internal_default(monkeypatch):
     assert calls == [(4, 4, 256)]
     assert attn.original_calls == 0
 
+
+def test_qwen_dflash2_block5_uses_native_gqa_at_long_kv(monkeypatch):
+    routes: list[str] = []
+
+    def _native(queries, keys, values, *, cache, scale, mask):
+        del keys, values, cache, scale, mask
+        routes.append("native")
+        return mx.zeros_like(queries)
+
+    def _grouped(queries, keys, values, *, cache, scale, mask):
+        del keys, values, cache, scale, mask
+        routes.append("grouped")
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen_gdn, "scaled_dot_product_attention", _native)
+    monkeypatch.setattr(qwen_gdn, "grouped_gqa_sdpa", _grouped)
+
+    queries = mx.zeros((1, 4, 5, 256), dtype=mx.bfloat16)
+    short_kv = mx.zeros((1, 1, 8191, 256), dtype=mx.bfloat16)
+    long_kv = mx.zeros((1, 1, 8192, 256), dtype=mx.bfloat16)
+
+    qwen_gdn._gqa_reshape_sdpa(
+        queries,
+        short_kv,
+        short_kv,
+        scale=1.0,
+        mask=None,
+    )
+    qwen_gdn._gqa_reshape_sdpa(
+        queries,
+        long_kv,
+        long_kv,
+        scale=1.0,
+        mask=None,
+    )
+
+    assert routes == ["grouped", "native"]
+
+
 def test_qwen_prefill_uses_original_attention(monkeypatch):
     attn, cache = _fake_qwen_full_attention()
     qwen_gdn._install_full_attention_gqa_hook(attn)

--- a/tests/test_target_ops.py
+++ b/tests/test_target_ops.py
@@ -547,7 +547,7 @@ def test_gemma4_full_attention_gqa_hook_is_internal():
     full_attn = model.model.layers[1].self_attn
     assert not hasattr(sliding_attn, "_dflash_split_sdpa_enabled")
     assert not hasattr(full_attn, "_dflash_split_sdpa_enabled")
-    assert getattr(type(full_attn), "_dflash_full_attention_gqa_installed") is True
+    assert getattr(type(full_attn), "_dflash_full_attention_gqa_installed") == "gemma4"
 
 def test_gemma4_logits_use_tied_embedding_head():
     target = _FakeGemmaLogitTarget(tied=True)


### PR DESCRIPTION
Fixes #44
Fixes #50
Fixes #51
Fixes #52
Fixes #53
Fixes #54

Integrates open PRs #45, #46, and #55 with additional ownership and regression hardening.

Key commits:
- 5c9fd37, 23356b9, 68f8fca, 6a5c881: multi-model cache isolation, fail-loud target hooks, stable model identity, windowed sidecar restore, and public cache-store hit-kind contract.
- 2982d52: nested dflash_config.block_size and rope_parameters.rope_theta support for #50/#51.
- 0c89a12 and 68f8fca: empty target-hidden chunk/L2 fix for #54/#55.
- 9df491a, 40ec23d, d46cbcf: Qwen3.8 DFlash2 checkpoint dispatch, dynamic-conv/selector draft path, capability gates, rope normalization, and W4 verification cap at 5.

Validation on final head 6a5c881:
- Issue-focused suites: 7 config, 46 multi-model/hook/server, 236 prefix-cache/L2, 141 DFlash2/runtime/Qwen, and 99 cache-manager tests passed.
- Full suite: 1310 passed, 11 skipped.
- Real model smoke: mlx-community/Qwen3.8-27B-4bit + z-lab/Qwen3.8-27B-DFlash2, W4 gs64, 8 tokens at 69.3 tok/s with 75.0% acceptance; process exited cleanly.
- Runtime versions: mlx 0.32.1 and mlx-lm 0.31.3.