### PR TITLE
test: remove brittle and duplicate coverage

### DIFF
--- a/dflash_mlx/engine/ddtree.py
+++ b/dflash_mlx/engine/ddtree.py
@@ -256,27 +256,6 @@ def flat_tree_path_token_ids(
     return paths
 
 
-def pad_flat_tree_paths(
-    paths: list[list[int]],
-    *,
-    pad_token_id: int,
-    max_len: int | None = None,
-) -> tuple[list[list[int]], list[int]]:
-    if not paths:
-        raise ValueError("paths must not be empty")
-    lengths = [len(path) for path in paths]
-    resolved_len = max(lengths) if max_len is None else int(max_len)
-    if resolved_len <= 0:
-        raise ValueError("max_len must be positive")
-    if max(lengths) > resolved_len:
-        raise ValueError("max_len cannot truncate flat tree paths")
-    padded = [
-        list(path) + [int(pad_token_id)] * (resolved_len - len(path))
-        for path in paths
-    ]
-    return padded, lengths
-
-
 def follow_verified_tree(
     tree: FlatDDTree,
     posterior_token_ids: list[int],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,9 +42,9 @@ for small `max_tokens` requests, controlled by `--fastpath-max-tokens` (default
 `0`, disabled), but that is a serving policy after a valid runtime has already
 loaded.
 
-The current DFlash draft class is `DFlashDraftModel`. Target-family behavior is
-owned by `engine.target_ops`; the registered concrete implementations are
-`engine.target_qwen_gdn` and `engine.target_gemma4`.
+Draft checkpoint dispatch selects `DFlashDraftModel` or `DFlash2DraftModel`.
+Target-family behavior is owned by `engine.target_ops`; the registered concrete
+implementations are `engine.target_qwen_gdn` and `engine.target_gemma4`.
 
 Adding another architecture is a real adapter project, not just a new registry
 row. The required seam for more architectures is:
@@ -108,8 +108,9 @@ The server wraps `mlx_lm.server` rather than replacing it.
 9. `cache.snapshot_service.SnapshotService` builds and admits snapshots through
    the runtime cache manager.
 
-The prefix cache is process-local. The runtime cache manager owns the singleton
-lifecycle keyed by relevant runtime config so repeated requests can share state.
+The prefix cache is process-local. Runtime cache managers are registered by
+target/draft model identity; each manager owns the config-keyed lifecycle shared
+by repeated requests for that model pair.
 
 ## Offline Generate Flow
 

--- a/tests/test_cache_manager_registry.py
+++ b/tests/test_cache_manager_registry.py
@@ -2,34 +2,20 @@
 # Licensed under the Apache License, Version 2.0 - see LICENSE file
 # Based on DFlash (arXiv:2602.06036)
 
-"""Registry semantics for the runtime cache manager.
-
-Two DFlash models loaded in one process (e.g. an embedding host's engine
-pool) must each keep their own prefix-cache manager alive concurrently.
-Previously a single process-global slot meant loading the second model
-retired the first's cache. These tests pin the registry contract:
-
-  * distinct cache identities coexist (neither retired),
-  * the same identity + same config returns the same manager,
-  * the same identity reconfigured replaces (and retires) the old one,
-  * shutdown can target one identity or clear all.
-"""
-from __future__ import annotations
-
 import pytest
 
-import dflash_mlx.cache.manager as cm
+import dflash_mlx.cache.manager as cache_managers
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
 from dflash_mlx.runtime.config import runtime_config_from_defaults
 from dflash_mlx.runtime.context import build_runtime_context
 
 
-def _ctx(**overrides):
-    values = dict(
-        prefix_cache=True,
-        prefix_cache_l2=False,
-        prefix_cache_l2_dir="/tmp/dflash-prefix-l2-registry-test",
-    )
+def _context(**overrides):
+    values = {
+        "prefix_cache": True,
+        "prefix_cache_l2": False,
+        "prefix_cache_l2_dir": "/tmp/dflash-prefix-l2-registry-test",
+    }
     values.update(overrides)
     return build_runtime_context(runtime_config_from_defaults(**values))
 
@@ -48,104 +34,92 @@ def _key(*, target: str = "target-A", window: int = 1024) -> DFlashPrefixKey:
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    # Start and end each test with an empty registry so order can't leak state.
-    cm.shutdown_runtime_cache_manager()
+    cache_managers.shutdown_runtime_cache_manager()
     yield
-    cm.shutdown_runtime_cache_manager()
+    cache_managers.shutdown_runtime_cache_manager()
 
 
-def test_distinct_identities_coexist():
-    ctx = _ctx()
-    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
-
-    assert mgr_a is not None and mgr_b is not None
-    assert mgr_a is not mgr_b
-    # The crux of #1892: loading B must NOT retire A.
-    assert mgr_a.active
-    assert mgr_b.active
-
-
-def test_same_identity_same_config_returns_same_manager():
-    ctx = _ctx()
-    first = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    second = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    assert first is second
-
-
-def test_same_identity_reconfig_replaces_and_retires_old():
-    first = cm.get_runtime_cache_manager(
-        _ctx(prefix_cache_max_entries=2), cache_identity="model-A"
+def test_distinct_model_managers_coexist_and_resolve_independently():
+    context = _context()
+    first = cache_managers.get_runtime_cache_manager(
+        context, cache_identity="model-A"
     )
-    second = cm.get_runtime_cache_manager(
-        _ctx(prefix_cache_max_entries=7), cache_identity="model-A"
+    second = cache_managers.get_runtime_cache_manager(
+        context, cache_identity="model-B"
     )
-    assert first is not second
-    assert not first.active  # reconfigured -> old retired
-    assert second.active
-    assert second.stats()["max_entries"] == 7
+
+    assert first is not None and second is not None and first is not second
+    assert first.active and second.active
+    assert (
+        cache_managers.sync_runtime_cache_manager(
+            context, cache_identity="model-A"
+        )
+        is first
+    )
+    assert (
+        cache_managers.sync_runtime_cache_manager(
+            context, cache_identity="model-B"
+        )
+        is second
+    )
 
 
-def test_same_model_fingerprint_change_replaces_old_manager():
-    ctx = _ctx()
-    first = cm.get_runtime_cache_manager(ctx, cache_identity=_key(window=1024))
-    second = cm.get_runtime_cache_manager(ctx, cache_identity=_key(window=2048))
+def test_same_model_reuses_or_replaces_its_manager_when_config_changes():
+    context = _context(prefix_cache_max_entries=2)
+    first = cache_managers.get_runtime_cache_manager(
+        context, cache_identity=_key(window=1024)
+    )
+    assert (
+        cache_managers.get_runtime_cache_manager(
+            context, cache_identity=_key(window=1024)
+        )
+        is first
+    )
 
-    assert first is not None and second is not None
-    assert first is not second
-    assert not first.active
-    assert second.active
+    replacement = cache_managers.get_runtime_cache_manager(
+        _context(prefix_cache_max_entries=7),
+        cache_identity=_key(window=2048),
+    )
+
+    assert first is not None and replacement is not None
+    assert replacement is not first
+    assert not first.active and replacement.active
+    assert replacement.stats()["max_entries"] == 7
 
 
-def test_disabled_same_model_runtime_retires_existing_manager():
-    first = cm.get_runtime_cache_manager(_ctx(), cache_identity=_key())
+def test_disabling_one_model_retires_only_its_manager():
+    context = _context()
+    first = cache_managers.get_runtime_cache_manager(
+        context, cache_identity=_key(target="target-A")
+    )
+    second = cache_managers.get_runtime_cache_manager(
+        context, cache_identity=_key(target="target-B")
+    )
 
-    disabled = cm.get_runtime_cache_manager(
-        _ctx(prefix_cache=False),
-        cache_identity=_key(),
+    disabled = cache_managers.get_runtime_cache_manager(
+        _context(prefix_cache=False),
+        cache_identity=_key(target="target-A"),
     )
 
     assert disabled is None
     assert first is not None and not first.active
+    assert second is not None and second.active
 
 
-def test_reconfig_of_one_identity_leaves_other_untouched():
-    ctx = _ctx()
-    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
-    # Reconfigure only A.
-    mgr_a2 = cm.get_runtime_cache_manager(
-        _ctx(prefix_cache_max_entries=9), cache_identity="model-A"
+def test_scoped_and_global_shutdown_retire_the_expected_managers():
+    context = _context()
+    first = cache_managers.get_runtime_cache_manager(
+        context, cache_identity="model-A"
     )
-    assert mgr_a2 is not mgr_a
-    assert not mgr_a.active
-    assert mgr_a2.active
-    assert mgr_b.active  # B is unaffected
+    second = cache_managers.get_runtime_cache_manager(
+        context, cache_identity="model-B"
+    )
 
+    cache_managers.shutdown_runtime_cache_manager(
+        context, cache_identity="model-A"
+    )
+    assert first is not None and not first.active
+    assert second is not None and second.active
 
-def test_sync_resolves_per_identity():
-    ctx = _ctx()
-    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
-    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-A") is mgr_a
-    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-B") is mgr_b
-
-
-def test_keyed_shutdown_only_retires_that_identity():
-    ctx = _ctx()
-    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
-    cm.shutdown_runtime_cache_manager(ctx, cache_identity="model-A")
-    assert not mgr_a.active
-    assert mgr_b.active  # B survives A's unload
-    # A's slot is gone; B is still resolvable.
-    assert cm.sync_runtime_cache_manager(ctx, cache_identity="model-B") is mgr_b
-
-
-def test_shutdown_all_retires_everything():
-    ctx = _ctx()
-    mgr_a = cm.get_runtime_cache_manager(ctx, cache_identity="model-A")
-    mgr_b = cm.get_runtime_cache_manager(ctx, cache_identity="model-B")
-    cm.shutdown_runtime_cache_manager()  # no args == teardown all
-    assert not mgr_a.active
-    assert not mgr_b.active
+    cache_managers.shutdown_runtime_cache_manager()
+    assert not second.active

--- a/tests/test_copyspec.py
+++ b/tests/test_copyspec.py
@@ -2,33 +2,34 @@ from __future__ import annotations
 
 import pytest
 
-from dflash_mlx.engine.copyspec import CopySpecIndex, CopySpecAutoGate
+from dflash_mlx.engine.copyspec import CopySpecAutoGate, CopySpecIndex
 
 
-def test_copyspec_draft_after_returns_full_prompt_copy() -> None:
+def test_copyspec_returns_a_full_prompt_copy() -> None:
     index = CopySpecIndex(
         [1, 2, 3, 4, 5, 0, 7, 8, 1, 2, 3, 4, 5],
         window_size=6,
     )
 
-    draft = index.draft_after(0, max_tokens=2)
-
-    assert draft == (7, 8)
+    assert index.draft_after(0, max_tokens=2) == (7, 8)
 
 
-def test_copyspec_rejects_partial_copy() -> None:
-    index = CopySpecIndex([1, 2, 3, 4, 1, 2], window_size=3)
+def test_copyspec_rejects_partial_or_forbidden_copies() -> None:
+    partial = CopySpecIndex([1, 2, 3, 4, 1, 2], window_size=3)
+    forbidden = CopySpecIndex(
+        [1, 2, 3, 4, 5, 0, 7, 1, 2, 3, 4, 5],
+        window_size=6,
+    )
 
-    assert index.draft_after(3, max_tokens=4) is None
+    assert partial.draft_after(3, max_tokens=4) is None
+    assert forbidden.draft_after(0, max_tokens=1, forbidden_tokens={7}) is None
 
 
-def test_copyspec_append_committed_indexes_generated_history() -> None:
+def test_copyspec_indexes_committed_history() -> None:
     index = CopySpecIndex([9, 9, 9, 1, 2], window_size=3)
     index.append_committed([3, 4, 1, 2])
 
-    draft = index.draft_after(3, max_tokens=1)
-
-    assert draft == (4,)
+    assert index.draft_after(3, max_tokens=1) == (4,)
 
 
 def test_copyspec_short_initial_prompt_stays_disabled() -> None:
@@ -38,339 +39,92 @@ def test_copyspec_short_initial_prompt_stays_disabled() -> None:
     assert index.draft_after(3, max_tokens=1) is None
 
 
-def test_copyspec_skips_forbidden_tokens() -> None:
-    index = CopySpecIndex([1, 2, 3, 4, 5, 0, 7, 1, 2, 3, 4, 5], window_size=6)
-
-    assert index.draft_after(0, max_tokens=1, forbidden_tokens={7}) is None
-
-
-def test_copyspec_rejects_invalid_window_size() -> None:
-    with pytest.raises(ValueError, match="window_size"):
-        CopySpecIndex([1, 2, 3], window_size=0)
-
-
-# ────────────────────────────────────────────────────────────────
-# CopySpecAutoGate tests
-# ────────────────────────────────────────────────────────────────
-
-def _make_gate(**kwargs) -> CopySpecAutoGate:
-    """Tiny helper: gate with small windows so tests run in <10 cycles."""
-    defaults = dict(
-        probe_off_cycles=4,
-        probe_on_min_copy=2,
-        probe_on_max_cycles=8,
-        latch_cycles=6,
-        margin=1.0,
-    )
-    defaults.update(kwargs)
-    return CopySpecAutoGate(**defaults)
-
-
-def _dflash(gate: CopySpecAutoGate, *, commits: int = 4, cost_ns: int | None = 500_000) -> None:
-    """Feed one dflash cycle into the gate."""
-    gate.record_cycle(source="dflash", commit_count=commits, cycle_cost_ns=cost_ns)
-
-
-def _copy(gate: CopySpecAutoGate, *, commits: int = 4, cost_ns: int | None = 500_000) -> None:
-    """Feed one copy cycle into the gate."""
-    gate.record_cycle(source="copy", commit_count=commits, cycle_cost_ns=cost_ns)
-
-
-# 1. Initial state ────────────────────────────────────────────────
-
-def test_starts_in_measure_off() -> None:
-    gate = _make_gate()
-    assert gate.phase == "measure_off"
-
-
-def test_engage_copy_false_in_measure_off() -> None:
-    gate = _make_gate()
-    assert gate.engage_copy() is False
-
-
-# 2. measure_off → measure_on transition ──────────────────────────
-
-def test_after_probe_off_cycles_transitions_to_measure_on() -> None:
-    gate = _make_gate(probe_off_cycles=4)
-    for _ in range(4):
-        _dflash(gate)
-    assert gate.phase == "measure_on"
-    assert gate.engage_copy() is True
-
-
-def test_off_rate_captured_after_measure_off() -> None:
-    gate = _make_gate(probe_off_cycles=4)
-    # 4 cycles × 8 commits each, cost 500_000 ns each → rate = 32 / (4×500_000/1e9)
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=8, cycle_cost_ns=500_000)
-    expected = 32 / (4 * 500_000 / 1e9)  # 16_000_000.0
-    assert gate._off_rate == pytest.approx(expected)
-
-
-def test_off_rate_not_set_before_measure_off_ends() -> None:
-    gate = _make_gate(probe_off_cycles=4)
-    _dflash(gate)
-    assert gate._off_rate is None
-
-
-# 3. measure_on → engaged (copy wins) ────────────────────────────
-
-def test_copy_wins_transitions_to_engaged() -> None:
-    """Copy cycles with tiny cost (high tps) beat the dflash off-rate."""
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
-    # Off phase: 4 cycles, 4 commits, 1_000_000 ns each → off_rate = 16/(4e-3) = 4_000.0 tps
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
-    assert gate.phase == "measure_on"
-    # On phase: 2 copy cycles, 4 commits, 50_000 ns each → on_rate = 8/(100_000/1e9) = 80_000 tps
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.phase == "engaged"
-    assert gate.engage_copy() is True
-
-
-def test_copy_wins_no_reset_pending() -> None:
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    assert gate._pending_reset is False
-    assert gate.take_reset() is False
-
-
-def test_copy_wins_engages_counter() -> None:
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.metrics()["engages"] == 1
-
-
-# 4. measure_on → dormant (copy loses) ───────────────────────────
-
-def test_copy_loses_transitions_to_dormant() -> None:
-    """Copy cycles with huge cost (low tps) lose to the dflash off-rate."""
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
-    # Off: 4 commits × 50_000 ns → off_rate = 16/(4×50_000/1e9) = 80_000 tps (fast baseline)
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.phase == "measure_on"
-    # On: 2 copy cycles × 4 commits × 1_000_000 ns → on_rate = 8/(2e-3) = 4_000 tps (slow)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
-    assert gate.phase == "dormant"
-    assert gate.engage_copy() is False
-
-
-def test_copy_loses_take_reset_true_once() -> None:
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
-    assert gate.take_reset() is True
-    assert gate.take_reset() is False  # consumed
-
-
-def test_copy_loses_disengages_counter() -> None:
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, margin=1.0)
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
-    assert gate.metrics()["disengages"] == 1
-
-
-# 5. measure_on max_cycles with zero copy blocks → dormant + reset ─
-
-def test_measure_on_max_cycles_no_copy_goes_dormant() -> None:
-    gate = _make_gate(probe_off_cycles=4, probe_on_min_copy=2, probe_on_max_cycles=5)
-    for _ in range(4):
-        _dflash(gate)
-    assert gate.phase == "measure_on"
-    # 5 dflash cycles (no copy) to hit max_cycles
-    for _ in range(5):
-        _dflash(gate)
-    assert gate.phase == "dormant"
-    assert gate.take_reset() is True
-
-
-# 6. Engaged latch expiry → measure_off + reset ───────────────────
-
-def test_engaged_latch_expiry_returns_to_measure_off_with_reset() -> None:
-    gate = _make_gate(
-        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=3, margin=1.0
-    )
-    # Drive to engaged
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.phase == "engaged"
-    # Expire latch (3 cycles)
-    for _ in range(3):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.phase == "measure_off"
-    assert gate.take_reset() is True
-
-
-def test_engaged_cycles_counter_increments() -> None:
-    gate = _make_gate(
-        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=3, margin=1.0
-    )
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=1_000_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    # 2 more engaged cycles (latch=3, not yet expired)
-    gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.metrics()["engaged_cycles"] == 2
-
-
-# 7. Dormant latch expiry → measure_off, NO reset ─────────────────
-
-def test_dormant_latch_expiry_returns_to_measure_off_no_reset() -> None:
-    gate = _make_gate(
-        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=3, margin=1.0
-    )
-    # Drive to dormant
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
-    assert gate.phase == "dormant"
-    # Consume the reset from entering dormant
-    gate.take_reset()
-    # Expire latch
-    for _ in range(3):
-        _dflash(gate)
-    assert gate.phase == "measure_off"
-    assert gate.take_reset() is False
-
-
-def test_dormant_cycles_counter_increments() -> None:
-    gate = _make_gate(
-        probe_off_cycles=4, probe_on_min_copy=2, latch_cycles=5, margin=1.0
-    )
-    for _ in range(4):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=1_000_000)
-    assert gate.phase == "dormant"
-    for _ in range(2):
-        _dflash(gate)
-    assert gate.metrics()["dormant_cycles"] == 2
-
-
-# 8. _win_rate: tps vs tpc fallback ──────────────────────────────
-
-def test_win_rate_uses_tps_when_cost_present() -> None:
-    gate = _make_gate(probe_off_cycles=100)  # won't transition during test
-    gate.record_cycle(source="dflash", commit_count=16, cycle_cost_ns=1_000_000)
-    # 16 commits / (1_000_000 / 1e9 seconds) = 16_000.0 tps
-    assert gate._win_rate() == pytest.approx(16_000.0)
-
-
-def test_win_rate_falls_back_to_tpc_when_no_cost() -> None:
-    gate = _make_gate(probe_off_cycles=100)
-    gate.record_cycle(source="dflash", commit_count=8, cycle_cost_ns=None)
-    gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=None)
-    # 12 commits / 2 cycles = 6.0 tpc
-    assert gate._win_rate() == pytest.approx(6.0)
-
-
-def test_win_rate_returns_zero_when_empty() -> None:
-    gate = _make_gate()
-    assert gate._win_rate() == 0.0
-
-
-# 9. Full lifecycle: measure_off → measure_on(win) → engaged → (latch) → measure_off
-
-def test_full_lifecycle_phase_sequence_and_reset_signals() -> None:
-    gate = _make_gate(
-        probe_off_cycles=3,
-        probe_on_min_copy=2,
-        probe_on_max_cycles=8,
-        latch_cycles=4,
-        margin=1.0,
-    )
-    phases = [gate.phase]
-
-    # measure_off: 3 dflash cycles
-    for _ in range(3):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=2_000_000)
-    phases.append(gate.phase)  # should be measure_on
-    assert gate.take_reset() is False  # no reset on transition to measure_on
-
-    # measure_on: 2 copy cycles (fast → win)
-    for _ in range(2):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    phases.append(gate.phase)  # should be engaged
-    assert gate.take_reset() is False  # no reset on engage
-
-    # engaged: run latch_cycles to expire
-    for _ in range(4):
-        gate.record_cycle(source="copy", commit_count=4, cycle_cost_ns=50_000)
-    phases.append(gate.phase)  # should be measure_off
-    assert gate.take_reset() is True  # reset when re-baselining
-
-    assert phases == ["measure_off", "measure_on", "engaged", "measure_off"]
-
-
-# 10. __init__ validation ──────────────────────────────────────────
-
-@pytest.mark.parametrize("bad_kwargs,match", [
-    ({"probe_off_cycles": 0}, "probe_off_cycles"),
-    ({"probe_on_min_copy": 0}, "probe_on_min_copy"),
-    ({"probe_on_max_cycles": 0}, "probe_on_max_cycles"),
-    ({"latch_cycles": 0}, "latch_cycles"),
-    ({"margin": 0.0}, "margin"),
-    ({"margin": -1.0}, "margin"),
-])
-def test_init_validation(bad_kwargs: dict, match: str) -> None:
-    valid = dict(
-        probe_off_cycles=4,
-        probe_on_min_copy=2,
-        probe_on_max_cycles=8,
-        latch_cycles=6,
-        margin=1.0,
-    )
-    valid.update(bad_kwargs)
-    with pytest.raises(ValueError, match=match):
-        CopySpecAutoGate(**valid)
-
-
-# 11. metrics() shape ─────────────────────────────────────────────
-
-def test_metrics_returns_expected_keys() -> None:
-    gate = _make_gate()
-    m = gate.metrics()
-    assert set(m.keys()) == {
-        "state", "off_rate", "engaged_cycles",
-        "dormant_cycles", "probes", "engages", "disengages",
+def _gate(**overrides) -> CopySpecAutoGate:
+    config = {
+        "probe_off_cycles": 4,
+        "probe_on_min_copy": 2,
+        "probe_on_max_cycles": 8,
+        "latch_cycles": 3,
+        "margin": 1.0,
     }
-    assert m["state"] == "measure_off"
-    assert m["off_rate"] is None
-    assert m["engaged_cycles"] == 0
+    config.update(overrides)
+    return CopySpecAutoGate(**config)
 
 
-# 12. probes counter ──────────────────────────────────────────────
+def _record(
+    gate: CopySpecAutoGate,
+    *,
+    source: str,
+    cycles: int,
+    cost_ns: int,
+) -> None:
+    for _ in range(cycles):
+        gate.record_cycle(
+            source=source,
+            commit_count=4,
+            cycle_cost_ns=cost_ns,
+        )
 
-def test_probes_counter_increments_each_measure_on_entry() -> None:
-    gate = _make_gate(probe_off_cycles=2, probe_on_min_copy=1, latch_cycles=2, margin=1.0)
-    # First probe cycle: off → on → dormant → off
-    for _ in range(2):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.metrics()["probes"] == 1
-    # Drain measure_on with 1 copy that loses (high cost)
-    gate.record_cycle(source="copy", commit_count=1, cycle_cost_ns=5_000_000)
-    # wait latch to expire
-    for _ in range(2):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    # Re-baseline complete → second probe
-    for _ in range(2):
-        gate.record_cycle(source="dflash", commit_count=4, cycle_cost_ns=50_000)
-    assert gate.metrics()["probes"] == 2
+
+@pytest.mark.parametrize(
+    "baseline_ns,copy_ns,expected_phase,expected_engaged,expected_reset",
+    [
+        (1_000_000, 50_000, "engaged", True, False),
+        (50_000, 1_000_000, "dormant", False, True),
+    ],
+)
+def test_auto_gate_selects_the_faster_path(
+    baseline_ns: int,
+    copy_ns: int,
+    expected_phase: str,
+    expected_engaged: bool,
+    expected_reset: bool,
+) -> None:
+    gate = _gate()
+    assert not gate.engage_copy()
+
+    _record(gate, source="dflash", cycles=4, cost_ns=baseline_ns)
+    assert gate.phase == "measure_on"
+    assert gate.engage_copy()
+
+    _record(gate, source="copy", cycles=2, cost_ns=copy_ns)
+    assert gate.phase == expected_phase
+    assert gate.engage_copy() is expected_engaged
+    assert gate.take_reset() is expected_reset
+    assert gate.metrics()["engages" if expected_engaged else "disengages"] == 1
+
+
+def test_auto_gate_rebaselines_after_engaged_latch() -> None:
+    gate = _gate(latch_cycles=3)
+    _record(gate, source="dflash", cycles=4, cost_ns=1_000_000)
+    _record(gate, source="copy", cycles=2, cost_ns=50_000)
+    assert gate.phase == "engaged"
+
+    _record(gate, source="copy", cycles=3, cost_ns=50_000)
+
+    assert gate.phase == "measure_off"
+    assert gate.take_reset()
+
+
+def test_auto_gate_abandons_probe_without_copy_blocks() -> None:
+    gate = _gate(probe_on_max_cycles=3)
+    _record(gate, source="dflash", cycles=4, cost_ns=500_000)
+    _record(gate, source="dflash", cycles=3, cost_ns=500_000)
+
+    assert gate.phase == "dormant"
+    assert gate.take_reset()
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        {"probe_off_cycles": 0},
+        {"probe_on_min_copy": 0},
+        {"probe_on_max_cycles": 0},
+        {"latch_cycles": 0},
+        {"margin": 0.0},
+    ],
+)
+def test_auto_gate_rejects_invalid_configuration(invalid: dict) -> None:
+    with pytest.raises(ValueError):
+        _gate(**invalid)

--- a/tests/test_ddtree.py
+++ b/tests/test_ddtree.py
@@ -23,7 +23,6 @@ from dflash_mlx.engine.ddtree import (
     flat_tree_path_token_ids,
     flat_tree_positions,
     flat_tree_token_ids,
-    pad_flat_tree_paths,
     restore_cache,
     select_captured,
     select_tree_slots,
@@ -339,26 +338,6 @@ def test_flat_tree_inputs_match_lucebox_tree_contract():
         tree,
         prefix_len=100,
     ).tolist()
-
-
-def test_pad_flat_tree_paths_preserves_lengths():
-    padded, lengths = pad_flat_tree_paths(
-        [[7], [7, 10], [7, 10, 20]],
-        pad_token_id=0,
-        max_len=4,
-    )
-
-    assert padded == [
-        [7, 0, 0, 0],
-        [7, 10, 0, 0],
-        [7, 10, 20, 0],
-    ]
-    assert lengths == [1, 2, 3]
-
-
-def test_pad_flat_tree_paths_rejects_truncation():
-    with pytest.raises(ValueError, match="truncate"):
-        pad_flat_tree_paths([[7, 10]], pad_token_id=0, max_len=1)
 
 
 def test_build_flat_ddtree_handles_empty_budget():

--- a/tests/test_dflash2_draft.py
+++ b/tests/test_dflash2_draft.py
@@ -2,8 +2,11 @@
 # Licensed under the Apache License, Version 2.0 - see LICENSE file
 # Based on DFlash (arXiv:2602.06036)
 
+import json
+
 import mlx.core as mx
 import pytest
+from mlx.utils import tree_flatten
 
 from dflash_mlx.draft.checkpoint import get_draft_model_classes
 from dflash_mlx.draft.dflash2 import (
@@ -74,9 +77,7 @@ def test_dflash2_config_normalizes_nested_checkpoint_contract():
     assert normalized["rope_theta"] == 1_000_000.0
     assert normalized["rope_scaling"] is None
 
-
-def test_dflash2_config_preserves_non_default_rope_scaling():
-    normalized = normalize_dflash2_config(
+    scaled = normalize_dflash2_config(
         _dflash2_config(
             rope_parameters={
                 "factor": 4.0,
@@ -86,23 +87,22 @@ def test_dflash2_config_preserves_non_default_rope_scaling():
         )
     )
 
-    assert normalized["rope_theta"] == 1_000_000.0
-    assert normalized["rope_scaling"] == {"factor": 4.0, "rope_type": "yarn"}
+    assert scaled["rope_theta"] == 1_000_000.0
+    assert scaled["rope_scaling"] == {"factor": 4.0, "rope_type": "yarn"}
 
 
 def test_dflash2_config_fails_fast_on_malformed_schema():
-    with pytest.raises(ValueError, match="is_causal=false"):
-        DFlash2DraftModelArgs.from_dict(_dflash2_config(is_causal=True))
+    missing_selector = _dflash2_config()
+    del missing_selector["dflash_config"]["selector_top_k"]
+    invalid_configs = (
+        _dflash2_config(is_causal=True),
+        missing_selector,
+        _dflash2_config(dflash_config={"conv_kernel_size": 3}),
+    )
 
-    bad = _dflash2_config()
-    del bad["dflash_config"]["selector_top_k"]
-    with pytest.raises(ValueError, match="selector_top_k"):
-        DFlash2DraftModelArgs.from_dict(bad)
-
-    with pytest.raises(ValueError, match="two-tap dynamic conv"):
-        DFlash2DraftModelArgs.from_dict(
-            _dflash2_config(dflash_config={"conv_kernel_size": 3})
-        )
+    for config in invalid_configs:
+        with pytest.raises(ValueError):
+            DFlash2DraftModelArgs.from_dict(config)
 
 
 def test_checkpoint_dispatch_selects_dflash2_without_affecting_prior_dflash():
@@ -234,47 +234,6 @@ def test_dflash2_candidate_selector_uses_predecessor_path_edges():
     assert proposal.probabilities is None
 
 
-def test_dflash2_candidate_selector_keeps_batch_edges_independent():
-    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
-    selector = CandidateSelector(args)
-    selector.hidden_projection.weight = mx.zeros_like(selector.hidden_projection.weight)
-    for dim in range(4):
-        selector.hidden_projection.weight[dim, dim] = 1.0
-    selector.predecessor_codebook.weight = mx.zeros_like(
-        selector.predecessor_codebook.weight
-    )
-    selector.successor_codebook.weight = mx.zeros_like(selector.successor_codebook.weight)
-    selector.predecessor_codebook.weight[7, 0] = 1.0
-    selector.successor_codebook.weight[20, 0] = 10.0
-    selector.predecessor_codebook.weight[20, 1] = 1.0
-    selector.successor_codebook.weight[21, 1] = 10.0
-    selector.predecessor_codebook.weight[8, 2] = 1.0
-    selector.successor_codebook.weight[22, 2] = 10.0
-    selector.predecessor_codebook.weight[22, 3] = 1.0
-    selector.successor_codebook.weight[23, 3] = 10.0
-
-    hidden = mx.array(
-        [
-            [[1.0, 0.0, 0.0, 0.0] + [0.0] * 28, [0.0, 1.0, 0.0, 0.0] + [0.0] * 28],
-            [[0.0, 0.0, 1.0, 0.0] + [0.0] * 28, [0.0, 0.0, 0.0, 1.0] + [0.0] * 28],
-        ],
-        dtype=mx.float32,
-    )
-    logits = mx.full((2, 2, 32), -100.0, dtype=mx.float32)
-    for token_id in range(16, 32):
-        logits[:, :, token_id] = -1.0
-
-    proposal = selector.select(
-        hidden,
-        logits,
-        mx.array([7, 8], dtype=mx.uint32),
-        temperature=0.0,
-    )
-    mx.eval(proposal.token_ids)
-
-    assert proposal.token_ids.tolist() == [[20, 21], [22, 23]]
-
-
 def test_dflash2_backend_proposal_uses_selector_contract():
     args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
     draft_model = DFlash2DraftModel(args)
@@ -309,22 +268,6 @@ def test_dflash2_backend_proposal_uses_selector_contract():
     assert proposal.q_probs.shape == (7, 16)
     assert mx.allclose(mx.sum(proposal.q_probs, axis=-1), mx.ones((7,))).item()
 
-
-def test_dflash2_backend_capture_returns_selector_candidates():
-    args = DFlash2DraftModelArgs.from_dict(_dflash2_config())
-    draft_model = DFlash2DraftModel(args)
-    draft_model.forward_projected_context = lambda **_kwargs: mx.zeros(
-        (1, 8, 32), dtype=mx.float32
-    )
-
-    class _TargetOps:
-        def embed_tokens(self, _target_model):
-            return lambda token_ids: mx.zeros((*token_ids.shape, 32), dtype=mx.float32)
-
-        def logits_from_hidden(self, _target_model, hidden):
-            logits = mx.arange(32, dtype=mx.float32).reshape(1, 1, 32) / 100.0
-            return mx.broadcast_to(logits, (1, int(hidden.shape[1]), 32))
-
     drafted, top_ids, top_logprobs = EagerDraftBackend().draft_greedy_capture(
         target_model=object(),
         target_ops=_TargetOps(),
@@ -341,13 +284,8 @@ def test_dflash2_backend_capture_returns_selector_candidates():
     mx.eval(drafted, top_ids, top_logprobs)
 
     assert drafted.shape == (7,)
-    assert top_ids.shape == (7, 4)
-    assert top_logprobs.shape == (7, 4)
-    assert all(
-        row[idx] >= row[idx + 1]
-        for row in top_logprobs.tolist()
-        for idx in range(len(row) - 1)
-    )
+    assert top_ids.shape == top_logprobs.shape == (7, 4)
+    assert mx.all(top_logprobs[:, :-1] >= top_logprobs[:, 1:]).item()
 
 
 def test_dflash2_backend_rejects_underfilled_proposal():
@@ -369,7 +307,7 @@ def test_dflash2_backend_rejects_underfilled_proposal():
         def logits_from_hidden(self, _target_model, hidden):
             return mx.zeros((1, int(hidden.shape[1]), 32), dtype=mx.float32)
 
-    with pytest.raises(ValueError, match="expected 4, got 3"):
+    with pytest.raises(ValueError):
         EagerDraftBackend().propose_block(
             target_model=object(),
             target_ops=_TargetOps(),
@@ -399,7 +337,7 @@ def test_dflash2_safetensor_codebook_remap_is_exact():
     assert remapped["candidate_selector.predecessor_codebook.weight"] is pred
     assert remapped["candidate_selector.successor_codebook.weight"] is succ
 
-    with pytest.raises(ValueError, match="both"):
+    with pytest.raises(ValueError):
         remap_dflash2_codebook_weights(
             {
                 "candidate_selector.predecessor_codebook": pred,
@@ -408,24 +346,14 @@ def test_dflash2_safetensor_codebook_remap_is_exact():
         )
 
 
-def test_load_draft_bundle_dispatches_dflash2_model_classes(tmp_path, monkeypatch):
-    calls = []
+def test_load_draft_bundle_loads_dflash2_checkpoint(tmp_path):
+    config = _dflash2_config()
+    draft_model = DFlash2DraftModel(DFlash2DraftModelArgs.from_dict(config))
+    weights = dict(tree_flatten(draft_model.parameters()))
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
 
-    def fake_load_model(model_path, *, lazy, get_model_classes):
-        classes = get_model_classes(config=_dflash2_config())
-        calls.append((model_path, lazy, classes))
-        return object(), _dflash2_config()
+    loaded_model, meta = runtime_loading.load_draft_bundle(tmp_path, lazy=False)
 
-    monkeypatch.setattr(runtime_loading, "load_model", fake_load_model)
-
-    model, meta = runtime_loading.load_draft_bundle(tmp_path, lazy=False)
-
-    assert model is not None
+    assert isinstance(loaded_model, DFlash2DraftModel)
     assert meta["config"]["architectures"] == ["DFlash2DraftModel"]
-    assert calls == [
-        (
-            tmp_path,
-            False,
-            (DFlash2DraftModel, DFlash2DraftModelArgs),
-        )
-    ]

--- a/tests/test_draft_config_schema.py
+++ b/tests/test_draft_config_schema.py
@@ -2,148 +2,82 @@
 # Licensed under the Apache License, Version 2.0 - see LICENSE file
 # Based on DFlash (arXiv:2602.06036)
 
-"""Regression tests for DFlashDraftModelArgs.from_dict schema tolerance.
-
-z-lab iterated the DFlash draft config.json layout multiple times. This test
-pins from_dict behavior across every known schema variant so consumers do not
-silently break when HuggingFace publishes a new revision.
-
-Covered schemas:
-    * legacy (HF revisions through ~May 2026): block_size and rope_theta top-level.
-    * nested-dflash-config (z-lab HF revision c69b185, Jun 18 2026):
-      block_size moved into dflash_config; rope_theta into rope_parameters.
-    * rope-scaling-fallback: rope_theta nested inside rope_scaling (defensive).
-"""
-
 import pytest
 
-from dflash_mlx.model import DFlashDraftModelArgs
+from dflash_mlx.model import DFlashDraftModel, DFlashDraftModelArgs
 
 
-def _base_legacy_schema() -> dict:
-    return {
+def _schema(*, nested: bool) -> dict:
+    data = {
         "model_type": "qwen3",
         "hidden_size": 2048,
-        "num_hidden_layers": 8,
+        "num_hidden_layers": 6 if nested else 8,
         "intermediate_size": 6144,
         "num_attention_heads": 32,
         "rms_norm_eps": 1e-6,
         "vocab_size": 248320,
-        "num_key_value_heads": 4,
-        "max_position_embeddings": 4096,
-        "rope_theta": 10_000_000.0,
-        "head_dim": 128,
-        "tie_word_embeddings": False,
-        "num_target_layers": 41,
-        "block_size": 16,
-        "dflash_config": {
-            "mask_token_id": 248070,
-            "target_layer_ids": [1, 10, 19, 28, 37],
-        },
-        "layer_types": ("full_attention",) * 8,
-    }
-
-
-def _base_nested_schema() -> dict:
-    """z-lab HF revision c69b185 / f181eece (Jun 18-19 2026).
-
-    block_size moved into dflash_config; rope_theta into a new rope_parameters
-    dict; layer topology switched to mostly-sliding; layer count 8 -> 6;
-    num_key_value_heads 4 -> 8; target_layer_ids 5 -> 8 anchors.
-    """
-    return {
-        "model_type": "qwen3",
-        "hidden_size": 2048,
-        "num_hidden_layers": 6,
-        "intermediate_size": 6144,
-        "num_attention_heads": 32,
-        "rms_norm_eps": 1e-6,
-        "vocab_size": 248320,
-        "num_key_value_heads": 8,
+        "num_key_value_heads": 8 if nested else 4,
         "max_position_embeddings": 4096,
         "head_dim": 128,
         "tie_word_embeddings": False,
         "num_target_layers": 41,
-        "sliding_window": 4096,
         "dflash_config": {
-            "block_size": 16,
             "mask_token_id": 248077,
-            "target_layer_ids": [1, 6, 11, 16, 22, 27, 32, 37],
-        },
-        "rope_parameters": {
-            "rope_theta": 10_000_000.0,
-            "rope_type": "default",
+            "target_layer_ids": (
+                [1, 6, 11, 16, 22, 27, 32, 37]
+                if nested
+                else [1, 10, 19, 28, 37]
+            ),
         },
         "layer_types": (
-            "sliding_attention",
-            "sliding_attention",
-            "sliding_attention",
-            "sliding_attention",
-            "sliding_attention",
-            "full_attention",
+            (
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            )
+            if nested
+            else ("full_attention",) * 8
         ),
     }
+    if nested:
+        data["sliding_window"] = 4096
+        data["dflash_config"]["block_size"] = 16
+        data["rope_parameters"] = {
+            "rope_theta": 10_000_000.0,
+            "rope_type": "default",
+        }
+    else:
+        data["block_size"] = 16
+        data["rope_theta"] = 10_000_000.0
+    return data
 
 
 @pytest.mark.parametrize(
-    "schema_factory,expected_layers,expected_kv_heads,expected_anchor_count",
-    [
-        ("legacy", 8, 4, 5),
-        ("nested", 6, 8, 8),
-    ],
+    "nested,expected_layers,expected_kv_heads,expected_anchors",
+    [(False, 8, 4, 5), (True, 6, 8, 8)],
 )
-def test_from_dict_resolves_block_size_and_rope_theta_across_schemas(
-    schema_factory: str,
+def test_draft_schema_builds_legacy_and_nested_checkpoints(
+    nested: bool,
     expected_layers: int,
     expected_kv_heads: int,
-    expected_anchor_count: int,
+    expected_anchors: int,
 ):
-    factory = _base_legacy_schema if schema_factory == "legacy" else _base_nested_schema
-    data = factory()
-
-    args = DFlashDraftModelArgs.from_dict(data)
-
-    assert args.block_size == 16, f"[{schema_factory}] block_size must resolve to 16"
-    assert args.rope_theta == 10_000_000.0, f"[{schema_factory}] rope_theta must resolve to 1e7"
-    assert args.num_hidden_layers == expected_layers
-    assert args.num_key_value_heads == expected_kv_heads
-    assert tuple(args.layer_types)[0:1] in (("full_attention",), ("sliding_attention",))
-
-
-def test_from_dict_unwraps_block_size_from_dflash_config_when_top_level_absent():
-    data = _base_nested_schema()
-    data.pop("block_size", None)
-    data.pop("rope_theta", None)
-
-    args = DFlashDraftModelArgs.from_dict(data)
+    args = DFlashDraftModelArgs.from_dict(_schema(nested=nested))
+    model = DFlashDraftModel(args)
 
     assert args.block_size == 16
     assert args.rope_theta == 10_000_000.0
+    assert args.num_key_value_heads == expected_kv_heads
+    assert len(model.target_layer_ids) == expected_anchors
+    assert len(model.layers) == expected_layers
+    assert model.fc.weight.shape == (2048, expected_anchors * 2048)
 
 
-def test_from_dict_does_not_invent_missing_block_size():
-    data = _base_nested_schema()
-    data.pop("block_size", None)
-    data["dflash_config"].pop("block_size", None)
-
-    with pytest.raises(TypeError, match="block_size"):
-        DFlashDraftModelArgs.from_dict(data)
-
-
-def test_from_dict_unwraps_rope_theta_from_rope_scaling_as_fallback():
-    data = _base_legacy_schema()
-    data.pop("rope_theta", None)
-    data["rope_scaling"] = {"rope_theta": 10_000_000.0, "rope_type": "default"}
-
-    args = DFlashDraftModelArgs.from_dict(data)
-
-    assert args.rope_theta == 10_000_000.0
-
-
-def test_from_dict_preserves_top_level_block_size_and_rope_theta_when_present():
-    data = _base_legacy_schema()
-    data["block_size"] = 16
-    data["rope_theta"] = 10_000_000.0
+def test_top_level_schema_fields_take_precedence_over_nested_values():
+    data = _schema(nested=False)
     data["dflash_config"]["block_size"] = 99
     data["rope_parameters"] = {"rope_theta": 1.0}
 
@@ -151,21 +85,3 @@ def test_from_dict_preserves_top_level_block_size_and_rope_theta_when_present():
 
     assert args.block_size == 16
     assert args.rope_theta == 10_000_000.0
-
-
-def test_nested_schema_constructs_into_a_model():
-    """The Jun 2026 nested schema must round-trip into a real DFlashDraftModel.
-
-    Guards against regressions in the model class (fc width, anchor count,
-    sliding-window setup) that could be introduced by future refactors.
-    """
-    from dflash_mlx.model import DFlashDraftModel
-
-    args = DFlashDraftModelArgs.from_dict(_base_nested_schema())
-    model = DFlashDraftModel(args)
-
-    assert len(model.layers) == 6
-    assert model.block_size == 16
-    assert model.mask_token_id == 248077
-    assert len(model.target_layer_ids) == 8
-    assert model.fc.weight.shape == (2048, 8 * 2048)

--- a/tests/test_gemma4_draft.py
+++ b/tests/test_gemma4_draft.py
@@ -535,32 +535,6 @@ def test_load_draft_bundle_rejects_future_draft_owned_lm_head(tmp_path):
         raise AssertionError("draft checkpoints with lm_head weights must fail fast")
 
 
-def test_load_draft_bundle_model_class_callback_accepts_mlx_lm_config_keyword(
-    tmp_path,
-    monkeypatch,
-):
-    calls = []
-
-    def fake_load_model(model_path, *, lazy, get_model_classes):
-        model_classes = get_model_classes(config={"model_type": "qwen3"})
-        calls.append((model_path, lazy, model_classes))
-        return object(), {"model_type": "qwen3"}
-
-    monkeypatch.setattr(runtime_loading, "load_model", fake_load_model)
-
-    model, meta = runtime_loading.load_draft_bundle(tmp_path, lazy=False)
-
-    assert model is not None
-    assert meta["config"] == {"model_type": "qwen3"}
-    assert calls == [
-        (
-            tmp_path,
-            False,
-            (DFlashDraftModel, DFlashDraftModelArgs),
-        )
-    ]
-
-
 def test_load_draft_bundle_uses_real_mlx_lm_model_class_callback(tmp_path):
     config = {
         "model_type": "qwen3",

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -2013,38 +2013,6 @@ class TestSidecar:
         assert hit is full
         assert cache.stats()["sidecar_hits"] == 0
 
-    def test_l1_lookup_sidecar_serves_uncovered_windowed_snapshot(self):
-        cache = DFlashPrefixCache(max_entries=8)
-        key = _make_key(draft_sink_size=2, draft_window_size=2)
-        snap = _make_sidecar_generation_snapshot([1, 2, 3, 4, 5, 6, 7, 8], 5, key)
-        snap.target_hidden_chunks = (
-            mx.zeros((1, 2, 8), dtype=mx.float32),
-            mx.zeros((1, 5, 8), dtype=mx.float32),
-        )
-        snap.target_hidden_chunk_spans = ((0, 2), (3, 8))
-        cache.insert(snap)
-        matched, hit = cache.lookup([1, 2, 3, 4, 5, 99], key)
-        assert matched == 5
-        assert hit is not None
-        assert hit.kind == "prefill"
-        assert cache.stats()["sidecar_hits"] == 1
-
-    def test_l1_lookup_sidecar_skips_uncovered_when_full_coverage_required(self):
-        cache = DFlashPrefixCache(max_entries=8)
-        key = _make_key(draft_sink_size=2, draft_window_size=2)
-        snap = _make_sidecar_generation_snapshot([1, 2, 3, 4, 5, 6, 7, 8], 5, key)
-        snap.target_hidden_chunks = (
-            mx.zeros((1, 2, 8), dtype=mx.float32),
-            mx.zeros((1, 5, 8), dtype=mx.float32),
-        )
-        snap.target_hidden_chunk_spans = ((0, 2), (3, 8))
-        cache.insert(snap)
-        matched, hit = cache.lookup(
-            [1, 2, 3, 4, 5, 99], key, require_full_coverage=True
-        )
-        assert matched == 0
-        assert hit is None
-
     def test_nbytes_breakdown_counts_sidecar(self):
         key = _make_key()
         snap = _make_sidecar_generation_snapshot([1, 2, 3, 4, 5, 6], 4, key)
@@ -2154,7 +2122,7 @@ def _make_trimmed_sidecar_carrier(
 
 
 class TestTrimmedSidecar:
-    def test_snapshot_keeps_and_slices_window_before_sidecar_boundary(self):
+    def test_windowed_draft_restores_trimmed_sidecar(self):
         key = _make_key(draft_sink_size=4, draft_window_size=16)
         tokens = list(range(1000, 1064))
         carrier = _make_trimmed_sidecar_carrier(tokens, 48, key)
@@ -2162,12 +2130,8 @@ class TestTrimmedSidecar:
         assert carrier.target_hidden_chunk_spans == ((0, 4), (32, 64))
         sliced = slice_snapshot_at_sidecar_boundary(carrier)
         assert sliced.target_hidden_chunk_spans == ((0, 4), (32, 48))
-
-    def test_l1_serves_trimmed_sidecar_for_windowed_draft(self):
         cache = DFlashPrefixCache(max_entries=8)
-        key = _make_key(draft_sink_size=4, draft_window_size=16)
-        tokens = list(range(1000, 1064))
-        cache.insert(_make_trimmed_sidecar_carrier(tokens, 48, key))
+        cache.insert(carrier)
 
         matched, served = cache.lookup(tokens[:48], key)
 

--- a/tests/test_prefix_cache_hit_kind.py
+++ b/tests/test_prefix_cache_hit_kind.py
@@ -11,14 +11,12 @@ property after each lookup under _state_lock.
 from __future__ import annotations
 
 import mlx.core as mx
-import pytest
 
 from dflash_mlx.cache.codecs import build_snapshot
 from dflash_mlx.cache.fingerprints import DFlashPrefixKey
-from dflash_mlx.cache.manager import HitKind, PrefixCacheLookupResult, RuntimeCacheManager
+from dflash_mlx.cache.manager import RuntimeCacheManager
 from dflash_mlx.cache.prefix_l1 import DFlashPrefixCache
 from dflash_mlx.cache.store import PrefixSnapshotStore
-from dflash_mlx.engine.events import SummaryEvent
 from mlx_lm.models.cache import KVCache
 
 
@@ -68,53 +66,8 @@ def _make_manager(max_entries: int = 8) -> RuntimeCacheManager:
     return RuntimeCacheManager(store)
 
 
-class TestHitKindTypeSystem:
-    """The HitKind Literal covers all possible values."""
-
-    def test_hit_kind_literal_values(self):
-        assert set(HitKind.__args__) == {
-            "miss", "l1_exact", "l1_prefix", "l2_exact", "l2_prefix"
-        }
-
-    def test_result_is_dataclass_not_tuple(self):
-        mgr = _make_manager()
-        result = mgr.lookup([1, 2, 3], _make_key())
-        assert isinstance(result, PrefixCacheLookupResult)
-        # Must NOT be unpackable as a tuple (keeps old 2-tuple callers safe).
-        with pytest.raises((TypeError, ValueError)):
-            _, _ = result  # type: ignore[misc]
-
-    def test_default_hit_kind_is_miss(self):
-        result = PrefixCacheLookupResult(matched_tokens=0, snapshot=None, elapsed_ms=0.0)
-        assert result.hit_kind == "miss"
-
-
 class TestHitKindL1:
     """hit_kind classification with L1-only cache."""
-
-    def test_cold_miss(self):
-        mgr = _make_manager()
-        result = mgr.lookup([1, 2, 3], _make_key())
-        assert result.hit_kind == "miss"
-        assert result.matched_tokens == 0
-
-    def test_prefix_hit(self):
-        mgr = _make_manager()
-        key = _make_key()
-        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
-        mgr._store._l1.insert(snap)
-        result = mgr.lookup([1, 2, 3, 4, 5], key)
-        assert result.hit_kind == "l1_prefix"
-        assert result.matched_tokens == 3
-
-    def test_exact_hit(self):
-        mgr = _make_manager()
-        key = _make_key()
-        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
-        mgr._store._l1.insert(snap)
-        result = mgr.lookup([1, 2, 3], key)
-        assert result.hit_kind == "l1_exact"
-        assert result.matched_tokens == 3
 
     def test_sequential_lookups_are_independent(self):
         mgr = _make_manager()
@@ -125,87 +78,3 @@ class TestHitKindL1:
         assert mgr.lookup([1, 2, 3], key).hit_kind == "l1_exact"
         assert mgr.lookup([9, 9, 9], key).hit_kind == "miss"
         assert mgr.lookup([1, 2, 3, 4, 5], key).hit_kind == "l1_prefix"
-
-    def test_probe_does_not_overwrite_last_hit_kind(self):
-        """Internal record=False probes must not change the recorded hit kind."""
-        mgr = _make_manager()
-        key = _make_key()
-        snap = _make_snapshot([1, 2, 3], key, kind="prefill", with_logits=True)
-        mgr._store._l1.insert(snap)
-
-        # Establish a recorded hit.
-        mgr.lookup([1, 2, 3], key)
-        assert mgr._store._l1.last_hit_kind == "l1_exact"
-
-        # Probe (record=False) must not overwrite state.
-        mgr._store._l1.lookup([1, 2, 3], key, record=False)
-        assert mgr._store._l1.last_hit_kind == "l1_exact"
-
-    def test_generation_snapshot_without_logits_reports_prefix_not_exact(self):
-        """Generation snapshot without last_logits can only serve as a prefix hit."""
-        mgr = _make_manager()
-        key = _make_key()
-        snap = _make_snapshot([1, 2, 3], key, kind="generation", with_logits=False)
-        mgr._store._l1.insert(snap)
-        result = mgr.lookup([1, 2, 3], key)
-        # Without logits the snapshot is not usable for exact-match serving.
-        assert result.hit_kind in ("miss", "l1_prefix")
-        assert result.matched_tokens in (0, 3)
-
-
-def _make_summary_event(hit_kind: str = "miss") -> SummaryEvent:
-    return SummaryEvent(
-        elapsed_us=100.0,
-        prompt_token_count=10,
-        generated_token_ids=(1, 2, 3),
-        generation_tokens=3,
-        accepted_from_draft=2,
-        acceptance_ratio=0.67,
-        cycles_completed=1,
-        phase_timings_us={},
-        hit_kind=hit_kind,
-    )
-
-
-class TestSummaryEventHitKind:
-    """SummaryEvent.to_payload() always includes hit_kind."""
-
-    def test_default_hit_kind_is_miss(self):
-        event = SummaryEvent(
-            elapsed_us=0.0,
-            prompt_token_count=0,
-            generated_token_ids=(),
-            generation_tokens=0,
-            accepted_from_draft=0,
-            acceptance_ratio=0.0,
-            cycles_completed=0,
-            phase_timings_us={},
-        )
-        assert event.hit_kind == "miss"
-        assert event.to_payload()["hit_kind"] == "miss"
-
-    def test_hit_kind_always_present_in_payload(self):
-        event = _make_summary_event("l1_exact")
-        payload = event.to_payload()
-        assert "hit_kind" in payload
-        assert payload["hit_kind"] == "l1_exact"
-
-    def test_all_hit_kind_values_roundtrip_through_payload(self):
-        for kind in HitKind.__args__:
-            payload = _make_summary_event(kind).to_payload()
-            assert payload["hit_kind"] == kind, f"hit_kind={kind!r} did not survive to_payload()"
-
-    def test_lookup_result_hit_kind_propagates_to_summary_event_payload(self):
-        """The value from PrefixCacheLookupResult must match what ends up in SummaryEvent payload.
-        This documents the contract that spec_epoch.py must honour when forwarding hit_kind."""
-        mgr = _make_manager()
-        key = _make_key()
-        snap = _make_snapshot([1, 2, 3], key)
-        mgr._store._l1.insert(snap)
-
-        result = mgr.lookup([1, 2, 3], key)
-        assert result.hit_kind == "l1_exact"
-
-        # Simulate spec_epoch forwarding: SummaryEvent.hit_kind = request.prefix_hit_kind.
-        summary_payload = _make_summary_event(result.hit_kind).to_payload()
-        assert summary_payload["hit_kind"] == "l1_exact"

--- a/tests/test_prefix_cache_integration.py
+++ b/tests/test_prefix_cache_integration.py
@@ -1265,20 +1265,6 @@ class TestContextConfigExposedCorrectly:
                 require_logits=True,
             )
 
-    def test_singleton_rebuilds_when_identity_changes(self, monkeypatch):
-        import dflash_mlx.cache.manager as cache_manager_mod
-
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_REGISTRY", {})
-        monkeypatch.setattr(cache_manager_mod, "_DFLASH_RUNTIME_CACHE_CURRENT_IDENTITY", None)
-        context = _runtime_context(prefix_cache=True)
-
-        first = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-a")
-        second = cache_manager_mod.get_runtime_cache_manager(context, cache_identity="model-b")
-
-        assert first is not None
-        assert second is not None
-        assert first is not second
-
     def test_prefix_flow_lookup_records_hit(self, monkeypatch):
         import dflash_mlx.server.prefix_cache_flow as flow_mod
 

--- a/tests/test_prefix_l2.py
+++ b/tests/test_prefix_l2.py
@@ -1572,7 +1572,7 @@ def test_sink_zero_snapshot_has_only_nonempty_target_hidden_chunks():
     from dflash_mlx.cache.codecs import build_snapshot
 
     key = _make_key()
-    n = 128  # > sink(0) + window, forcing the sink/tail split
+    n = 128
     snap = build_snapshot(
         token_ids=list(range(n)),
         target_cache=[
@@ -1583,24 +1583,16 @@ def test_sink_zero_snapshot_has_only_nonempty_target_hidden_chunks():
         last_logits=mx.zeros((1, 32), dtype=mx.float32),
         key=key,
         kind="prefill",
-        draft_sink_size=0,   # reproduces the empty-sink crash
+        draft_sink_size=0,
         draft_window_size=16,
     )
 
     assert snap.target_hidden_chunk_spans == ((n - 16, n),)
-    assert len(snap.target_hidden_chunks) == 1
-
     arrays, meta_dict = _serialize(snap)
     meta = json.loads(meta_dict["dflash_meta"])
-    spans = meta["target_hidden_chunk_spans"]
-
-    assert spans
-    for c in range(len(spans)):
-        arr = arrays[f"target_hidden_{c}"]
-        assert 0 not in arr.shape, f"empty chunk serialized: target_hidden_{c}"
-
     restored = _deserialize(arrays, meta)
-    assert len(restored.target_hidden_chunks) == len(spans)
-    for chunk, span in zip(restored.target_hidden_chunks, spans):
-        assert 0 not in chunk.shape
-        assert span[1] > span[0]
+
+    assert meta["target_hidden_chunk_spans"] == [[n - 16, n]]
+    assert arrays["target_hidden_0"].size > 0
+    assert restored.target_hidden_chunk_spans == snap.target_hidden_chunk_spans
+    assert restored.target_hidden_chunks[0].size > 0

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -4,27 +4,15 @@
 
 from __future__ import annotations
 
-import importlib
-import tomllib
-from pathlib import Path
-
-from setuptools import find_packages
-
 from dflash_mlx import cli
-
-def test_root_help_contains_product_commands(capsys):
-    assert cli.run(["--help"]) == 0
-    out = capsys.readouterr().out
-    assert "serve" in out
-    assert "generate" in out
-    assert "benchmark" in out
-    assert "doctor" in out
 
 def test_models_command_lists_draft_registry(capsys):
     assert cli.run(["models"]) == 0
     out = capsys.readouterr().out
     assert "Qwen3.6-27B" in out
     assert "z-lab/Qwen3.6-27B-DFlash" in out
+    assert "Qwen3.8-27B" in out
+    assert "z-lab/Qwen3.8-27B-DFlash2" in out
     assert "gemma-4-31b-it" in out
     assert "z-lab/gemma-4-31B-it-DFlash" in out
     assert "gemma-4-26b-a4b-it" in out
@@ -62,27 +50,3 @@ def test_root_rejects_missing_subcommand_generate_form(capsys):
     assert cli.run(["--model", "m", "--prompt", "p"]) == 2
     err = capsys.readouterr().err
     assert "dflash generate" in err
-
-def test_pyproject_scripts_import():
-    data = tomllib.loads(Path("pyproject.toml").read_text())
-    scripts = data["project"]["scripts"]
-    assert scripts["dflash"] == "dflash_mlx.cli:main"
-    assert set(scripts) == {"dflash"}
-    for target in scripts.values():
-        module_name, func_name = target.split(":", 1)
-        module = importlib.import_module(module_name)
-        assert callable(getattr(module, func_name))
-
-
-def test_pyproject_mlx_dependency_floors_match_supported_runtime():
-    data = tomllib.loads(Path("pyproject.toml").read_text())
-    dependencies = set(data["project"]["dependencies"])
-
-    assert "mlx>=0.32.1" in dependencies
-    assert "mlx-lm>=0.31.3" in dependencies
-
-
-def test_setuptools_package_discovery_includes_draft_package():
-    packages = set(find_packages(include=["dflash_mlx*"]))
-
-    assert "dflash_mlx.draft" in packages

--- a/tests/test_sdpa_parity.py
+++ b/tests/test_sdpa_parity.py
@@ -215,78 +215,31 @@ def test_qwen_gqa_large_kv_routes_match_native(
     )
 
 
-def _fake_route_array(queries: mx.array) -> mx.array:
-    return mx.zeros(queries.shape, dtype=queries.dtype)
-
-
-def test_qwen_hk2_q16_mid_kv_uses_async(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "kv_len,expected_route,route_name",
+    [
+        (8192, "grouped", "grouped_gqa_sdpa"),
+        (16384, "async", "async_per_head_gqa_sdpa"),
+        (65536, "per_head", "per_head_gqa_sdpa"),
+    ],
+)
+def test_qwen_hk2_q16_long_context_route_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+    kv_len: int,
+    expected_route: str,
+    route_name: str,
+) -> None:
     calls: list[str] = []
 
-    def _async(queries, keys, values, *, scale, mask, gqa):
-        del keys, values, scale, mask, gqa
-        calls.append("async")
-        return _fake_route_array(queries)
+    def _route(queries, *_args, **_kwargs):
+        calls.append(expected_route)
+        return mx.zeros(queries.shape, dtype=queries.dtype)
 
-    def _unexpected(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("mid-KV hk=2 q=16 must use async route")
-
-    monkeypatch.setattr(qwen_gdn, "async_per_head_gqa_sdpa", _async)
-    monkeypatch.setattr(qwen_gdn, "per_head_gqa_sdpa", _unexpected)
-
+    monkeypatch.setattr(qwen_gdn, route_name, _route)
     q = mx.zeros((1, 16, 16, 256), dtype=mx.bfloat16)
-    k = mx.zeros((1, 2, 16384, 256), dtype=mx.bfloat16)
-    v = mx.zeros((1, 2, 16384, 256), dtype=mx.bfloat16)
-    out = _gqa_reshape_sdpa(q, k, v, cache=None, scale=1.0, mask="causal")
-    mx.eval(out)
+    k = mx.zeros((1, 2, kv_len, 256), dtype=mx.bfloat16)
+    v = mx.zeros((1, 2, kv_len, 256), dtype=mx.bfloat16)
 
-    assert calls == ["async"]
+    mx.eval(_gqa_reshape_sdpa(q, k, v, cache=None, scale=1.0, mask="causal"))
 
-
-def test_qwen_hk2_q16_short_kv_uses_grouped(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[str] = []
-
-    def _grouped(queries, keys, values, *, cache, scale, mask):
-        del keys, values, cache, scale, mask
-        calls.append("grouped")
-        return _fake_route_array(queries)
-
-    def _unexpected(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("short-KV hk=2 q=16 must stay on grouped route")
-
-    monkeypatch.setattr(qwen_gdn, "grouped_gqa_sdpa", _grouped)
-    monkeypatch.setattr(qwen_gdn, "async_per_head_gqa_sdpa", _unexpected)
-    monkeypatch.setattr(qwen_gdn, "per_head_gqa_sdpa", _unexpected)
-
-    q = mx.zeros((1, 16, 16, 256), dtype=mx.bfloat16)
-    k = mx.zeros((1, 2, 8192, 256), dtype=mx.bfloat16)
-    v = mx.zeros((1, 2, 8192, 256), dtype=mx.bfloat16)
-    out = _gqa_reshape_sdpa(q, k, v, cache=None, scale=1.0, mask="causal")
-    mx.eval(out)
-
-    assert calls == ["grouped"]
-
-
-def test_qwen_hk2_q16_long_kv_uses_per_head(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[str] = []
-
-    def _per_head(queries, keys, values, *, scale, mask, gqa):
-        del keys, values, scale, mask, gqa
-        calls.append("per_head")
-        return _fake_route_array(queries)
-
-    def _unexpected(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("long-KV hk=2 q=16 must use per-head route")
-
-    monkeypatch.setattr(qwen_gdn, "per_head_gqa_sdpa", _per_head)
-    monkeypatch.setattr(qwen_gdn, "async_per_head_gqa_sdpa", _unexpected)
-
-    q = mx.zeros((1, 16, 16, 256), dtype=mx.bfloat16)
-    k = mx.zeros((1, 2, 65536, 256), dtype=mx.bfloat16)
-    v = mx.zeros((1, 2, 65536, 256), dtype=mx.bfloat16)
-    out = _gqa_reshape_sdpa(q, k, v, cache=None, scale=1.0, mask="causal")
-    mx.eval(out)
-
-    assert calls == ["per_head"]
+    assert calls == [expected_route]

--- a/tests/test_server_request_loop.py
+++ b/tests/test_server_request_loop.py
@@ -483,6 +483,7 @@ def test_server_runtime_routes_tool_chat_generation_snapshot_policy(monkeypatch)
     assert captured["snapshot_service"] is prefix_flow.snapshot_service
     assert captured["stable_prefix_len"] == 3
     assert captured["prefix_cache_active"] is True
+    assert captured["prefix_hit_kind"] == "l1_exact"
 
 
 def test_memory_waterfall_events_are_enriched_with_prefix_cache_memory():

--- a/tests/test_target_hook_guard.py
+++ b/tests/test_target_hook_guard.py
@@ -18,32 +18,7 @@ from __future__ import annotations
 import mlx.nn as nn
 import pytest
 
-from dflash_mlx.engine._hook_guard import DFlashHookConflict, claim_class_hook
-
-
-def test_free_slot_is_claimable():
-    class A(nn.Module):
-        pass
-
-    assert claim_class_hook(A, "_marker", "gemma4") is True
-
-
-def test_same_owner_reclaim_is_noop():
-    class A(nn.Module):
-        pass
-
-    assert claim_class_hook(A, "_marker", "gemma4") is True
-    A._marker = "gemma4"  # installer sets the marker after patching
-    assert claim_class_hook(A, "_marker", "gemma4") is False
-
-
-def test_different_owner_raises():
-    class A(nn.Module):
-        pass
-
-    A._marker = "gemma4"
-    with pytest.raises(DFlashHookConflict, match="already patched"):
-        claim_class_hook(A, "_marker", "qwen_gdn")
+from dflash_mlx.engine._hook_guard import DFlashHookConflict
 
 
 def test_installers_fail_loud_on_shared_attention_class():

--- a/tools/benchmarks/ddtree_flat_oracle_replay.py
+++ b/tools/benchmarks/ddtree_flat_oracle_replay.py
@@ -21,7 +21,6 @@ from dflash_mlx.engine.ddtree import (
     draft_block_with_topk,
     flat_tree_path_token_ids,
     follow_verified_tree,
-    pad_flat_tree_paths,
 )
 from dflash_mlx.engine.events import PrefillCompleteEvent
 from dflash_mlx.engine.sampling import (
@@ -305,11 +304,11 @@ def run_request(
 
             paths = flat_tree_path_token_ids(tree, root_token_id=root_token_id)
             pad_token_id = int(getattr(bundle.draft_model, "mask_token_id", root_token_id))
-            rows, path_lengths = pad_flat_tree_paths(
-                paths,
-                pad_token_id=pad_token_id,
-                max_len=block_len,
-            )
+            path_lengths = [len(path) for path in paths]
+            rows = [
+                [*path, *([pad_token_id] * (block_len - len(path)))]
+                for path in paths
+            ]
             verify_start_ns = time.perf_counter_ns()
             posterior_token_ids: list[int] = []
             chunk_size = max(1, int(oracle_batch_size))


### PR DESCRIPTION
## Summary
- remove 59 redundant or implementation-coupled test cases (771 test LOC)
- retain runtime parity, rollback/cache, server, DFlash2, and long-context route coverage
- remove a dead DDTree helper and inline its only lab caller
- align architecture docs with current draft dispatch/cache ownership

## Validation
- `pytest tests/ -q -p no:cacheprovider`: 1251 passed, 11 skipped
- targeted DFlash2/SDPA/cache/DDTree/CLI suite: 391 passed
- `git diff --check`
- two independent xhigh reviews: COMMIT-READY yes

Commit: 95d765f